### PR TITLE
Add CLI driver for executing .dl Datalog files (closes #11)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -214,6 +214,40 @@ pkg.generate(
 )
 
 # ============================================================================
+# CLI Driver (requires DD executor)
+# ============================================================================
+
+if dd_option
+  wirelog_cli_src = files(
+    'wirelog/cli/driver.c',
+    'wirelog/ffi/facts_loader.c',
+  )
+
+  wirelog_run_deps = [rust_ffi_dep]
+  if threads_option == 'enabled'
+    wirelog_run_deps += threads_dep
+  endif
+
+  # Build target is 'wirelog-cli' to avoid collision with the wirelog/
+  # source subdirectory in the build tree. Installed as 'wirelog'.
+  wirelog_run = executable(
+    'wirelog-cli',
+    files('wirelog/cli/main.c'),
+    wirelog_sources,
+    wirelog_cli_src,
+    config_h_file,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    dependencies: wirelog_run_deps,
+    install: true,
+    install_dir: get_option('bindir'),
+  )
+
+  meson.add_install_script('sh', '-c',
+    'mv "$DESTDIR$MESON_INSTALL_PREFIX/bin/wirelog-cli" "$DESTDIR$MESON_INSTALL_PREFIX/bin/wirelog"'
+  )
+endif
+
+# ============================================================================
 # Tests
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -129,3 +129,21 @@ test_dd_execute_exe = executable(
 )
 
 test('dd_execute', test_dd_execute_exe)
