### PR TITLE
Add CodeQL Advanced Setup with security-and-quality suite

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+name: "wirelog CodeQL Configuration"
+
+queries:
+  - uses: security-and-quality
+
+paths:
+  - wirelog
+  - rust/wirelog-dd/src
+  - tests
+
+paths-ignore:
+  - bench
+  - build*
+  - third_party
+
+threat-models:
+  - remote
+  - local

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wirelog/**'
+      - 'rust/**'
+      - 'tests/**'
+      - 'meson.build'
+      - '.github/codeql/**'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'wirelog/**'
+      - 'rust/**'
+      - 'tests/**'
+      - 'meson.build'
+      - '.github/codeql/**'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '0 2 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: manual
+          - language: rust
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install C build tools
+        if: matrix.language == 'c-cpp'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Build (C11)
+        if: matrix.language == 'c-cpp'
+        run: |
+          meson setup builddir -Dtests=true
+          meson compile -C builddir
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Switch from CodeQL default setup to advanced setup for deeper analysis
- Use `security-and-quality` query suite (covers more CWEs than default)
- Configure both `remote` and `local` threat models for FFI boundary analysis
- Manual Meson build for accurate C11 code analysis
- Path-filtered triggers to skip documentation-only changes

## What changes
- `.github/codeql/codeql-config.yml` — analysis scope, threat models, query suite
- `.github/workflows/codeql.yml` — advanced workflow with C/Rust matrix

## Next steps after merge
1. Disable default CodeQL setup in GitHub Settings > Code Security
2. Review initial scan results in Security tab
3. Tune false positives if needed
4. Consider custom queries for FFI memory safety patterns (Phase 2)

## Test plan
- [ ] CodeQL workflow runs successfully on both `c-cpp` and `rust` languages
- [ ] Results appear in GitHub Security tab
- [ ] PR comments show inline CodeQL findings