### PR TITLE
Restructure CI pipeline: staged workflow with static analysis reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       ${{ matrix.embedded && ' / embedded' || '' }}
       ${{ matrix.ipc == 'enabled' && ' / ipc' || '' }}
       ${{ matrix.threads == 'disabled' && ' / no-threads' || '' }}
+    needs: [sanitizers]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cppcheck:
-    name: cppcheck
+    name: cppcheck (report)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,18 +19,34 @@ jobs:
           sudo apt-get install -y cppcheck
 
       - name: Run cppcheck
-        run: >
-          cppcheck
-          --enable=warning,style,performance,portability
-          --std=c11
-          --error-exitcode=1
-          --suppress=missingIncludeSystem
-          --inline-suppr
-          -I wirelog
-          wirelog/
+        run: |
+          cppcheck \
+            --enable=warning,style,performance,portability \
+            --std=c11 \
+            --suppress=missingIncludeSystem \
+            --inline-suppr \
+            -I wirelog \
+            --template='{file}:{line}: {severity}: {message} [{id}]' \
+            wirelog/ 2> cppcheck-results.txt || true
+
+      - name: Publish cppcheck report
+        if: always()
+        run: |
+          echo "## cppcheck Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -s cppcheck-results.txt ]; then
+            count=$(wc -l < cppcheck-results.txt | tr -d ' ')
+            echo "**${count} finding(s)**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat cppcheck-results.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No issues found." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   scan-build:
-    name: scan-build (Clang)
+    name: scan-build (report)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +59,31 @@ jobs:
       - name: Run scan-build
         run: |
           meson setup builddir-scan
-          scan-build --status-bugs meson compile -C builddir-scan
+          scan-build -o scan-results meson compile -C builddir-scan 2>&1 | tee scan-build-output.txt || true
         env:
           CC: clang
+
+      - name: Publish scan-build report
+        if: always()
+        run: |
+          echo "## scan-build Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if grep -q "scan-build: No bugs found" scan-build-output.txt 2>/dev/null; then
+            echo "No bugs found." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            tail -20 scan-build-output.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            if [ -d scan-results ] && [ "$(ls -A scan-results 2>/dev/null)" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "Detailed HTML reports were generated. Download the artifact for full results." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+      - name: Upload scan-build report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-build-report
+          path: scan-results/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Resolves #1

- **Stage 1 (Static Analysis)**: Converted to report-only (non-blocking). Both `cppcheck` and `scan-build` now publish results as GitHub Actions job summaries instead of failing the pipeline. Scan-build HTML reports are uploaded as artifacts.
- **Stage 2 (Sanitizers)**: Unchanged — ASan + UBSan with GCC and Clang remain as a blocking gate.
- **Stage 3 (Platform Build Matrix)**: Added `needs: [sanitizers]` so the 6-entry build matrix only runs after sanitizers pass. If sanitizers fail, all platform builds are skipped (~12 min CI time saved).

## Changes

### `ci.yml`
- Added `needs: [sanitizers]` to the `build` job

### `static-analysis.yml`
- Removed `--error-exitcode=1` from cppcheck (non-blocking)
- Removed `--status-bugs` from scan-build (non-blocking)
- Added `|| true` to prevent job failure on findings
- Added GitHub Actions job summaries (`$GITHUB_STEP_SUMMARY`) for both tools
- Added `--template` for structured cppcheck output
- Added scan-build HTML report artifact upload via `actions/upload-artifact@v4`
- Renamed jobs to `(report)` to signal advisory nature

## Pipeline Structure

```
Static Analysis (report only, non-blocking)
    │
Sanitizers (ASan + UBSan) ── must pass
    │
Platform Build Matrix ── only runs if sanitizers pass
```

## Test plan

- [x] Verify static analysis jobs run and publish summaries (not pass/fail)
- [x] Verify sanitizer jobs run before platform builds (`needs:` dependency)
- [x] Verify platform build matrix is skipped when sanitizers fail
- [x] Verify total CI time for clean runs is not significantly increased
- [x] Verify scan-build artifact is uploaded when findings exist