### PR TITLE
Update README badges to per-platform CI build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # wirelog
 
-[![CI](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml/badge.svg)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![Static Analysis](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/static-analysis.yml?label=static%20analysis)](https://github.com/justinjoy/wirelog/actions/workflows/static-analysis.yml)
+[![Sanitizers](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Sanitizers)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![Linux GCC](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20GCC)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![Linux Clang](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20Clang)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![Linux Embedded](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20Embedded)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![macOS](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=macOS)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![Windows MSVC](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Windows%20MSVC)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
 
 **Embedded-to-Enterprise Datalog Engine**
 


### PR DESCRIPTION
## Summary

- Replace generic CI and Static Analysis badges with per-platform build status badges
- Sanitizers badge first (pipeline gate), followed by platform builds
- Badges: Sanitizers, Linux GCC, Linux Clang, Linux Embedded, macOS, Windows MSVC
- Removed Static Analysis badge (advisory-only, not needed in README)

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify badge links point to the correct workflow