### PR TITLE
Add fact extraction utility for EDB loading

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -100,6 +100,12 @@ ffi_src = files(
   '../wirelog/ffi/dd_marshal.c',
 )
 
+# facts_loader.c calls wl_dd_load_edb (Rust FFI), so it is only
+# compiled into targets that link rust_ffi_dep.
+facts_loader_src = files(
+  '../wirelog/ffi/facts_loader.c',
+)
+
 test_dd_ffi_exe = executable(
   'test_dd_ffi',
   files('test_dd_ffi.c'),
@@ -117,6 +123,7 @@ test_dd_execute_exe = executable(
   parser_src,
   ir_src,
   ffi_src,
+  facts_loader_src,
   dependencies: [rust_ffi_dep],
   include_directories: [wirelog_inc, wirelog_src_inc],
 )

--- a/tests/test_dd_execute.c
+++ b/tests/test_dd_execute.c
@@ -11,6 +11,7 @@
 
 #include "../wirelog/ffi/dd_ffi.h"
 #include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -592,6 +593,242 @@ test_execute_no_callback(void)
 }
 
 /* ======================================================================== */
+/* Test: Bulk Fact Loading                                                  */
+/* ======================================================================== */
+
+/*
+ * wirelog_load_all_facts() should iterate over all relations with
+ * inline facts in the program and call wl_dd_load_edb() for each.
+ *
+ * Program:
+ *   .decl edge(x: int32, y: int32)
+ *   .decl node(x: int32)
+ *   edge(1, 2). edge(2, 3).
+ *   node(10).
+ *
+ * After calling wirelog_load_all_facts(), the DD worker should have
+ * EDB data for both "edge" (2 rows x 2 cols) and "node" (1 row x 1 col).
+ */
+static void
+test_load_all_facts(void)
+{
+    TEST("wirelog_load_all_facts loads all EDB relations");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl edge(x: int32, y: int32)\n"
+                               ".decl node(x: int32)\n"
+                               "edge(1, 2).\n"
+                               "edge(2, 3).\n"
+                               "node(10).\n",
+                               &err);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    wl_dd_worker_t *w = wl_dd_worker_create(1);
+    if (!w) {
+        wirelog_program_free(prog);
+        FAIL("worker is NULL");
+        return;
+    }
+
+    int rc = wirelog_load_all_facts(prog, w);
+    if (rc != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "load_all_facts returned %d", rc);
+        wl_dd_worker_destroy(w);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    /* Verify by executing a passthrough rule that uses the loaded facts */
+    /* For now, just verify the function returns 0 (success) */
+
+    wl_dd_worker_destroy(w);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_load_all_facts_no_facts(void)
+{
+    TEST("wirelog_load_all_facts with no inline facts returns 0");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl edge(x: int32, y: int32)\n", NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    wl_dd_worker_t *w = wl_dd_worker_create(1);
+
+    int rc = wirelog_load_all_facts(prog, w);
+    if (rc != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected 0, got %d", rc);
+        wl_dd_worker_destroy(w);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wl_dd_worker_destroy(w);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_load_all_facts_null_args(void)
+{
+    TEST("wirelog_load_all_facts rejects NULL arguments");
+
+    wl_dd_worker_t *w = wl_dd_worker_create(1);
+
+    if (wirelog_load_all_facts(NULL, w) != -1) {
+        wl_dd_worker_destroy(w);
+        FAIL("should return -1 for NULL program");
+        return;
+    }
+
+    wirelog_program_t *prog = wirelog_parse_string(".decl a(x: int32)\n", NULL);
+    if (wirelog_load_all_facts(prog, NULL) != -1) {
+        wirelog_program_free(prog);
+        wl_dd_worker_destroy(w);
+        FAIL("should return -1 for NULL worker");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    wl_dd_worker_destroy(w);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test: End-to-end Inline Facts + Rules                                    */
+/* ======================================================================== */
+
+/*
+ * Full pipeline: inline facts parsed -> loaded via wirelog_load_all_facts ->
+ * rules executed via DD -> results verified.
+ *
+ * Datalog:
+ *   .decl edge(x: int32, y: int32)
+ *   .decl tc(x: int32, y: int32)
+ *   edge(1, 2).
+ *   edge(2, 3).
+ *   edge(3, 4).
+ *   tc(x, y) :- edge(x, y).
+ *   tc(x, z) :- tc(x, y), edge(y, z).
+ *
+ * Expected tc: (1,2),(2,3),(3,4),(1,3),(2,4),(1,4)  = 6 tuples
+ */
+static void
+test_e2e_inline_facts_tc(void)
+{
+    TEST("e2e: inline facts + transitive closure rules");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+                      ".decl tc(x: int32, y: int32)\n"
+                      "edge(1, 2).\n"
+                      "edge(2, 3).\n"
+                      "edge(3, 4).\n"
+                      "tc(x, y) :- edge(x, y).\n"
+                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    /* Generate DD plan */
+    wl_dd_plan_t *dd_plan = NULL;
+    int rc = wl_dd_plan_generate(prog, &dd_plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("dd_plan_generate failed");
+        return;
+    }
+
+    wl_ffi_plan_t *ffi = NULL;
+    rc = wl_dd_marshal_plan(dd_plan, &ffi);
+    if (rc != 0) {
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        FAIL("dd_marshal_plan failed");
+        return;
+    }
+
+    /* Create worker and load inline facts */
+    wl_dd_worker_t *w = wl_dd_worker_create(1);
+    rc = wirelog_load_all_facts(prog, w);
+    if (rc != 0) {
+        wl_dd_worker_destroy(w);
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        FAIL("wirelog_load_all_facts failed");
+        return;
+    }
+
+    /* Execute */
+    tuple_collector_t results;
+    memset(&results, 0, sizeof(results));
+
+    rc = wl_dd_execute_cb(ffi, w, collect_tuple, &results);
+    if (rc != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "execute_cb returned %d", rc);
+        wl_dd_worker_destroy(w);
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    /* Verify: 6 tc tuples */
+    int n = count_tuples(&results, "tc");
+    if (n != 6) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected 6 tc tuples, got %d", n);
+        wl_dd_worker_destroy(w);
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    int64_t e12[] = { 1, 2 }, e23[] = { 2, 3 }, e34[] = { 3, 4 };
+    int64_t e13[] = { 1, 3 }, e24[] = { 2, 4 }, e14[] = { 1, 4 };
+
+    if (!has_tuple(&results, "tc", e12, 2) || !has_tuple(&results, "tc", e23, 2)
+        || !has_tuple(&results, "tc", e34, 2)
+        || !has_tuple(&results, "tc", e13, 2)
+        || !has_tuple(&results, "tc", e24, 2)
+        || !has_tuple(&results, "tc", e14, 2)) {
+        wl_dd_worker_destroy(w);
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        FAIL("missing expected tc tuple");
+        return;
+    }
+
+    wl_dd_worker_destroy(w);
+    wl_ffi_plan_free(ffi);
+    wl_dd_plan_free(dd_plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -610,6 +847,14 @@ main(void)
     printf("\n--- Callback Variants ---\n");
     test_execute_null_callback();
     test_execute_no_callback();
+
+    printf("\n--- Bulk Fact Loading ---\n");
+    test_load_all_facts();
+    test_load_all_facts_no_facts();
+    test_load_all_facts_null_args();
+
+    printf("\n--- End-to-end Inline Facts ---\n");
+    test_e2e_inline_facts_tc();
 
     printf("\n=== Results: %d passed, %d failed, %d total ===\n\n",
            tests_passed, tests_failed, tests_run);

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -1583,6 +1583,175 @@ test_api_end_to_end(void)
 }
 
 /* ======================================================================== */
+/* Fact Collection Tests                                                    */
+/* ======================================================================== */
+
+static void
+test_fact_collection_single_relation(void)
+{
+    TEST("Fact collection: edge(1,2). edge(2,3). stored in relation");
+
+    struct wirelog_program *prog
+        = make_program(".decl edge(src: int32, dst: int32)\n"
+                       "edge(1, 2).\n"
+                       "edge(2, 3).\n");
+
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    if (prog->relation_count != 1) {
+        wl_program_free(prog);
+        FAIL("expected 1 relation");
+        return;
+    }
+
+    wl_relation_info_t *rel = &prog->relations[0];
+    if (rel->fact_count != 2) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 2 facts, got %u", rel->fact_count);
+        wl_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    /* fact_data layout: [1, 2, 2, 3] (row-major, 2 cols per row) */
+    if (!rel->fact_data) {
+        wl_program_free(prog);
+        FAIL("fact_data should not be NULL");
+        return;
+    }
+
+    if (rel->fact_data[0] != 1 || rel->fact_data[1] != 2) {
+        wl_program_free(prog);
+        FAIL("fact 0 should be (1, 2)");
+        return;
+    }
+
+    if (rel->fact_data[2] != 2 || rel->fact_data[3] != 3) {
+        wl_program_free(prog);
+        FAIL("fact 1 should be (2, 3)");
+        return;
+    }
+
+    wl_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Fact Extraction API Tests                                                */
+/* ======================================================================== */
+
+static void
+test_api_get_facts(void)
+{
+    TEST("wirelog_program_get_facts returns correct data");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl edge(src: int32, dst: int32)\n"
+                               "edge(1, 2).\n"
+                               "edge(2, 3).\n"
+                               "edge(3, 4).\n",
+                               NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    int64_t *data = NULL;
+    uint32_t num_rows = 0, num_cols = 0;
+    int rc
+        = wirelog_program_get_facts(prog, "edge", &data, &num_rows, &num_cols);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("get_facts should return 0");
+        return;
+    }
+
+    if (num_rows != 3 || num_cols != 2) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 3x2, got %ux%u", num_rows,
+                 num_cols);
+        free(data);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    /* Verify data: {1,2, 2,3, 3,4} */
+    if (data[0] != 1 || data[1] != 2 || data[2] != 2 || data[3] != 3
+        || data[4] != 3 || data[5] != 4) {
+        free(data);
+        wirelog_program_free(prog);
+        FAIL("fact data mismatch");
+        return;
+    }
+
+    free(data);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_api_get_facts_no_facts(void)
+{
+    TEST("wirelog_program_get_facts returns 1 for no-facts relation");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl edge(src: int32, dst: int32)\n", NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    int64_t *data = NULL;
+    uint32_t num_rows = 0, num_cols = 0;
+    int rc
+        = wirelog_program_get_facts(prog, "edge", &data, &num_rows, &num_cols);
+    if (rc != 1) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected rc=1, got %d", rc);
+        free(data);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_api_get_facts_unknown_relation(void)
+{
+    TEST("wirelog_program_get_facts returns -1 for unknown relation");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl edge(src: int32, dst: int32)\n", NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    int64_t *data = NULL;
+    uint32_t num_rows = 0, num_cols = 0;
+    int rc = wirelog_program_get_facts(prog, "nonexistent", &data, &num_rows,
+                                       &num_cols);
+    if (rc != -1) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected rc=-1, got %d", rc);
+        free(data);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -1625,6 +1794,14 @@ main(void)
     /* UNION merge */
     test_union_merge_tc();
     test_union_single_rule();
+
+    /* Fact collection */
+    test_fact_collection_single_relation();
+
+    /* Fact extraction API */
+    test_api_get_facts();
+    test_api_get_facts_no_facts();
+    test_api_get_facts_unknown_relation();
 
     /* Public API */
     test_api_parse_string();

--- a/wirelog/ffi/facts_loader.c
+++ b/wirelog/ffi/facts_loader.c
@@ -1,0 +1,40 @@
+/*
+ * facts_loader.c - Bulk EDB Fact Loading via Rust FFI
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Implements wirelog_load_all_facts(), which bridges the parser's inline
+ * fact storage with the DD execution engine.  This file is compiled only
+ * into targets that link the Rust FFI (rust_ffi_dep), keeping the core
+ * IR library free of Rust dependencies.
+ */
+
+#include "dd_ffi.h"
+#include "../ir/program.h"
+#include "../wirelog.h"
+
+#include <string.h>
+
+int
+wirelog_load_all_facts(const wirelog_program_t *prog, void *worker)
+{
+    if (!prog || !worker)
+        return -1;
+
+    wl_dd_worker_t *w = (wl_dd_worker_t *)worker;
+
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        const wl_relation_info_t *rel = &prog->relations[i];
+        if (rel->fact_count == 0)
+            continue;
+
+        int rc = wl_dd_load_edb(w, rel->name, rel->fact_data, rel->fact_count,
+                                rel->column_count);
+        if (rc != 0)
+            return -1;
+    }
+
+    return 0;
+}

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -22,6 +22,7 @@
 #include "../parser/parser.h"
 #include "../wirelog-parser.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 /* ======================================================================== */
@@ -172,6 +173,47 @@ wirelog_program_is_stratified(const wirelog_program_t *program)
     if (!program)
         return false;
     return program->is_stratified;
+}
+
+/* ======================================================================== */
+/* Fact Extraction                                                          */
+/* ======================================================================== */
+
+int
+wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
+                          int64_t **data, uint32_t *num_rows,
+                          uint32_t *num_cols)
+{
+    if (!prog || !relation || !data || !num_rows || !num_cols)
+        return -1;
+
+    *data = NULL;
+    *num_rows = 0;
+    *num_cols = 0;
+
+    /* Find the relation */
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (prog->relations[i].name
+            && strcmp(prog->relations[i].name, relation) == 0) {
+            const wl_relation_info_t *rel = &prog->relations[i];
+            if (rel->fact_count == 0)
+                return 1;
+
+            uint32_t ncols = rel->column_count;
+            uint32_t total = rel->fact_count * ncols;
+            int64_t *copy = (int64_t *)malloc(total * sizeof(int64_t));
+            if (!copy)
+                return -1;
+            memcpy(copy, rel->fact_data, total * sizeof(int64_t));
+
+            *data = copy;
+            *num_rows = rel->fact_count;
+            *num_cols = ncols;
+            return 0;
+        }
+    }
+
+    return -1; /* relation not found */
 }
 
 /* ======================================================================== */

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -79,6 +79,7 @@ relation_info_free(wl_relation_info_t *info)
         free(info->input_param_names);
         free(info->input_param_values);
     }
+    free(info->fact_data);
 }
 
 static void
@@ -355,6 +356,52 @@ collect_rule(struct wirelog_program *prog, const wl_ast_node_t *rule_node)
     return 0;
 }
 
