### PR TITLE
Add LGPL-3.0 license headers to Rust source files

### DIFF
--- a/rust/wirelog-dd/src/dataflow.rs
+++ b/rust/wirelog-dd/src/dataflow.rs
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
  * dataflow.rs - Interpreter-based plan execution (Phase 0)
  *
  * Executes a SafePlan against in-memory EDB data using a simple

--- a/rust/wirelog-dd/src/expr.rs
+++ b/rust/wirelog-dd/src/expr.rs
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
  * expr.rs - RPN expression deserializer and stack-based evaluator
  *
  * The wirelog C side serializes IR expression trees into flat RPN (Reverse Polish

--- a/rust/wirelog-dd/src/ffi.rs
+++ b/rust/wirelog-dd/src/ffi.rs
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
  * ffi.rs - C FFI entry points for wirelog DD executor
  *
  * These functions are exported with C linkage and called by the wirelog

--- a/rust/wirelog-dd/src/ffi_types.rs
+++ b/rust/wirelog-dd/src/ffi_types.rs
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
  * ffi_types.rs - Rust mirrors of wirelog/ffi/dd_ffi.h types
  *
  * These #[repr(C)] types exactly match the C structs defined in dd_ffi.h.

--- a/rust/wirelog-dd/src/lib.rs
+++ b/rust/wirelog-dd/src/lib.rs
@@ -1,9 +1,11 @@
 /*
- * wirelog-dd: Rust Differential Dataflow executor for wirelog
- *
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
  * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
+ * wirelog-dd: Rust Differential Dataflow executor for wirelog
  */
 
 mod dataflow;

--- a/rust/wirelog-dd/src/plan_reader.rs
+++ b/rust/wirelog-dd/src/plan_reader.rs
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+/*
  * plan_reader.rs - Convert unsafe FFI plan pointers into safe Rust types
  *
  * The C side passes a const wl_ffi_plan_t* across the FFI boundary.


### PR DESCRIPTION
## Summary
- Add separate LGPL-3.0 copyright/license block at the top of all 6 Rust source files
- License block placed before module documentation comments, matching project convention
- Files updated: lib.rs, dataflow.rs, expr.rs, ffi.rs, ffi_types.rs, plan_reader.rs

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] 88/88 Rust unit tests pass