### PR TITLE
Fix CodeQL alerts: workflow permissions and FFI null guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # ==========================================================================
   # Gate: Lint must pass before any CI job runs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: clang-format (report)

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # ==========================================================================
   # Gate: Lint must pass before any static analysis job runs

--- a/rust/wirelog-dd/src/ffi.rs
+++ b/rust/wirelog-dd/src/ffi.rs
@@ -328,6 +328,7 @@ mod tests {
             assert_eq!(rc, 0);
 
             // Verify stored data
+            assert!(!w.is_null());
             let worker = &*w;
             let rows = worker.edb_data.get("edge").unwrap();
             assert_eq!(rows.len(), 3);
@@ -353,6 +354,7 @@ mod tests {
             let data_b: [i64; 4] = [1, 2, 3, 4];
             wl_dd_load_edb(w, name_b.as_ptr(), data_b.as_ptr(), 2, 2);
 
+            assert!(!w.is_null());
             let worker = &*w;
             assert_eq!(worker.edb_data.len(), 2);
             assert_eq!(worker.edb_data["a"].len(), 2);
@@ -376,6 +378,7 @@ mod tests {
             let data2: [i64; 2] = [3, 4];
             wl_dd_load_edb(w, name.as_ptr(), data2.as_ptr(), 1, 2);
 
+            assert!(!w.is_null());
             let worker = &*w;
             let rows = worker.edb_data.get("a").unwrap();
             assert_eq!(rows.len(), 2);


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to all CI workflows (least-privilege principle) — resolves 11 `actions/missing-workflow-permissions` alerts
- Add `assert!(!w.is_null())` null guards before raw pointer dereference in Rust FFI tests — resolves 3 `rust/access-invalid-pointer` alerts

## Test plan
- [x] All 84 Rust tests pass (`cargo test`)
- [ ] CI workflows still trigger correctly with the new permissions block
- [ ] CodeQL re-scan shows 0 open alerts after merge