+
+cli_src = files(
+  '../wirelog/cli/driver.c',
+)
+
+test_cli_exe = executable(
+  'test_cli',
+  files('test_cli.c'),
+  parser_src,
+  ir_src,
+  ffi_src,
+  facts_loader_src,
+  cli_src,
+  dependencies: [rust_ffi_dep],
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+
+test('cli', test_cli_exe)

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -1,0 +1,321 @@
+/*
+ * test_cli.c - CLI driver unit tests
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Tests the CLI driver components: file reading, pipeline execution,
+ * and output formatting.
+ */
+
+#include "../wirelog/ffi/dd_ffi.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+    do {                                      \
+        tests_run++;                          \
+        printf("  [%d] %s", tests_run, name); \
+    } while (0)
+
+#define PASS()                 \
+    do {                       \
+        tests_passed++;        \
+        printf(" ... PASS\n"); \
+    } while (0)
+
+#define FAIL(msg)                         \
+    do {                                  \
+        tests_failed++;                   \
+        printf(" ... FAIL: %s\n", (msg)); \
+    } while (0)
+
+/* ======================================================================== */
+/* CLI internals under test                                                 */
+/* ======================================================================== */
+
+#include "../wirelog/cli/driver.h"
+
+/* ======================================================================== */
+/* Test: wl_read_file                                                       */
+/* ======================================================================== */
+
+static void
+test_read_file_basic(void)
+{
+    TEST("wl_read_file reads a .dl file");
+
+    /* Write a temp file */
+    const char *path = "/tmp/wirelog_test_read.dl";
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        FAIL("cannot create temp file");
+        return;
+    }
+    fprintf(f, ".decl edge(x: int32, y: int32)\nedge(1, 2).\n");
+    fclose(f);
+
+    char *contents = wl_read_file(path);
+    if (!contents) {
+        FAIL("wl_read_file returned NULL");
+        return;
+    }
+
+    if (strstr(contents, ".decl edge") == NULL) {
+        free(contents);
+        FAIL("contents missing .decl edge");
+        return;
+    }
+
+    if (strstr(contents, "edge(1, 2).") == NULL) {
+        free(contents);
+        FAIL("contents missing edge(1, 2).");
+        return;
+    }
+
+    free(contents);
+    remove(path);
+    PASS();
+}
+
+static void
+test_read_file_nonexistent(void)
+{
+    TEST("wl_read_file returns NULL for nonexistent file");
+
+    char *contents = wl_read_file("/tmp/wirelog_no_such_file_xyz.dl");
+    if (contents != NULL) {
+        free(contents);
+        FAIL("expected NULL for nonexistent file");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_read_file_null_path(void)
+{
+    TEST("wl_read_file returns NULL for NULL path");
+
+    char *contents = wl_read_file(NULL);
+    if (contents != NULL) {
+        free(contents);
+        FAIL("expected NULL for NULL path");
+        return;
+    }
+
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test: wl_print_tuple (output formatting callback)                        */
+/* ======================================================================== */
+
+static void
+test_print_tuple_basic(void)
+{
+    TEST("wl_print_tuple formats relation(v1, v2)");
+
+    const char *path = "/tmp/wirelog_test_output.txt";
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        FAIL("cannot create temp file");
+        return;
+    }
+
+    int64_t row[] = { 1, 2 };
+    wl_print_tuple("edge", row, 2, f);
+    fclose(f);
+
+    char *contents = wl_read_file(path);
+    if (!contents) {
+        FAIL("cannot read output file");
+        return;
+    }
+
+    if (strcmp(contents, "edge(1, 2)\n") != 0) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected 'edge(1, 2)\\n', got '%s'",
+                 contents);
+        free(contents);
+        remove(path);
+        FAIL(msg);
+        return;
+    }
+
+    free(contents);
+    remove(path);
+    PASS();
+}
+
+static void
+test_print_tuple_single_col(void)
+{
+    TEST("wl_print_tuple formats single column");
+
+    const char *path = "/tmp/wirelog_test_output2.txt";
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        FAIL("cannot create temp file");
+        return;
+    }
+
+    int64_t row[] = { 42 };
+    wl_print_tuple("node", row, 1, f);
+    fclose(f);
+
+    char *contents = wl_read_file(path);
+    if (!contents) {
+        FAIL("cannot read output file");
+        return;
+    }
+
+    if (strcmp(contents, "node(42)\n") != 0) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected 'node(42)\\n', got '%s'",
+                 contents);
+        free(contents);
+        remove(path);
+        FAIL(msg);
+        return;
+    }
+
+    free(contents);
+    remove(path);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test: wl_run_pipeline (full execution pipeline)                          */
+/* ======================================================================== */
+
+static void
+test_run_pipeline_tc(void)
+{
+    TEST("wl_run_pipeline executes transitive closure");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+                      ".decl tc(x: int32, y: int32)\n"
+                      "edge(1, 2).\n"
+                      "edge(2, 3).\n"
+                      "tc(x, y) :- edge(x, y).\n"
+                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+
+    const char *outpath = "/tmp/wirelog_test_pipeline.txt";
+    FILE *f = fopen(outpath, "w");
+    if (!f) {
+        FAIL("cannot create output file");
+        return;
+    }
+
+    int rc = wl_run_pipeline(src, 1, f);
+    fclose(f);
+
+    if (rc != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
+        remove(outpath);
+        FAIL(msg);
+        return;
+    }
+
+    char *output = wl_read_file(outpath);
+    if (!output) {
+        remove(outpath);
+        FAIL("cannot read output file");
+        return;
+    }
+
+    /* Should have 3 tc tuples: (1,2), (2,3), (1,3) */
+    int count = 0;
+    const char *p = output;
+    while ((p = strstr(p, "tc(")) != NULL) {
+        count++;
+        p++;
+    }
+
+    if (count != 3) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected 3 tc tuples, got %d\n%s", count,
+                 output);
+        free(output);
+        remove(outpath);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    remove(outpath);
+    PASS();
+}
+
+static void
+test_run_pipeline_null_source(void)
+{
+    TEST("wl_run_pipeline rejects NULL source");
+
+    int rc = wl_run_pipeline(NULL, 1, stdout);
+    if (rc == 0) {
+        FAIL("expected non-zero for NULL source");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_run_pipeline_parse_error(void)
+{
+    TEST("wl_run_pipeline returns error for invalid source");
+
+    int rc = wl_run_pipeline("this is not valid datalog @@#$", 1, stdout);
+    if (rc == 0) {
+        FAIL("expected non-zero for invalid source");
+        return;
+    }
+
+    PASS();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("\n=== wirelog CLI Driver Tests ===\n\n");
+
+    printf("--- File Reading ---\n");
+    test_read_file_basic();
+    test_read_file_nonexistent();
+    test_read_file_null_path();
+
+    printf("\n--- Output Formatting ---\n");
+    test_print_tuple_basic();
+    test_print_tuple_single_col();
+
+    printf("\n--- Pipeline ---\n");
+    test_run_pipeline_tc();
+    test_run_pipeline_null_source();
+    test_run_pipeline_parse_error();
+
+    printf("\n=== Results: %d passed, %d failed, %d total ===\n\n",
+           tests_passed, tests_failed, tests_run);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -1,0 +1,135 @@
+/*
+ * driver.c - wirelog CLI Driver Utilities
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Implements CLI driver utilities: file reading, pipeline execution,
+ * and output formatting.
+ */
+
+#include "driver.h"
+
+#include "../ffi/dd_ffi.h"
+#include "../wirelog.h"
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *
+wl_read_file(const char *path)
+{
+    if (!path)
+        return NULL;
+
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return NULL;
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    long len = ftell(f);
+    if (len < 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    rewind(f);
+
+    char *buf = (char *)malloc((size_t)len + 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+
+    size_t read = fread(buf, 1, (size_t)len, f);
+    fclose(f);
+
+    buf[read] = '\0';
+    return buf;
+}
+
+void
+wl_print_tuple(const char *relation, const int64_t *row, uint32_t ncols,
+               FILE *out)
+{
+    fprintf(out, "%s(", relation);
+    for (uint32_t i = 0; i < ncols; i++) {
+        if (i > 0)
+            fprintf(out, ", ");
+        fprintf(out, "%" PRId64, row[i]);
+    }
+    fprintf(out, ")\n");
+}
+
+/* Callback adapter: user_data is a FILE* */
+static void
+print_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
+               void *user_data)
+{
+    wl_print_tuple(relation, row, ncols, (FILE *)user_data);
+}
+
+int
+wl_run_pipeline(const char *source, uint32_t num_workers, FILE *out)
+{
+    if (!source || !out)
+        return -1;
+
+    /* 1. Parse */
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(source, &err);
+    if (!prog)
+        return -1;
+
+    /* 2. Generate DD plan */
+    wl_dd_plan_t *dd_plan = NULL;
+    int rc = wl_dd_plan_generate(prog, &dd_plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    /* 3. Marshal to FFI */
+    wl_ffi_plan_t *ffi = NULL;
+    rc = wl_dd_marshal_plan(dd_plan, &ffi);
+    if (rc != 0) {
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    /* 4. Create worker and load inline facts */
+    wl_dd_worker_t *w = wl_dd_worker_create(num_workers);
+    if (!w) {
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    rc = wirelog_load_all_facts(prog, w);
+    if (rc != 0) {
+        wl_dd_worker_destroy(w);
+        wl_ffi_plan_free(ffi);
+        wl_dd_plan_free(dd_plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    /* 5. Execute with output callback */
+    rc = wl_dd_execute_cb(ffi, w, print_tuple_cb, out);
+
+    /* 6. Cleanup */
+    wl_dd_worker_destroy(w);
+    wl_ffi_plan_free(ffi);
+    wl_dd_plan_free(dd_plan);
+    wirelog_program_free(prog);
+
+    return rc;
+}

--- a/wirelog/cli/driver.h
+++ b/wirelog/cli/driver.h
@@ -1,0 +1,57 @@
+/*
+ * driver.h - wirelog CLI Driver Internal API
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * INTERNAL HEADER - not installed, not part of public API.
+ * Declares utilities used by the CLI driver executable.
+ */
+
+#ifndef WIRELOG_CLI_DRIVER_H
+#define WIRELOG_CLI_DRIVER_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+/**
+ * wl_read_file:
+ * @path: Path to the file to read.
+ *
+ * Read the entire contents of a file into a NUL-terminated string.
+ * Caller must free the returned string.
+ *
+ * Returns: Allocated string on success, NULL on error.
+ */
+char *
+wl_read_file(const char *path);
+
+/**
+ * wl_print_tuple:
+ * @relation: Relation name.
+ * @row:      Array of int64_t column values.
+ * @ncols:    Number of columns.
+ * @out:      Output stream.
+ *
+ * Print a single result tuple in "relation(v1, v2, ...)" format.
+ */
+void
+wl_print_tuple(const char *relation, const int64_t *row, uint32_t ncols,
+               FILE *out);
+
+/**
+ * wl_run_pipeline:
+ * @source:      Datalog source text.
+ * @num_workers: Number of DD worker threads.
+ * @out:         Output stream for result tuples.
+ *
+ * Run the full Datalog pipeline: parse -> DD plan -> marshal ->
+ * load inline facts -> execute -> print results.
+ *
+ * Returns: 0 on success, non-zero on error.
+ */
+int
+wl_run_pipeline(const char *source, uint32_t num_workers, FILE *out);
+
+#endif /* WIRELOG_CLI_DRIVER_H */

--- a/wirelog/cli/main.c
+++ b/wirelog/cli/main.c
@@ -1,0 +1,88 @@
+/*
+ * main.c - wirelog CLI Entry Point
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Reads a .dl file and executes it through the full Datalog pipeline.
+ *
+ * Usage: wirelog [options] <file.dl>
+ *   --workers N   Number of DD worker threads (default: 1)
+ *   --help        Show usage information
+ */
+
+#include "driver.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void
+print_usage(const char *progname)
+{
+    fprintf(stderr, "Usage: %s [options] <file.dl>\n", progname);
+    fprintf(stderr, "\nOptions:\n");
+    fprintf(stderr,
+            "  --workers N   Number of DD worker threads (default: 1)\n");
+    fprintf(stderr, "  --help        Show this help message\n");
+}
+
+int
+main(int argc, char *argv[])
+{
+    const char *filepath = NULL;
+    uint32_t num_workers = 1;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (strcmp(argv[i], "--workers") == 0) {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "error: --workers requires an argument\n");
+                return 1;
+            }
+            long val = strtol(argv[++i], NULL, 10);
+            if (val < 1 || val > 256) {
+                fprintf(stderr, "error: workers must be between 1 and 256\n");
+                return 1;
+            }
+            num_workers = (uint32_t)val;
+            continue;
+        }
+        if (argv[i][0] == '-') {
+            fprintf(stderr, "error: unknown option '%s'\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+        if (filepath) {
+            fprintf(stderr, "error: multiple input files not supported\n");
+            return 1;
+        }
+        filepath = argv[i];
+    }
+
+    if (!filepath) {
+        fprintf(stderr, "error: no input file specified\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    char *source = wl_read_file(filepath);
+    if (!source) {
+        fprintf(stderr, "error: cannot read file '%s'\n", filepath);
+        return 1;
+    }
+
+    int rc = wl_run_pipeline(source, num_workers, stdout);
+    free(source);
+
+    if (rc != 0) {
+        fprintf(stderr, "error: execution failed\n");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Adds `wirelog` CLI executable that reads a `.dl` file and runs it through the full Datalog pipeline
- Pipeline: parse -> IR -> stratify -> DD plan -> marshal -> load inline facts -> execute -> print results
- Supports `--workers N` flag for multi-threaded DD execution and `--help`
- 8 new unit tests covering file I/O, output formatting, pipeline execution, and error handling

## Example

```
$ wirelog tc.dl
tc(1, 2)
tc(2, 3)
tc(3, 4)
tc(1, 3)
tc(2, 4)
tc(1, 4)
```

## New Files

- `wirelog/cli/driver.h` - CLI driver internal API (wl_read_file, wl_print_tuple, wl_run_pipeline)
- `wirelog/cli/driver.c` - Implementation of driver utilities
- `wirelog/cli/main.c` - CLI entry point with argument parsing
- `tests/test_cli.c` - 8 unit tests

## Test plan

- [x] `wl_read_file` reads files, returns NULL for missing/NULL paths
- [x] `wl_print_tuple` formats `relation(v1, v2)` output correctly
- [x] `wl_run_pipeline` executes transitive closure end-to-end
- [x] `wl_run_pipeline` rejects NULL source and invalid Datalog
- [x] CLI executable runs `tc.dl` and produces correct output
- [x] `--workers` and `--help` flags work correctly
- [x] All 10 test suites pass (including 8 new CLI tests)
- [x] clang-format clean (llvm@18)