+static int
+collect_fact(struct wirelog_program *prog, const wl_ast_node_t *fact_node)
+{
+    if (!fact_node->name)
+        return -1;
+
+    wl_relation_info_t *rel = find_relation(prog, fact_node->name);
+    if (!rel) {
+        rel = add_relation(prog, fact_node->name);
+        if (!rel)
+            return -1;
+    }
+
+    uint32_t ncols = fact_node->child_count;
+
+    /* Grow fact_data buffer if needed */
+    uint32_t needed = (rel->fact_count + 1) * ncols;
+    if (needed > rel->fact_capacity) {
+        uint32_t new_cap
+            = rel->fact_capacity == 0 ? ncols * 8 : rel->fact_capacity * 2;
+        if (new_cap < needed)
+            new_cap = needed;
+        int64_t *new_data
+            = (int64_t *)realloc(rel->fact_data, new_cap * sizeof(int64_t));
+        if (!new_data)
+            return -1;
+        rel->fact_data = new_data;
+        rel->fact_capacity = new_cap;
+    }
+
+    /* Copy fact values into row-major layout */
+    uint32_t offset = rel->fact_count * ncols;
+    for (uint32_t i = 0; i < ncols; i++) {
+        const wl_ast_node_t *arg = fact_node->children[i];
+        if (arg->type == WL_NODE_INTEGER) {
+            rel->fact_data[offset + i] = arg->int_value;
+        } else if (arg->type == WL_NODE_STRING) {
+            /* String facts: store 0 for now (string interning TBD) */
+            rel->fact_data[offset + i] = 0;
+        }
+    }
+
+    rel->fact_count++;
+    return 0;
+}
+
 int
 wl_program_collect_metadata(struct wirelog_program *program,
                             const wl_ast_node_t *ast)
