### PR TITLE
Add parser support for inline facts

### DIFF
--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -997,6 +997,203 @@ test_parse_comparison_program(void)
 }
 
 /* ======================================================================== */
+/* Parser: Inline Facts                                                     */
+/* ======================================================================== */
+
+static void
+test_parse_single_fact(void)
+{
+    TEST("inline fact: edge(1, 2).");
+    PARSE("edge(1, 2).");
+    ASSERT_PARSED();
+    if (program->child_count != 1) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 1 child, got %u",
+                 program->child_count);
+        CLEANUP();
+        FAIL(buf);
+        return;
+    }
+    const wl_ast_node_t *fact = child(program, 0);
+    if (fact->type != WL_NODE_FACT) {
+        CLEANUP();
+        FAIL("expected FACT node");
+        return;
+    }
+    if (!fact->name || strcmp(fact->name, "edge") != 0) {
+        CLEANUP();
+        FAIL("expected relation name 'edge'");
+        return;
+    }
+    if (fact->child_count != 2) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 2 args, got %u",
+                 fact->child_count);
+        CLEANUP();
+        FAIL(buf);
+        return;
+    }
+    const wl_ast_node_t *a0 = child(fact, 0);
+    const wl_ast_node_t *a1 = child(fact, 1);
+    if (a0->type != WL_NODE_INTEGER || a0->int_value != 1) {
+        CLEANUP();
+        FAIL("arg 0 should be INTEGER 1");
+        return;
+    }
+    if (a1->type != WL_NODE_INTEGER || a1->int_value != 2) {
+        CLEANUP();
+        FAIL("arg 1 should be INTEGER 2");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_multiple_facts(void)
+{
+    TEST("multiple inline facts");
+    PARSE("edge(1, 2). edge(2, 3). edge(3, 4).");
+    ASSERT_PARSED();
+    if (program->child_count != 3) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 3 children, got %u",
+                 program->child_count);
+        CLEANUP();
+        FAIL(buf);
+        return;
+    }
+    /* Check all three are FACT nodes */
+    for (uint32_t i = 0; i < 3; i++) {
+        const wl_ast_node_t *f = child(program, i);
+        if (f->type != WL_NODE_FACT) {
+            char buf[64];
+            snprintf(buf, sizeof(buf), "child %u should be FACT", i);
+            CLEANUP();
+            FAIL(buf);
+            return;
+        }
+    }
+    /* Verify values of second fact: edge(2, 3) */
+    const wl_ast_node_t *f1 = child(program, 1);
+    if (!f1->name || strcmp(f1->name, "edge") != 0) {
+        CLEANUP();
+        FAIL("fact 1 name should be 'edge'");
+        return;
+    }
+    if (f1->child_count != 2) {
+        CLEANUP();
+        FAIL("fact 1 should have 2 args");
+        return;
+    }
+    if (child(f1, 0)->int_value != 2 || child(f1, 1)->int_value != 3) {
+        CLEANUP();
+        FAIL("fact 1 args should be 2, 3");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_facts_mixed_with_rules(void)
+{
+    TEST("facts mixed with decls and rules");
+    PARSE(".decl edge(src: int32, dst: int32)\n"
+          "edge(1, 2).\n"
+          "edge(2, 3).\n"
+          "Tc(x, y) :- edge(x, y).\n"
+          ".output Tc\n");
+    ASSERT_PARSED();
+    if (program->child_count != 5) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 5 children, got %u",
+                 program->child_count);
+        CLEANUP();
+        FAIL(buf);
+        return;
+    }
+    if (child(program, 0)->type != WL_NODE_DECL) {
+        CLEANUP();
+        FAIL("child 0 should be DECL");
+        return;
+    }
+    if (child(program, 1)->type != WL_NODE_FACT) {
+        CLEANUP();
+        FAIL("child 1 should be FACT");
+        return;
+    }
+    if (child(program, 2)->type != WL_NODE_FACT) {
+        CLEANUP();
+        FAIL("child 2 should be FACT");
+        return;
+    }
+    if (child(program, 3)->type != WL_NODE_RULE) {
+        CLEANUP();
+        FAIL("child 3 should be RULE");
+        return;
+    }
+    if (child(program, 4)->type != WL_NODE_OUTPUT) {
+        CLEANUP();
+        FAIL("child 4 should be OUTPUT");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_fact_rejects_variables(void)
+{
+    TEST("error: fact with variable argument");
+    PARSE("edge(x, 2).");
+    if (program != NULL) {
+        CLEANUP();
+        FAIL("expected parse failure for fact with variable");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_fact_string_constant(void)
+{
+    TEST("fact with string constant: name(1, \"alice\").");
+    PARSE("name(1, \"alice\").");
+    ASSERT_PARSED();
+    if (program->child_count != 1) {
+        CLEANUP();
+        FAIL("expected 1 child");
+        return;
+    }
+    const wl_ast_node_t *fact = child(program, 0);
+    if (fact->type != WL_NODE_FACT) {
+        CLEANUP();
+        FAIL("expected FACT node");
+        return;
+    }
+    if (fact->child_count != 2) {
+        CLEANUP();
+        FAIL("expected 2 args");
+        return;
+    }
+    if (child(fact, 0)->type != WL_NODE_INTEGER
+        || child(fact, 0)->int_value != 1) {
+        CLEANUP();
+        FAIL("arg 0 should be INTEGER 1");
+        return;
+    }
+    if (child(fact, 1)->type != WL_NODE_STRING || !child(fact, 1)->str_value
+        || strcmp(child(fact, 1)->str_value, "alice") != 0) {
+        CLEANUP();
+        FAIL("arg 1 should be STRING 'alice'");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+/* ======================================================================== */
 /* Parser: Error Cases                                                      */
 /* ======================================================================== */
 
@@ -1165,6 +1362,13 @@ main(void)
     test_parse_sssp();
     test_parse_negation_program();
     test_parse_comparison_program();
+
+    printf("\n--- Inline Facts ---\n");
+    test_parse_single_fact();
+    test_parse_multiple_facts();
+    test_parse_facts_mixed_with_rules();
+    test_parse_fact_rejects_variables();
+    test_parse_fact_string_constant();
 
     printf("\n--- Error Cases ---\n");
     test_parse_error_missing_horn();

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -156,6 +156,8 @@ wl_node_type_str(wl_node_type_t type)
         return "AGGREGATE";
     case WL_NODE_BINARY_EXPR:
         return "BINARY_EXPR";
+    case WL_NODE_FACT:
+        return "FACT";
     case WL_NODE_TYPED_PARAM:
         return "TYPED_PARAM";
     case WL_NODE_INPUT_PARAM:

--- a/wirelog/parser/ast.h
+++ b/wirelog/parser/ast.h
@@ -59,6 +59,9 @@ typedef enum {
     /* Expressions */
     WL_NODE_BINARY_EXPR, /* arith_op, children[0]=left, children[1]=right */
 
+    /* Inline facts */
+    WL_NODE_FACT, /* name=relation, children=constant args */
+
     /* Declaration parts */
     WL_NODE_TYPED_PARAM, /* name=attr_name, type_name=data_type */
     WL_NODE_INPUT_PARAM, /* name=param_name, str_value=param_value */

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -12,7 +12,7 @@
  *
  * Grammar (FlowLog-compatible):
  *
- *   program     = (declaration | input_dir | output_dir | printsize_dir | rule)*
+ *   program     = (declaration | input_dir | output_dir | printsize_dir | rule | fact)*
  *   declaration = ".decl" IDENT "(" attributes? ")"
  *   input_dir   = ".input" IDENT "(" input_params? ")"
  *   output_dir  = ".output" IDENT
@@ -613,11 +613,49 @@ parse_head(wl_parser_t *parser)
 }
 
 /* ======================================================================== */
-/* Rule Parsing                                                             */
+/* Fact / Rule Parsing                                                      */
 /* ======================================================================== */
 
 static wl_ast_node_t *
-parse_rule(wl_parser_t *parser)
+parse_fact(wl_parser_t *parser, wl_ast_node_t *head)
+{
+    /* Convert HEAD node to FACT node, reusing name and children */
+    wl_ast_node_t *fact
+        = wl_ast_node_create(WL_NODE_FACT, head->line, head->col);
+    fact->name = head->name;
+    head->name = NULL;
+
+    /* Move children from head to fact */
+    fact->children = head->children;
+    fact->child_count = head->child_count;
+    fact->child_capacity = head->child_capacity;
+    head->children = NULL;
+    head->child_count = 0;
+    head->child_capacity = 0;
+
+    wl_ast_node_free(head);
+
+    /* Validate: fact arguments must be constants (INTEGER or STRING) */
+    for (uint32_t i = 0; i < fact->child_count; i++) {
+        wl_node_type_t arg_type = fact->children[i]->type;
+        if (arg_type != WL_NODE_INTEGER && arg_type != WL_NODE_STRING) {
+            parser_error(
+                parser, "fact arguments must be constants (integer or string)");
+            wl_ast_node_free(fact);
+            return NULL;
+        }
+    }
+
+    if (!parser_consume(parser, WL_TOK_DOT, "expected '.' at end of fact")) {
+        wl_ast_node_free(fact);
+        return NULL;
+    }
+
+    return fact;
+}
+
+static wl_ast_node_t *
+parse_rule_or_fact(wl_parser_t *parser)
 {
     uint32_t line = parser->current.line;
     uint32_t col = parser->current.col;
@@ -626,7 +664,14 @@ parse_rule(wl_parser_t *parser)
     if (!head)
         return NULL;
 
-    if (!parser_consume(parser, WL_TOK_HORN, "expected ':-' after rule head")) {
+    /* Fact: head followed by '.' */
+    if (parser_check(parser, WL_TOK_DOT)) {
+        return parse_fact(parser, head);
+    }
+
+    /* Rule: head followed by ':-' */
+    if (!parser_consume(parser, WL_TOK_HORN,
+                        "expected ':-' or '.' after head")) {
         wl_ast_node_free(head);
         return NULL;
     }
@@ -867,8 +912,8 @@ parse_program(wl_parser_t *parser)
         } else if (parser_match(parser, WL_TOK_PRINTSIZE)) {
             node = parse_printsize_directive(parser);
         } else if (parser_check(parser, WL_TOK_IDENT)) {
-            /* Rule: starts with identifier (head relation) */
-            node = parse_rule(parser);
+            /* Fact or rule: both start with identifier */
+            node = parse_rule_or_fact(parser);
         } else {
             parser_error(parser, "expected declaration, directive, or rule");
             break;


### PR DESCRIPTION
Closes #13

## Summary
- Add `WL_NODE_FACT` to `wl_node_type_t` enum in AST
- Replace `parse_rule()` with `parse_rule_or_fact()` that disambiguates based on `.` (fact) vs `:-` (rule) after the head
- Validate fact arguments are constants only (INTEGER or STRING); variables are rejected at parse time
- Add 5 new parser tests covering: single fact, multiple facts, mixed programs, variable rejection, and string constants (49 total)

## Test plan
- [x] All 49 parser tests pass
- [x] Full test suite passes (9/9 suites)
- [x] clang-format applied
- [x] Existing error tests still pass (e.g., `r(x) a(x).` still rejected)