@@ -381,6 +428,9 @@ wl_program_collect_metadata(struct wirelog_program *program,
             break;
         case WL_NODE_RULE:
             rc = collect_rule(program, child);
+            break;
+        case WL_NODE_FACT:
+            rc = collect_fact(program, child);
             break;
         default:
             /* Ignore unknown node types */

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -34,6 +34,10 @@ typedef struct {
     char **input_param_names;
     char **input_param_values;
     uint32_t input_param_count;
+    /* Inline facts (row-major int64_t array) */
+    int64_t *fact_data;
+    uint32_t fact_count;
+    uint32_t fact_capacity;
 } wl_relation_info_t;
 
 /* ======================================================================== */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -97,6 +97,42 @@ void
 wirelog_program_free(wirelog_program_t *program);
 
 /* ======================================================================== */
+/* Fact Extraction API                                                      */
+/* ======================================================================== */
+
+/**
+ * Extract inline facts for a relation from the compiled program.
+ *
+ * Returns a flat row-major int64_t array of all facts declared for
+ * the given relation.  Caller must free the returned array.
+ *
+ * @param prog       Compiled program
+ * @param relation   Relation name (e.g., "edge")
+ * @param data       Output: allocated array of int64_t values (caller frees)
+ * @param num_rows   Output: number of fact tuples
+ * @param num_cols   Output: number of columns per tuple
+ * @return 0 on success, -1 on error (unknown relation), 1 if no facts
+ */
+int
+wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
+                          int64_t **data, uint32_t *num_rows,
+                          uint32_t *num_cols);
+
+/**
+ * Load all inline facts from the program into a DD worker.
+ *
+ * Iterates over all relations with inline facts (fact_count > 0) and
+ * calls wl_dd_load_edb() for each.  This bridges the parser's fact
+ * storage with the DD execution engine.
+ *
+ * @param prog    Compiled program with inline facts
+ * @param worker  DD worker handle to load facts into
+ * @return 0 on success, -1 on error (NULL args or EDB load failure)
+ */
+int
+wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
+
+/* ======================================================================== */
 /* Optimizer API                                                            */
 /* ======================================================================== */
 


### PR DESCRIPTION
## Summary

Closes #14 (depends on #15 / #13 for parser inline facts)

- Adds inline fact storage (`fact_data`/`fact_count`) to `wl_relation_info_t` and collects facts during metadata pass
- Adds `wirelog_program_get_facts()` public API for per-relation fact extraction as flat `int64_t` arrays
- Adds `wirelog_load_all_facts()` to bulk-load all inline EDB facts into a DD worker
- End-to-end test: inline facts + transitive closure rules executed through the full DD pipeline

## Test plan

- [x] `test_program`: 4 new tests (fact collection, get_facts, no-facts, unknown-relation) — 41/41 pass
- [x] `test_dd_execute`: 4 new tests (load_all_facts, no-facts, null-args, e2e TC) — 11/11 pass
- [x] Full suite: 9/9 test suites pass
- [x] clang-format (llvm@18) clean