### PR TITLE
Add DOOP benchmark and fix ANTIJOIN with constants (#41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ compile_commands.json
 *.swp
 *.swo
 *~
-.DS_Store
 *.kate-swp
 .clangd/
 
@@ -50,6 +49,9 @@ third_party/nanoarrow-vendor/
 # OMC and Claude Code specific
 .omc/
 .claude/
+
+# Large benchmark datasets (download via bench/data/*/download.sh)
+bench/data/doop/*.csv
 
 # OS specific
 .DS_Store

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -1581,6 +1581,574 @@ run_crdt_workload(const char *data_dir, uint32_t workers, int repeat)
 }
 
 /* ----------------------------------------------------------------
+ * DOOP - Java Points-to Analysis (zxing dataset)
+ * ---------------------------------------------------------------- */
+
+/* DOOP uses .input directives to load 34 CSV files (~3.5M tuples).
+ * EDB definitions are generated programmatically; rules are a static string.
+ * Dataset: zxing (smallest FlowLog DOOP artifact, 83MB).
+ * Magic constants are zxing-specific pre-hashed integer IDs. */
+
+#define DOOP_SRC_BUFSZ ((size_t)64 * 1024)
+#define DOOP_NRELS 34
+
+struct doop_edb {
+    const char *name;
+    const char *cols;
+    const char *csv;
+};
+
+static const struct doop_edb doop_edbs[DOOP_NRELS] = {
+    { "DirectSuperclass", "(class: int32, superclass: int32)",
+      "DirectSuperclass.csv" },
+    { "DirectSuperinterface", "(ref: int32, interface: int32)",
+      "DirectSuperinterface.csv" },
+    { "MainClass", "(class: int32)", "MainClass.csv" },
+    { "FormalParam", "(index: int32, method: int32, var: int32)",
+      "FormalParam.csv" },
+    { "ComponentType", "(arrayType: int32, componentType: int32)",
+      "ComponentType.csv" },
+    { "AssignReturnValue", "(invocation: int32, to: int32)",
+      "AssignReturnValue.csv" },
+    { "ActualParam", "(index: int32, invocation: int32, var: int32)",
+      "ActualParam.csv" },
+    { "Method_Modifier", "(mod: int32, method: int32)", "Method_Modifier.csv" },
+    { "Var_Type", "(var: int32, type: int32)", "Var_Type.csv" },
+    { "HeapAllocation_Type", "(heap: int32, type: int32)",
+      "HeapAllocation_Type.csv" },
+    { "_ClassType", "(class: int32)", "ClassType.csv" },
+    { "_ArrayType", "(arrayType: int32)", "ArrayType.csv" },
+    { "_InterfaceType", "(interface: int32)", "InterfaceType.csv" },
+    { "_Var_DeclaringMethod", "(var: int32, method: int32)",
+      "Var_DeclaringMethod.csv" },
+    { "_ApplicationClass", "(type: int32)", "ApplicationClass.csv" },
+    { "_ThisVar", "(method: int32, var: int32)", "ThisVar.csv" },
+    { "_NormalHeap", "(id: int32, type: int32)", "NormalHeap.csv" },
+    { "_StringConstant", "(id: int32)", "StringConstant.csv" },
+    { "_AssignHeapAllocation",
+      "(instruction: int32, idx: int32, heap: int32, to: int32, "
+      "inmethod: int32, linenumber: int32)",
+      "AssignHeapAllocation.csv" },
+    { "_AssignLocal",
+      "(instruction: int32, idx: int32, from: int32, to: int32, "
+      "inmethod: int32)",
+      "AssignLocal.csv" },
+    { "_AssignCast",
+      "(instruction: int32, idx: int32, from: int32, to: int32, "
+      "type: int32, inmethod: int32)",
+      "AssignCast.csv" },
+    { "_Field",
+      "(signature: int32, declaringClass: int32, simplename: int32, "
+      "type: int32)",
+      "Field.csv" },
+    { "_StaticMethodInvocation",
+      "(instruction: int32, idx: int32, signature: int32, method: int32)",
+      "StaticMethodInvocation.csv" },
+    { "_SpecialMethodInvocation",
+      "(instruction: int32, idx: int32, signature: int32, base: int32, "
+      "method: int32)",
+      "SpecialMethodInvocation.csv" },
+    { "_VirtualMethodInvocation",
+      "(instruction: int32, idx: int32, signature: int32, base: int32, "
+      "method: int32)",
+      "VirtualMethodInvocation.csv" },
+    { "_Method",
+      "(method: int32, simplename: int32, params: int32, "
+      "declaringType: int32, returnType: int32, jvmDescriptor: int32, "
+      "arity: int32)",
+      "Method.csv" },
+    { "Method_Descriptor", "(method: int32, descriptor: int32)",
+      "Method_Descriptor.csv" },
+    { "_StoreInstanceField",
+      "(instruction: int32, idx: int32, from: int32, base: int32, "
+      "signature: int32, method: int32)",
+      "StoreInstanceField.csv" },
+    { "_LoadInstanceField",
+      "(instruction: int32, idx: int32, to: int32, base: int32, "
+      "signature: int32, method: int32)",
+      "LoadInstanceField.csv" },
+    { "_StoreStaticField",
+      "(instruction: int32, idx: int32, from: int32, signature: int32, "
+      "method: int32)",
+      "StoreStaticField.csv" },
+    { "_LoadStaticField",
+      "(instruction: int32, idx: int32, to: int32, signature: int32, "
+      "method: int32)",
+      "LoadStaticField.csv" },
+    { "_StoreArrayIndex",
+      "(instruction: int32, idx: int32, from: int32, base: int32, "
+      "method: int32)",
+      "StoreArrayIndex.csv" },
+    { "_LoadArrayIndex",
+      "(instruction: int32, idx: int32, to: int32, base: int32, "
+      "method: int32)",
+      "LoadArrayIndex.csv" },
+    { "_Return", "(instruction: int32, idx: int32, var: int32, method: int32)",
+      "Return.csv" },
+};
+
+/* IDB declarations + all ~130 rules */
+static const char *doop_rules
+    /* IDB: Narrow schema */
+    = ".decl isType(t: int32)\n"
+      ".decl isReferenceType(t: int32)\n"
+      ".decl isArrayType(t: int32)\n"
+      ".decl isClassType(t: int32)\n"
+      ".decl isInterfaceType(t: int32)\n"
+      ".decl ApplicationClass(ref: int32)\n"
+      ".decl Field_DeclaringType(field: int32, declaringClass: int32)\n"
+      ".decl Method_DeclaringType(method: int32, declaringType: int32)\n"
+      ".decl Method_SimpleName(method: int32, simpleName: int32)\n"
+      ".decl ThisVar(method: int32, var: int32)\n"
+      ".decl Var_DeclaringMethod(var: int32, method: int32)\n"
+      ".decl Instruction_Method(insn: int32, inMethod: int32)\n"
+      ".decl isVirtualMethodInvocation_Insn(insn: int32)\n"
+      ".decl isStaticMethodInvocation_Insn(insn: int32)\n"
+      ".decl FieldInstruction_Signature(insn: int32, sign: int32)\n"
+      ".decl LoadInstanceField_Base(insn: int32, var: int32)\n"
+      ".decl LoadInstanceField_To(insn: int32, var: int32)\n"
+      ".decl StoreInstanceField_From(insn: int32, var: int32)\n"
+      ".decl StoreInstanceField_Base(insn: int32, var: int32)\n"
+      ".decl LoadStaticField_To(insn: int32, var: int32)\n"
+      ".decl StoreStaticField_From(insn: int32, var: int32)\n"
+      ".decl LoadArrayIndex_Base(insn: int32, var: int32)\n"
+      ".decl LoadArrayIndex_To(insn: int32, var: int32)\n"
+      ".decl StoreArrayIndex_From(insn: int32, var: int32)\n"
+      ".decl StoreArrayIndex_Base(insn: int32, var: int32)\n"
+      ".decl AssignInstruction_To(insn: int32, to: int32)\n"
+      ".decl AssignCast_From(insn: int32, from: int32)\n"
+      ".decl AssignCast_Type(insn: int32, type: int32)\n"
+      ".decl AssignLocal_From(insn: int32, from: int32)\n"
+      ".decl AssignHeapAllocation_Heap(insn: int32, heap: int32)\n"
+      ".decl ReturnNonvoid_Var(ret: int32, var: int32)\n"
+      ".decl MethodInvocation_Method(invocation: int32, signature: int32)\n"
+      ".decl VirtualMethodInvocation_Base(invocation: int32, base: int32)\n"
+      ".decl VirtualMethodInvocation_SimpleName(invocation: int32, "
+      "simplename: int32)\n"
+      ".decl VirtualMethodInvocation_Descriptor(invocation: int32, "
+      "descriptor: int32)\n"
+      ".decl SpecialMethodInvocation_Base(invocation: int32, base: int32)\n"
+      ".decl MethodInvocation_Base(invocation: int32, base: int32)\n"
+      /* IDB: Fat schema */
+      ".decl LoadInstanceField(base: int32, sig: int32, to: int32, "
+      "inmethod: int32)\n"
+      ".decl StoreInstanceField(from: int32, base: int32, signature: int32, "
+      "inmethod: int32)\n"
+      ".decl LoadStaticField(sig: int32, to: int32, inmethod: int32)\n"
+      ".decl StoreStaticField(from: int32, signature: int32, "
+      "inmethod: int32)\n"
+      ".decl LoadArrayIndex(base: int32, to: int32, inmethod: int32)\n"
+      ".decl StoreArrayIndex(from: int32, base: int32, inmethod: int32)\n"
+      ".decl AssignCast(type: int32, from: int32, to: int32, "
+      "inmethod: int32)\n"
+      ".decl AssignLocal(from: int32, to: int32, inmethod: int32)\n"
+      ".decl AssignHeapAllocation(heap: int32, to: int32, "
+      "inmethod: int32)\n"
+      ".decl ReturnVar(var: int32, method: int32)\n"
+      ".decl StaticMethodInvocation(invocation: int32, signature: int32, "
+      "inmethod: int32)\n"
+      /* IDB: Type hierarchy */
+      ".decl MethodLookup(simplename: int32, descriptor: int32, "
+      "type: int32, method: int32)\n"
+      ".decl MethodImplemented(simplename: int32, descriptor: int32, "
+      "type: int32, method: int32)\n"
+      ".decl DirectSubclass(a: int32, c: int32)\n"
+      ".decl Subclass(c: int32, a: int32)\n"
+      ".decl Superclass(c: int32, a: int32)\n"
+      ".decl Superinterface(k: int32, c: int32)\n"
+      ".decl SubtypeOf(subtype: int32, type: int32)\n"
+      ".decl SupertypeOf(supertype: int32, type: int32)\n"
+      ".decl SubtypeOfDifferent(subtype: int32, type: int32)\n"
+      ".decl MainMethodDeclaration(method: int32)\n"
+      /* IDB: Class initialization */
+      ".decl ClassInitializer(type: int32, method: int32)\n"
+      ".decl InitializedClass(classOrInterface: int32)\n"
+      /* IDB: Main analysis */
+      ".decl Assign(to: int32, from: int32)\n"
+      ".decl VarPointsTo(heap: int32, var: int32)\n"
+      ".decl InstanceFieldPointsTo(heap: int32, fld: int32, "
+      "baseheap: int32)\n"
+      ".decl StaticFieldPointsTo(heap: int32, fld: int32)\n"
+      ".decl CallGraphEdge(invocation: int32, meth: int32)\n"
+      ".decl ArrayIndexPointsTo(baseheap: int32, heap: int32)\n"
+      ".decl Reachable(method: int32)\n"
+      /* Phase 1: EDB staging & decomposition */
+      "isType(class) :- _ClassType(class).\n"
+      "isReferenceType(class) :- _ClassType(class).\n"
+      "isClassType(class) :- _ClassType(class).\n"
+      "isType(at) :- _ArrayType(at).\n"
+      "isReferenceType(at) :- _ArrayType(at).\n"
+      "isArrayType(at) :- _ArrayType(at).\n"
+      "isType(intf) :- _InterfaceType(intf).\n"
+      "isReferenceType(intf) :- _InterfaceType(intf).\n"
+      "isInterfaceType(intf) :- _InterfaceType(intf).\n"
+      "Var_DeclaringMethod(var, method) :- "
+      "_Var_DeclaringMethod(var, method).\n"
+      "isType(type) :- _ApplicationClass(type).\n"
+      "isReferenceType(type) :- _ApplicationClass(type).\n"
+      "ApplicationClass(type) :- _ApplicationClass(type).\n"
+      "ThisVar(method, var) :- _ThisVar(method, var).\n"
+      "isType(type) :- _NormalHeap(_, type).\n"
+      /* Decompose _AssignHeapAllocation */
+      "Instruction_Method(i, m) :- _AssignHeapAllocation(i, _, _, _, m, _).\n"
+      "AssignInstruction_To(i, t) :- _AssignHeapAllocation(i, _, _, t, _, _).\n"
+      "AssignHeapAllocation_Heap(i, h) :- "
+      "_AssignHeapAllocation(i, _, h, _, _, _).\n"
+      /* Decompose _AssignLocal */
+      "Instruction_Method(i, m) :- _AssignLocal(i, _, _, _, m).\n"
+      "AssignLocal_From(i, f) :- _AssignLocal(i, _, f, _, _).\n"
+      "AssignInstruction_To(i, t) :- _AssignLocal(i, _, _, t, _).\n"
+      /* Decompose _AssignCast */
+      "Instruction_Method(i, m) :- _AssignCast(i, _, _, _, _, m).\n"
+      "AssignCast_Type(i, tp) :- _AssignCast(i, _, _, _, tp, _).\n"
+      "AssignCast_From(i, f) :- _AssignCast(i, _, f, _, _, _).\n"
+      "AssignInstruction_To(i, t) :- _AssignCast(i, _, _, t, _, _).\n"
+      /* Decompose _Field */
+      "Field_DeclaringType(sig, dt) :- _Field(sig, dt, _, _).\n"
+      /* MethodInvocation_Base */
+      "MethodInvocation_Base(inv, b) :- "
+      "VirtualMethodInvocation_Base(inv, b).\n"
+      "MethodInvocation_Base(inv, b) :- "
+      "SpecialMethodInvocation_Base(inv, b).\n"
+      /* Decompose _StaticMethodInvocation */
+      "Instruction_Method(i, m) :- _StaticMethodInvocation(i, _, _, m).\n"
+      "isStaticMethodInvocation_Insn(i) :- "
+      "_StaticMethodInvocation(i, _, _, _).\n"
+      "MethodInvocation_Method(i, sig) :- "
+      "_StaticMethodInvocation(i, _, sig, _).\n"
+      /* Decompose _SpecialMethodInvocation */
+      "Instruction_Method(i, m) :- "
+      "_SpecialMethodInvocation(i, _, _, _, m).\n"
+      "SpecialMethodInvocation_Base(i, b) :- "
+      "_SpecialMethodInvocation(i, _, _, b, _).\n"
+      "MethodInvocation_Method(i, sig) :- "
+      "_SpecialMethodInvocation(i, _, sig, _, _).\n"
+      /* Decompose _VirtualMethodInvocation */
+      "Instruction_Method(i, m) :- "
+      "_VirtualMethodInvocation(i, _, _, _, m).\n"
+      "isVirtualMethodInvocation_Insn(i) :- "
+      "_VirtualMethodInvocation(i, _, _, _, _).\n"
+      "VirtualMethodInvocation_Base(i, b) :- "
+      "_VirtualMethodInvocation(i, _, _, b, _).\n"
+      "MethodInvocation_Method(i, sig) :- "
+      "_VirtualMethodInvocation(i, _, sig, _, _).\n"
+      /* Decompose _Method */
+      "Method_SimpleName(m, sn) :- _Method(m, sn, _, _, _, _, _).\n"
+      "Method_DeclaringType(m, dt) :- _Method(m, _, _, dt, _, _, _).\n"
+      /* Decompose _StoreInstanceField */
+      "Instruction_Method(i, m) :- "
+      "_StoreInstanceField(i, _, _, _, _, m).\n"
+      "FieldInstruction_Signature(i, sig) :- "
+      "_StoreInstanceField(i, _, _, _, sig, _).\n"
+      "StoreInstanceField_Base(i, b) :- "
+      "_StoreInstanceField(i, _, _, b, _, _).\n"
+      "StoreInstanceField_From(i, f) :- "
+      "_StoreInstanceField(i, _, f, _, _, _).\n"
+      /* Decompose _LoadInstanceField */
+      "Instruction_Method(i, m) :- "
+      "_LoadInstanceField(i, _, _, _, _, m).\n"
+      "FieldInstruction_Signature(i, sig) :- "
+      "_LoadInstanceField(i, _, _, _, sig, _).\n"
+      "LoadInstanceField_Base(i, b) :- "
+      "_LoadInstanceField(i, _, _, b, _, _).\n"
+      "LoadInstanceField_To(i, t) :- "
+      "_LoadInstanceField(i, _, t, _, _, _).\n"
+      /* Decompose _StoreStaticField */
+      "Instruction_Method(i, m) :- _StoreStaticField(i, _, _, _, m).\n"
+      "FieldInstruction_Signature(i, sig) :- "
+      "_StoreStaticField(i, _, _, sig, _).\n"
+      "StoreStaticField_From(i, f) :- _StoreStaticField(i, _, f, _, _).\n"
+      /* Decompose _LoadStaticField */
+      "Instruction_Method(i, m) :- _LoadStaticField(i, _, _, _, m).\n"
+      "FieldInstruction_Signature(i, sig) :- "
+      "_LoadStaticField(i, _, _, sig, _).\n"
+      "LoadStaticField_To(i, t) :- _LoadStaticField(i, _, t, _, _).\n"
+      /* Decompose _StoreArrayIndex */
+      "Instruction_Method(i, m) :- _StoreArrayIndex(i, _, _, _, m).\n"
+      "StoreArrayIndex_Base(i, b) :- _StoreArrayIndex(i, _, _, b, _).\n"
+      "StoreArrayIndex_From(i, f) :- _StoreArrayIndex(i, _, f, _, _).\n"
+      /* Decompose _LoadArrayIndex */
+      "Instruction_Method(i, m) :- _LoadArrayIndex(i, _, _, _, m).\n"
+      "LoadArrayIndex_Base(i, b) :- _LoadArrayIndex(i, _, _, b, _).\n"
+      "LoadArrayIndex_To(i, t) :- _LoadArrayIndex(i, _, t, _, _).\n"
+      /* Decompose _Return */
+      "Instruction_Method(i, m) :- _Return(i, _, _, m).\n"
+      "ReturnNonvoid_Var(i, v) :- _Return(i, _, v, _).\n"
+      /* Fat schema population */
+      "LoadInstanceField(base, sig, to, im) :- "
+      "Instruction_Method(insn, im), LoadInstanceField_Base(insn, base), "
+      "FieldInstruction_Signature(insn, sig), "
+      "LoadInstanceField_To(insn, to).\n"
+      "StoreInstanceField(from, base, sig, im) :- "
+      "Instruction_Method(insn, im), StoreInstanceField_From(insn, from), "
+      "StoreInstanceField_Base(insn, base), "
+      "FieldInstruction_Signature(insn, sig).\n"
+      "LoadStaticField(sig, to, im) :- Instruction_Method(insn, im), "
+      "FieldInstruction_Signature(insn, sig), "
+      "LoadStaticField_To(insn, to).\n"
+      "StoreStaticField(from, sig, im) :- Instruction_Method(insn, im), "
+      "StoreStaticField_From(insn, from), "
+      "FieldInstruction_Signature(insn, sig).\n"
+      "LoadArrayIndex(base, to, im) :- Instruction_Method(insn, im), "
+      "LoadArrayIndex_Base(insn, base), LoadArrayIndex_To(insn, to).\n"
+      "StoreArrayIndex(from, base, im) :- Instruction_Method(insn, im), "
+      "StoreArrayIndex_From(insn, from), "
+      "StoreArrayIndex_Base(insn, base).\n"
+      "AssignCast(type, from, to, im) :- Instruction_Method(insn, im), "
+      "AssignCast_From(insn, from), AssignInstruction_To(insn, to), "
+      "AssignCast_Type(insn, type).\n"
+      "AssignLocal(from, to, im) :- AssignInstruction_To(insn, to), "
+      "Instruction_Method(insn, im), AssignLocal_From(insn, from).\n"
+      "AssignHeapAllocation(heap, to, im) :- "
+      "Instruction_Method(insn, im), "
+      "AssignHeapAllocation_Heap(insn, heap), "
+      "AssignInstruction_To(insn, to).\n"
+      "ReturnVar(var, method) :- Instruction_Method(insn, method), "
+      "ReturnNonvoid_Var(insn, var).\n"
+      "StaticMethodInvocation(inv, sig, im) :- "
+      "isStaticMethodInvocation_Insn(inv), Instruction_Method(inv, im), "
+      "MethodInvocation_Method(inv, sig).\n"
+      /* VirtualMethodInvocation derived */
+      "VirtualMethodInvocation_SimpleName(inv, sn) :- "
+      "isVirtualMethodInvocation_Insn(inv), "
+      "MethodInvocation_Method(inv, sig), "
+      "Method_SimpleName(sig, sn), Method_Descriptor(sig, desc).\n"
+      "VirtualMethodInvocation_Descriptor(inv, desc) :- "
+      "isVirtualMethodInvocation_Insn(inv), "
+      "MethodInvocation_Method(inv, sig), "
+      "Method_SimpleName(sig, sn), Method_Descriptor(sig, desc).\n"
+      /* Phase 2: Type hierarchy */
+      "MethodLookup(sn, d, t, m) :- MethodImplemented(sn, d, t, m).\n"
+      "MethodLookup(sn, d, t, m) :- DirectSuperclass(t, st), "
+      "MethodLookup(sn, d, st, m), !MethodImplemented(sn, d, t, _).\n"
+      "MethodLookup(sn, d, t, m) :- DirectSuperinterface(t, st), "
+      "MethodLookup(sn, d, st, m), !MethodImplemented(sn, d, t, _).\n"
+      "MethodImplemented(sn, d, t, m) :- Method_SimpleName(m, sn), "
+      "Method_Descriptor(m, d), Method_DeclaringType(m, t), "
+      "!Method_Modifier(1928492, m).\n"
+      "MainMethodDeclaration(m) :- MainClass(t), "
+      "Method_DeclaringType(m, t), m != 536048, m != 1057660, "
+      "m != 796639, Method_SimpleName(m, 2648290), "
+      "Method_Descriptor(m, 2671384), Method_Modifier(760051, m), "
+      "Method_Modifier(841804, m).\n"
+      "DirectSubclass(a, c) :- DirectSuperclass(a, c).\n"
+      "Subclass(c, a) :- DirectSubclass(a, c).\n"
+      "Subclass(c, a) :- Subclass(b, a), DirectSubclass(b, c).\n"
+      "Superclass(c, a) :- Subclass(a, c).\n"
+      "Superinterface(k, c) :- DirectSuperinterface(c, k).\n"
+      "Superinterface(k, c) :- DirectSuperinterface(c, j), "
+      "Superinterface(k, j).\n"
+      "Superinterface(k, c) :- DirectSuperclass(c, s), "
+      "Superinterface(k, s).\n"
+      "SubtypeOf(s, s) :- isClassType(s).\n"
+      "SubtypeOf(t, t) :- isType(t).\n"
+      "SubtypeOf(s, t) :- Subclass(t, s).\n"
+      "SubtypeOf(s, s) :- isInterfaceType(s).\n"
+      "SubtypeOf(s, t) :- isClassType(s), Superinterface(t, s).\n"
+      "SubtypeOf(s, t) :- isInterfaceType(s), isType(t), t = 613907.\n"
+      "SubtypeOf(s, t) :- isArrayType(s), isType(t), t = 613907.\n"
+      "SubtypeOf(s, t) :- isInterfaceType(s), Superinterface(t, s).\n"
+      "SubtypeOf(s, t) :- SubtypeOf(sc, tc), ComponentType(s, sc), "
+      "ComponentType(t, tc), isReferenceType(sc), "
+      "isReferenceType(tc).\n"
+      "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), "
+      "isType(t), t = 935673.\n"
+      "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), "
+      "isType(t), t = 619327.\n"
+      "SupertypeOf(s, t) :- SubtypeOf(t, s).\n"
+      "SubtypeOfDifferent(s, t) :- SubtypeOf(s, t), s != t.\n"
+      /* Phase 3: Class initialization */
+      "ClassInitializer(t, m) :- MethodImplemented(777634, 2670449, t, m).\n"
+      "InitializedClass(sc) :- InitializedClass(c), "
+      "DirectSuperclass(c, sc).\n"
+      "InitializedClass(si) :- InitializedClass(ci), "
+      "DirectSuperinterface(ci, si).\n"
+      "InitializedClass(c) :- MainMethodDeclaration(m), "
+      "Method_DeclaringType(m, c).\n"
+      "InitializedClass(c) :- Reachable(im), "
+      "AssignHeapAllocation(h, _, im), HeapAllocation_Type(h, c).\n"
+      "InitializedClass(c) :- Reachable(im), "
+      "Instruction_Method(inv, im), "
+      "isStaticMethodInvocation_Insn(inv), "
+      "MethodInvocation_Method(inv, sig), "
+      "Method_DeclaringType(sig, c).\n"
+      "InitializedClass(ci) :- Reachable(im), "
+      "StoreStaticField(_, sig, im), "
+      "Field_DeclaringType(sig, ci).\n"
+      "InitializedClass(ci) :- Reachable(im), "
+      "LoadStaticField(sig, _, im), Field_DeclaringType(sig, ci).\n"
+      "Reachable(cl) :- InitializedClass(c), "
+      "ClassInitializer(c, cl).\n"
+      /* Phase 4: Main analysis */
+      "Assign(act, frm) :- CallGraphEdge(inv, m), "
+      "FormalParam(idx, m, frm), ActualParam(idx, inv, act).\n"
+      "Assign(ret, loc) :- CallGraphEdge(inv, m), ReturnVar(ret, m), "
+      "AssignReturnValue(inv, loc).\n"
+      "VarPointsTo(h, v) :- AssignHeapAllocation(h, v, im), "
+      "Reachable(im).\n"
+      "VarPointsTo(h, to) :- Assign(from, to), VarPointsTo(h, from).\n"
+      "VarPointsTo(h, to) :- Reachable(im), "
+      "AssignLocal(from, to, im), VarPointsTo(h, from).\n"
+      "VarPointsTo(h, to) :- Reachable(im), "
+      "AssignCast(tp, from, to, im), SupertypeOf(tp, ht), "
+      "HeapAllocation_Type(h, ht), VarPointsTo(h, from).\n"
+      "ArrayIndexPointsTo(bh, h) :- Reachable(im), "
+      "StoreArrayIndex(from, base, im), VarPointsTo(bh, base), "
+      "VarPointsTo(h, from), HeapAllocation_Type(h, ht), "
+      "HeapAllocation_Type(bh, bht), ComponentType(bht, ct), "
+      "SupertypeOf(ct, ht).\n"
+      "VarPointsTo(h, to) :- Reachable(im), "
+      "LoadArrayIndex(base, to, im), VarPointsTo(bh, base), "
+      "ArrayIndexPointsTo(bh, h), Var_Type(to, tp), "
+      "HeapAllocation_Type(bh, bht), ComponentType(bht, bct), "
+      "SupertypeOf(tp, bct).\n"
+      "VarPointsTo(h, to) :- Reachable(im), "
+      "LoadInstanceField(base, sig, to, im), "
+      "VarPointsTo(bh, base), "
+      "InstanceFieldPointsTo(h, sig, bh).\n"
+      "VarPointsTo(h, to) :- Reachable(im), "
+      "LoadStaticField(fld, to, im), "
+      "StaticFieldPointsTo(h, fld).\n"
+      "VarPointsTo(h, this) :- Reachable(im), "
+      "Instruction_Method(inv, im), "
+      "VirtualMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), HeapAllocation_Type(h, ht), "
+      "VirtualMethodInvocation_SimpleName(inv, sn), "
+      "VirtualMethodInvocation_Descriptor(inv, desc), "
+      "MethodLookup(sn, desc, ht, tm), ThisVar(tm, this).\n"
+      "InstanceFieldPointsTo(h, fld, bh) :- Reachable(im), "
+      "StoreInstanceField(from, base, fld, im), "
+      "VarPointsTo(h, from), VarPointsTo(bh, base).\n"
+      "StaticFieldPointsTo(h, fld) :- Reachable(im), "
+      "StoreStaticField(from, fld, im), VarPointsTo(h, from).\n"
+      "Reachable(tm) :- Reachable(im), Instruction_Method(inv, im), "
+      "VirtualMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), HeapAllocation_Type(h, ht), "
+      "VirtualMethodInvocation_SimpleName(inv, sn), "
+      "VirtualMethodInvocation_Descriptor(inv, desc), "
+      "MethodLookup(sn, desc, ht, tm).\n"
+      "CallGraphEdge(inv, tm) :- Reachable(im), "
+      "Instruction_Method(inv, im), "
+      "VirtualMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), HeapAllocation_Type(h, ht), "
+      "VirtualMethodInvocation_SimpleName(inv, sn), "
+      "VirtualMethodInvocation_Descriptor(inv, desc), "
+      "MethodLookup(sn, desc, ht, tm).\n"
+      "Reachable(tm) :- Reachable(im), "
+      "StaticMethodInvocation(inv, tm, im).\n"
+      "CallGraphEdge(inv, tm) :- Reachable(im), "
+      "StaticMethodInvocation(inv, tm, im).\n"
+      "Reachable(tm) :- Reachable(im), Instruction_Method(inv, im), "
+      "SpecialMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), "
+      "MethodInvocation_Method(inv, tm), ThisVar(tm, this).\n"
+      "CallGraphEdge(inv, tm) :- Reachable(im), "
+      "Instruction_Method(inv, im), "
+      "SpecialMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), "
+      "MethodInvocation_Method(inv, tm), ThisVar(tm, this).\n"
+      "VarPointsTo(h, this) :- Reachable(im), "
+      "Instruction_Method(inv, im), "
+      "SpecialMethodInvocation_Base(inv, base), "
+      "VarPointsTo(h, base), "
+      "MethodInvocation_Method(inv, tm), ThisVar(tm, this).\n"
+      "Reachable(m) :- MainMethodDeclaration(m).\n";
+
+static int
+run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
+{
+    /* Build source: generate .decl + .input for each EDB, then rules */
+    char *source = (char *)malloc(DOOP_SRC_BUFSZ);
+    if (!source)
+        return -1;
+
+    size_t pos = 0;
+    for (int i = 0; i < DOOP_NRELS; i++) {
+        int n = snprintf(source + pos, DOOP_SRC_BUFSZ - pos,
+                         ".decl %s%s\n"
+                         ".input %s(filename=\"%s/%s\", delimiter=\",\")\n",
+                         doop_edbs[i].name, doop_edbs[i].cols,
+                         doop_edbs[i].name, data_dir, doop_edbs[i].csv);
+        if (n < 0 || pos + (size_t)n >= DOOP_SRC_BUFSZ) {
+            fprintf(stderr, "error: DOOP EDB source buffer overflow\n");
+            free(source);
+            return -1;
+        }
+        pos += (size_t)n;
+    }
+
+    /* Append IDB declarations + rules */
+    int n = snprintf(source + pos, DOOP_SRC_BUFSZ - pos, "%s", doop_rules);
+    if (n < 0 || pos + (size_t)n >= DOOP_SRC_BUFSZ) {
+        fprintf(stderr, "error: DOOP rules source buffer overflow\n");
+        free(source);
+        return -1;
+    }
+
+    /* Count total input facts across all 34 CSV files */
+    int32_t total_facts = 0;
+    {
+        char path[1024];
+        char line[256];
+        for (int i = 0; i < DOOP_NRELS; i++) {
+            snprintf(path, sizeof(path), "%s/%s", data_dir, doop_edbs[i].csv);
+            FILE *f = fopen(path, "r");
+            if (f) {
+                while (fgets(line, sizeof(line), f))
+                    total_facts++;
+                fclose(f);
+            }
+        }
+    }
+
+    /* Collect timing samples */
+    double *times = (double *)malloc(sizeof(double) * (size_t)repeat);
+    if (!times) {
+        free(source);
+        return -1;
+    }
+
+    int64_t tuples = 0;
+    int64_t peak_rss = -1;
+    int status_ok = 1;
+
+    for (int r = 0; r < repeat; r++) {
+        bench_time_t t0 = bench_time_now();
+        int64_t cnt = 0;
+        int rc = run_pipeline_count(source, workers, &cnt);
+        bench_time_t t1 = bench_time_now();
+
+        times[r] = bench_time_diff_ms(t0, t1);
+
+        if (rc != 0) {
+            status_ok = 0;
+            break;
+        }
+        tuples = cnt;
+    }
+
+    peak_rss = bench_peak_rss_kb();
+
+    if (status_ok) {
+        qsort(times, (size_t)repeat, sizeof(double), bench_cmp_double);
+        double min_ms = times[0];
+        double median_ms = times[repeat / 2];
+        double max_ms = times[repeat - 1];
+
+        printf("doop\t-\t%d\t%u\t%d\t%.1f\t%.1f\t%.1f\t%" PRId64 "\t%" PRId64
+               "\t%s\n",
+               total_facts, workers, repeat, min_ms, median_ms, max_ms,
+               peak_rss, tuples, "OK");
+    } else {
+        printf("doop\t-\t-\t%u\t%d\t-\t-\t-\t-\t-\tFAIL\n", workers, repeat);
+    }
+
+    free(times);
+    free(source);
+    return status_ok ? 0 : -1;
+}
+
+/* ----------------------------------------------------------------
  * Main
  * ---------------------------------------------------------------- */
 
@@ -1598,7 +2166,7 @@ usage(const char *prog)
         stderr,
         "Usage: %s --workload "
         "{tc|reach|cc|sssp|sg|bipartite|andersen|dyck|cspa|csda|galen|"
-        "polonius|ddisasm|crdt|all} --data FILE\n"
+        "polonius|ddisasm|crdt|doop|all} --data FILE\n"
         "          [--data-weighted FILE] [--data-andersen DIR]\n"
         "          [--data-dyck DIR] [--data-cspa DIR]\n"
         "          [--data-csda DIR] [--data-galen DIR]\n"
@@ -1617,7 +2185,8 @@ usage(const char *prog)
         "  --data-polonius DIR   Directory with Polonius borrow checker "
         "CSVs\n"
         "  --data-ddisasm DIR    Directory with DDISASM disassembly CSVs\n"
-        "  --data-crdt DIR       Directory with CRDT Insert/Remove CSVs\n",
+        "  --data-crdt DIR       Directory with CRDT Insert/Remove CSVs\n"
+        "  --data-doop DIR       Directory with DOOP zxing CSVs\n",
         prog);
 }
 
@@ -1635,6 +2204,7 @@ main(int argc, char **argv)
     const char *data_polonius_path = NULL;
     const char *data_ddisasm_path = NULL;
     const char *data_crdt_path = NULL;
+    const char *data_doop_path = NULL;
     uint32_t workers = 1;
     int repeat = 3;
 
@@ -1650,6 +2220,7 @@ main(int argc, char **argv)
         { "data-polonius", required_argument, NULL, 'P' },
         { "data-ddisasm", required_argument, NULL, 'I' },
         { "data-crdt", required_argument, NULL, 'R' },
+        { "data-doop", required_argument, NULL, 'O' },
         { "workers", required_argument, NULL, 'j' },
         { "repeat", required_argument, NULL, 'r' },
         { "help", no_argument, NULL, 'h' },
@@ -1657,7 +2228,7 @@ main(int argc, char **argv)
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "w:d:W:A:D:C:S:G:P:I:R:j:r:h",
+    while ((opt = getopt_long(argc, argv, "w:d:W:A:D:C:S:G:P:I:R:O:j:r:h",
                               long_opts, NULL))
            != -1) {
         switch (opt) {
@@ -1694,6 +2265,9 @@ main(int argc, char **argv)
         case 'R':
             data_crdt_path = optarg;
             break;
+        case 'O':
+            data_doop_path = optarg;
+            break;
         case 'j':
             workers = (uint32_t)strtoul(optarg, NULL, 10);
             break;
@@ -1707,7 +2281,11 @@ main(int argc, char **argv)
         }
     }
 
-    if (!workload || !data_path) {
+    if (!workload
+        || (!data_path && !data_andersen_path && !data_dyck_path
+            && !data_cspa_path && !data_csda_path && !data_galen_path
+            && !data_polonius_path && !data_ddisasm_path && !data_crdt_path
+            && !data_doop_path)) {
         usage(argv[0]);
         return 1;
     }
@@ -1783,6 +2361,12 @@ main(int argc, char **argv)
             return 1;
         }
         rc = run_crdt_workload(data_crdt_path, workers, repeat);
+    } else if (strcmp(workload, "doop") == 0) {
+        if (!data_doop_path) {
+            fprintf(stderr, "error: doop requires --data-doop DIR\n");
+            return 1;
+        }
+        rc = run_doop_workload(data_doop_path, workers, repeat);
     } else if (strcmp(workload, "all") == 0) {
         for (int i = 0; i < WL_COUNT; i++) {
             if (i == WL_SSSP && !data_weighted_path) {
@@ -1831,6 +2415,11 @@ main(int argc, char **argv)
         }
         if (data_crdt_path) {
             int r = run_crdt_workload(data_crdt_path, workers, repeat);
+            if (r != 0)
+                rc = r;
+        }
+        if (data_doop_path) {
+            int r = run_doop_workload(data_doop_path, workers, repeat);
             if (r != 0)
                 rc = r;
         }

--- a/bench/data/doop/download.sh
+++ b/bench/data/doop/download.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Download DOOP (zxing) benchmark dataset
+# Source: FlowLog artifact (VLDB 2026)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+URL="https://pages.cs.wisc.edu/~m0riarty/dataset/csv/zxing.zip"
+TMPZIP="/tmp/zxing_doop_$$.zip"
+TMPDIR="/tmp/zxing_doop_$$"
+
+echo "Downloading zxing dataset (~112 MB)..."
+curl -L "$URL" -o "$TMPZIP"
+
+echo "Extracting required CSV files..."
+mkdir -p "$TMPDIR"
+unzip -o "$TMPZIP" -d "$TMPDIR" > /dev/null
+
+REQUIRED="DirectSuperclass DirectSuperinterface MainClass FormalParam
+ComponentType AssignReturnValue ActualParam Method_Modifier Var_Type
+HeapAllocation_Type ClassType ArrayType InterfaceType Var_DeclaringMethod
+ApplicationClass ThisVar NormalHeap StringConstant AssignHeapAllocation
+AssignLocal AssignCast Field StaticMethodInvocation SpecialMethodInvocation
+VirtualMethodInvocation Method Method_Descriptor StoreInstanceField
+LoadInstanceField StoreStaticField LoadStaticField StoreArrayIndex
+LoadArrayIndex Return"
+
+for f in $REQUIRED; do
+    cp "$TMPDIR/zxing/${f}.csv" "$SCRIPT_DIR/"
+done
+
+rm -rf "$TMPDIR" "$TMPZIP"
+echo "Done. 34 CSV files copied to $SCRIPT_DIR/"

--- a/bench/workloads/doop.dl
+++ b/bench/workloads/doop.dl
@@ -1,0 +1,424 @@
+/* DOOP - Java Points-to Analysis (zxing dataset)
+ *
+ * Simplified context-insensitive points-to analysis for Java programs,
+ * based on GrammaTech's DOOP framework. Models Andersen-style inclusion-based
+ * pointer analysis with on-the-fly call graph construction.
+ *
+ * ~130 rules across 5 phases:
+ *   Phase 1: EDB staging & decomposition  (~50 rules)
+ *            Wide CSV inputs decomposed into narrow IDB relations
+ *   Phase 2: Type hierarchy (Basic)       (~24 rules)
+ *            SubtypeOf, MethodLookup (recursive), Subclass
+ *   Phase 3: Class initialization          (~9 rules)
+ *            Static initializer reachability
+ *   Phase 4: Value-based analysis          (~22 rules)
+ *            VarPointsTo, InstanceFieldPointsTo, CallGraphEdge (recursive)
+ *   Phase 5: Fat schema population         (~11 rules)
+ *            Re-join narrow relations for analysis queries
+ *
+ * EDB: 34 CSV files (comma-delimited, pre-hashed integer IDs)
+ *      Total: ~3.5M input tuples (zxing dataset, 83MB)
+ *
+ * Features exercised:
+ *   - 8-way recursive joins (VarPointsTo via virtual dispatch)
+ *   - Stratified negation (MethodLookup, MethodImplemented)
+ *   - Mutual recursion (VarPointsTo <-> CallGraphEdge <-> Reachable)
+ *   - != and = comparisons with dataset-specific constants
+ *
+ * Dataset-specific constants (zxing):
+ *   613907  = java.lang.Object
+ *   935673  = java.io.Serializable
+ *   619327  = java.lang.Cloneable
+ *   1928492 = abstract modifier
+ *   760051  = public modifier
+ *   841804  = static modifier
+ *   2648290 = "main" method name
+ *   2671384 = "([Ljava/lang/String;)V" descriptor
+ *   777634  = "<clinit>" method name
+ *   2670449 = "()V" descriptor
+ *
+ * Reference: FlowLog (VLDB 2026), Section 10: Program Analysis
+ *            Yannis Smaragdakis & Martin Bravenboer, "Using Datalog for
+ *            Fast and Easy Program Analysis" (CGO 2010)
+ */
+
+/* ==== EDB: Direct inputs (10 relations) ==== */
+.decl DirectSuperclass(class: int32, superclass: int32)
+.input DirectSuperclass(filename="DirectSuperclass.csv", delimiter=",")
+.decl DirectSuperinterface(ref: int32, interface: int32)
+.input DirectSuperinterface(filename="DirectSuperinterface.csv", delimiter=",")
+.decl MainClass(class: int32)
+.input MainClass(filename="MainClass.csv", delimiter=",")
+.decl FormalParam(index: int32, method: int32, var: int32)
+.input FormalParam(filename="FormalParam.csv", delimiter=",")
+.decl ComponentType(arrayType: int32, componentType: int32)
+.input ComponentType(filename="ComponentType.csv", delimiter=",")
+.decl AssignReturnValue(invocation: int32, to: int32)
+.input AssignReturnValue(filename="AssignReturnValue.csv", delimiter=",")
+.decl ActualParam(index: int32, invocation: int32, var: int32)
+.input ActualParam(filename="ActualParam.csv", delimiter=",")
+.decl Method_Modifier(mod: int32, method: int32)
+.input Method_Modifier(filename="Method_Modifier.csv", delimiter=",")
+.decl Var_Type(var: int32, type: int32)
+.input Var_Type(filename="Var_Type.csv", delimiter=",")
+.decl HeapAllocation_Type(heap: int32, type: int32)
+.input HeapAllocation_Type(filename="HeapAllocation_Type.csv", delimiter=",")
+
+/* ==== EDB: Staging inputs with _ prefix (12 relations) ==== */
+.decl _ClassType(class: int32)
+.input _ClassType(filename="ClassType.csv", delimiter=",")
+.decl _ArrayType(arrayType: int32)
+.input _ArrayType(filename="ArrayType.csv", delimiter=",")
+.decl _InterfaceType(interface: int32)
+.input _InterfaceType(filename="InterfaceType.csv", delimiter=",")
+.decl _Var_DeclaringMethod(var: int32, method: int32)
+.input _Var_DeclaringMethod(filename="Var_DeclaringMethod.csv", delimiter=",")
+.decl _ApplicationClass(type: int32)
+.input _ApplicationClass(filename="ApplicationClass.csv", delimiter=",")
+.decl _ThisVar(method: int32, var: int32)
+.input _ThisVar(filename="ThisVar.csv", delimiter=",")
+.decl _NormalHeap(id: int32, type: int32)
+.input _NormalHeap(filename="NormalHeap.csv", delimiter=",")
+.decl _StringConstant(id: int32)
+.input _StringConstant(filename="StringConstant.csv", delimiter=",")
+.decl _AssignHeapAllocation(instruction: int32, idx: int32, heap: int32, to: int32, inmethod: int32, linenumber: int32)
+.input _AssignHeapAllocation(filename="AssignHeapAllocation.csv", delimiter=",")
+.decl _AssignLocal(instruction: int32, idx: int32, from: int32, to: int32, inmethod: int32)
+.input _AssignLocal(filename="AssignLocal.csv", delimiter=",")
+.decl _AssignCast(instruction: int32, idx: int32, from: int32, to: int32, type: int32, inmethod: int32)
+.input _AssignCast(filename="AssignCast.csv", delimiter=",")
+.decl _Field(signature: int32, declaringClass: int32, simplename: int32, type: int32)
+.input _Field(filename="Field.csv", delimiter=",")
+
+/* ==== EDB: More staging inputs (12 relations) ==== */
+.decl _StaticMethodInvocation(instruction: int32, idx: int32, signature: int32, method: int32)
+.input _StaticMethodInvocation(filename="StaticMethodInvocation.csv", delimiter=",")
+.decl _SpecialMethodInvocation(instruction: int32, idx: int32, signature: int32, base: int32, method: int32)
+.input _SpecialMethodInvocation(filename="SpecialMethodInvocation.csv", delimiter=",")
+.decl _VirtualMethodInvocation(instruction: int32, idx: int32, signature: int32, base: int32, method: int32)
+.input _VirtualMethodInvocation(filename="VirtualMethodInvocation.csv", delimiter=",")
+.decl _Method(method: int32, simplename: int32, params: int32, declaringType: int32, returnType: int32, jvmDescriptor: int32, arity: int32)
+.input _Method(filename="Method.csv", delimiter=",")
+.decl Method_Descriptor(method: int32, descriptor: int32)
+.input Method_Descriptor(filename="Method_Descriptor.csv", delimiter=",")
+.decl _StoreInstanceField(instruction: int32, idx: int32, from: int32, base: int32, signature: int32, method: int32)
+.input _StoreInstanceField(filename="StoreInstanceField.csv", delimiter=",")
+.decl _LoadInstanceField(instruction: int32, idx: int32, to: int32, base: int32, signature: int32, method: int32)
+.input _LoadInstanceField(filename="LoadInstanceField.csv", delimiter=",")
+.decl _StoreStaticField(instruction: int32, idx: int32, from: int32, signature: int32, method: int32)
+.input _StoreStaticField(filename="StoreStaticField.csv", delimiter=",")
+.decl _LoadStaticField(instruction: int32, idx: int32, to: int32, signature: int32, method: int32)
+.input _LoadStaticField(filename="LoadStaticField.csv", delimiter=",")
+.decl _StoreArrayIndex(instruction: int32, idx: int32, from: int32, base: int32, method: int32)
+.input _StoreArrayIndex(filename="StoreArrayIndex.csv", delimiter=",")
+.decl _LoadArrayIndex(instruction: int32, idx: int32, to: int32, base: int32, method: int32)
+.input _LoadArrayIndex(filename="LoadArrayIndex.csv", delimiter=",")
+.decl _Return(instruction: int32, idx: int32, var: int32, method: int32)
+.input _Return(filename="Return.csv", delimiter=",")
+
+/* ==== IDB: Narrow schema (decomposed from staging) ==== */
+.decl isType(t: int32)
+.decl isReferenceType(t: int32)
+.decl isArrayType(t: int32)
+.decl isClassType(t: int32)
+.decl isInterfaceType(t: int32)
+.decl ApplicationClass(ref: int32)
+.decl Field_DeclaringType(field: int32, declaringClass: int32)
+.decl Method_DeclaringType(method: int32, declaringType: int32)
+.decl Method_SimpleName(method: int32, simpleName: int32)
+.decl ThisVar(method: int32, var: int32)
+.decl Var_DeclaringMethod(var: int32, method: int32)
+.decl Instruction_Method(insn: int32, inMethod: int32)
+.decl isVirtualMethodInvocation_Insn(insn: int32)
+.decl isStaticMethodInvocation_Insn(insn: int32)
+.decl FieldInstruction_Signature(insn: int32, sign: int32)
+.decl LoadInstanceField_Base(insn: int32, var: int32)
+.decl LoadInstanceField_To(insn: int32, var: int32)
+.decl StoreInstanceField_From(insn: int32, var: int32)
+.decl StoreInstanceField_Base(insn: int32, var: int32)
+.decl LoadStaticField_To(insn: int32, var: int32)
+.decl StoreStaticField_From(insn: int32, var: int32)
+.decl LoadArrayIndex_Base(insn: int32, var: int32)
+.decl LoadArrayIndex_To(insn: int32, var: int32)
+.decl StoreArrayIndex_From(insn: int32, var: int32)
+.decl StoreArrayIndex_Base(insn: int32, var: int32)
+.decl AssignInstruction_To(insn: int32, to: int32)
+.decl AssignCast_From(insn: int32, from: int32)
+.decl AssignCast_Type(insn: int32, type: int32)
+.decl AssignLocal_From(insn: int32, from: int32)
+.decl AssignHeapAllocation_Heap(insn: int32, heap: int32)
+.decl ReturnNonvoid_Var(ret: int32, var: int32)
+.decl MethodInvocation_Method(invocation: int32, signature: int32)
+.decl VirtualMethodInvocation_Base(invocation: int32, base: int32)
+.decl VirtualMethodInvocation_SimpleName(invocation: int32, simplename: int32)
+.decl VirtualMethodInvocation_Descriptor(invocation: int32, descriptor: int32)
+.decl SpecialMethodInvocation_Base(invocation: int32, base: int32)
+.decl MethodInvocation_Base(invocation: int32, base: int32)
+
+/* ==== IDB: Fat schema (re-joined for analysis) ==== */
+.decl LoadInstanceField(base: int32, sig: int32, to: int32, inmethod: int32)
+.decl StoreInstanceField(from: int32, base: int32, signature: int32, inmethod: int32)
+.decl LoadStaticField(sig: int32, to: int32, inmethod: int32)
+.decl StoreStaticField(from: int32, signature: int32, inmethod: int32)
+.decl LoadArrayIndex(base: int32, to: int32, inmethod: int32)
+.decl StoreArrayIndex(from: int32, base: int32, inmethod: int32)
+.decl AssignCast(type: int32, from: int32, to: int32, inmethod: int32)
+.decl AssignLocal(from: int32, to: int32, inmethod: int32)
+.decl AssignHeapAllocation(heap: int32, to: int32, inmethod: int32)
+.decl ReturnVar(var: int32, method: int32)
+.decl StaticMethodInvocation(invocation: int32, signature: int32, inmethod: int32)
+
+/* ==== IDB: Type hierarchy ==== */
+.decl MethodLookup(simplename: int32, descriptor: int32, type: int32, method: int32)
+.decl MethodImplemented(simplename: int32, descriptor: int32, type: int32, method: int32)
+.decl DirectSubclass(a: int32, c: int32)
+.decl Subclass(c: int32, a: int32)
+.decl Superclass(c: int32, a: int32)
+.decl Superinterface(k: int32, c: int32)
+.decl SubtypeOf(subtype: int32, type: int32)
+.decl SupertypeOf(supertype: int32, type: int32)
+.decl SubtypeOfDifferent(subtype: int32, type: int32)
+.decl MainMethodDeclaration(method: int32)
+
+/* ==== IDB: Class initialization ==== */
+.decl ClassInitializer(type: int32, method: int32)
+.decl InitializedClass(classOrInterface: int32)
+
+/* ==== IDB: Main analysis ==== */
+.decl Assign(to: int32, from: int32)
+.decl VarPointsTo(heap: int32, var: int32)
+.decl InstanceFieldPointsTo(heap: int32, fld: int32, baseheap: int32)
+.decl StaticFieldPointsTo(heap: int32, fld: int32)
+.decl CallGraphEdge(invocation: int32, meth: int32)
+.decl ArrayIndexPointsTo(baseheap: int32, heap: int32)
+.decl Reachable(method: int32)
+
+/* ================================================================
+ * Phase 1: EDB staging & decomposition
+ * ================================================================ */
+
+/* Type classification from staging */
+isType(class) :- _ClassType(class).
+isReferenceType(class) :- _ClassType(class).
+isClassType(class) :- _ClassType(class).
+isType(arrayType) :- _ArrayType(arrayType).
+isReferenceType(arrayType) :- _ArrayType(arrayType).
+isArrayType(arrayType) :- _ArrayType(arrayType).
+isType(interface) :- _InterfaceType(interface).
+isReferenceType(interface) :- _InterfaceType(interface).
+isInterfaceType(interface) :- _InterfaceType(interface).
+
+/* Direct copies from staging */
+Var_DeclaringMethod(var, method) :- _Var_DeclaringMethod(var, method).
+isType(type) :- _ApplicationClass(type).
+isReferenceType(type) :- _ApplicationClass(type).
+ApplicationClass(type) :- _ApplicationClass(type).
+ThisVar(method, var) :- _ThisVar(method, var).
+isType(type) :- _NormalHeap(_, type).
+
+/* Decompose _AssignHeapAllocation (6 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _AssignHeapAllocation(instruction, _, _, _, method, _).
+AssignInstruction_To(instruction, to) :- _AssignHeapAllocation(instruction, _, _, to, _, _).
+AssignHeapAllocation_Heap(instruction, heap) :- _AssignHeapAllocation(instruction, _, heap, _, _, _).
+
+/* Decompose _AssignLocal (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _AssignLocal(instruction, _, _, _, method).
+AssignLocal_From(instruction, from) :- _AssignLocal(instruction, _, from, _, _).
+AssignInstruction_To(instruction, to) :- _AssignLocal(instruction, _, _, to, _).
+
+/* Decompose _AssignCast (6 cols -> 4 narrow relations) */
+Instruction_Method(instruction, method) :- _AssignCast(instruction, _, _, _, _, method).
+AssignCast_Type(instruction, type) :- _AssignCast(instruction, _, _, _, type, _).
+AssignCast_From(instruction, from) :- _AssignCast(instruction, _, from, _, _, _).
+AssignInstruction_To(instruction, to) :- _AssignCast(instruction, _, _, to, _, _).
+
+/* Decompose _Field */
+Field_DeclaringType(signature, declaringType) :- _Field(signature, declaringType, _, _).
+
+/* MethodInvocation_Base from virtual + special */
+MethodInvocation_Base(invocation, base) :- VirtualMethodInvocation_Base(invocation, base).
+MethodInvocation_Base(invocation, base) :- SpecialMethodInvocation_Base(invocation, base).
+
+/* Decompose _StaticMethodInvocation (4 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _StaticMethodInvocation(instruction, _, _, method).
+isStaticMethodInvocation_Insn(instruction) :- _StaticMethodInvocation(instruction, _, _, _).
+MethodInvocation_Method(instruction, signature) :- _StaticMethodInvocation(instruction, _, signature, _).
+
+/* Decompose _SpecialMethodInvocation (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _SpecialMethodInvocation(instruction, _, _, _, method).
+SpecialMethodInvocation_Base(instruction, base) :- _SpecialMethodInvocation(instruction, _, _, base, _).
+MethodInvocation_Method(instruction, signature) :- _SpecialMethodInvocation(instruction, _, signature, _, _).
+
+/* Decompose _VirtualMethodInvocation (5 cols -> 4 narrow relations) */
+Instruction_Method(instruction, method) :- _VirtualMethodInvocation(instruction, _, _, _, method).
+isVirtualMethodInvocation_Insn(instruction) :- _VirtualMethodInvocation(instruction, _, _, _, _).
+VirtualMethodInvocation_Base(instruction, base) :- _VirtualMethodInvocation(instruction, _, _, base, _).
+MethodInvocation_Method(instruction, signature) :- _VirtualMethodInvocation(instruction, _, signature, _, _).
+
+/* Decompose _Method (7 cols -> 2 narrow relations) */
+Method_SimpleName(method, simplename) :- _Method(method, simplename, _, _, _, _, _).
+Method_DeclaringType(method, declaringType) :- _Method(method, _, _, declaringType, _, _, _).
+
+/* Decompose _StoreInstanceField (6 cols -> 4 narrow relations) */
+Instruction_Method(instruction, method) :- _StoreInstanceField(instruction, _, _, _, _, method).
+FieldInstruction_Signature(instruction, signature) :- _StoreInstanceField(instruction, _, _, _, signature, _).
+StoreInstanceField_Base(instruction, base) :- _StoreInstanceField(instruction, _, _, base, _, _).
+StoreInstanceField_From(instruction, from) :- _StoreInstanceField(instruction, _, from, _, _, _).
+
+/* Decompose _LoadInstanceField (6 cols -> 4 narrow relations) */
+Instruction_Method(instruction, method) :- _LoadInstanceField(instruction, _, _, _, _, method).
+FieldInstruction_Signature(instruction, signature) :- _LoadInstanceField(instruction, _, _, _, signature, _).
+LoadInstanceField_Base(instruction, base) :- _LoadInstanceField(instruction, _, _, base, _, _).
+LoadInstanceField_To(instruction, to) :- _LoadInstanceField(instruction, _, to, _, _, _).
+
+/* Decompose _StoreStaticField (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _StoreStaticField(instruction, _, _, _, method).
+FieldInstruction_Signature(instruction, signature) :- _StoreStaticField(instruction, _, _, signature, _).
+StoreStaticField_From(instruction, from) :- _StoreStaticField(instruction, _, from, _, _).
+
+/* Decompose _LoadStaticField (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _LoadStaticField(instruction, _, _, _, method).
+FieldInstruction_Signature(instruction, signature) :- _LoadStaticField(instruction, _, _, signature, _).
+LoadStaticField_To(instruction, to) :- _LoadStaticField(instruction, _, to, _, _).
+
+/* Decompose _StoreArrayIndex (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _StoreArrayIndex(instruction, _, _, _, method).
+StoreArrayIndex_Base(instruction, base) :- _StoreArrayIndex(instruction, _, _, base, _).
+StoreArrayIndex_From(instruction, from) :- _StoreArrayIndex(instruction, _, from, _, _).
+
+/* Decompose _LoadArrayIndex (5 cols -> 3 narrow relations) */
+Instruction_Method(instruction, method) :- _LoadArrayIndex(instruction, _, _, _, method).
+LoadArrayIndex_Base(instruction, base) :- _LoadArrayIndex(instruction, _, _, base, _).
+LoadArrayIndex_To(instruction, to) :- _LoadArrayIndex(instruction, _, to, _, _).
+
+/* Decompose _Return (4 cols -> 2 narrow relations) */
+Instruction_Method(instruction, method) :- _Return(instruction, _, _, method).
+ReturnNonvoid_Var(instruction, var) :- _Return(instruction, _, var, _).
+
+/* Fat schema population (re-join narrow relations) */
+LoadInstanceField(base, sig, to, inmethod) :- Instruction_Method(insn, inmethod), LoadInstanceField_Base(insn, base), FieldInstruction_Signature(insn, sig), LoadInstanceField_To(insn, to).
+StoreInstanceField(from, base, sig, inmethod) :- Instruction_Method(insn, inmethod), StoreInstanceField_From(insn, from), StoreInstanceField_Base(insn, base), FieldInstruction_Signature(insn, sig).
+LoadStaticField(sig, to, inmethod) :- Instruction_Method(insn, inmethod), FieldInstruction_Signature(insn, sig), LoadStaticField_To(insn, to).
+StoreStaticField(from, sig, inmethod) :- Instruction_Method(insn, inmethod), StoreStaticField_From(insn, from), FieldInstruction_Signature(insn, sig).
+LoadArrayIndex(base, to, inmethod) :- Instruction_Method(insn, inmethod), LoadArrayIndex_Base(insn, base), LoadArrayIndex_To(insn, to).
+StoreArrayIndex(from, base, inmethod) :- Instruction_Method(insn, inmethod), StoreArrayIndex_From(insn, from), StoreArrayIndex_Base(insn, base).
+AssignCast(type, from, to, inmethod) :- Instruction_Method(insn, inmethod), AssignCast_From(insn, from), AssignInstruction_To(insn, to), AssignCast_Type(insn, type).
+AssignLocal(from, to, inmethod) :- AssignInstruction_To(insn, to), Instruction_Method(insn, inmethod), AssignLocal_From(insn, from).
+AssignHeapAllocation(heap, to, inmethod) :- Instruction_Method(insn, inmethod), AssignHeapAllocation_Heap(insn, heap), AssignInstruction_To(insn, to).
+ReturnVar(var, method) :- Instruction_Method(insn, method), ReturnNonvoid_Var(insn, var).
+StaticMethodInvocation(invocation, signature, inmethod) :- isStaticMethodInvocation_Insn(invocation), Instruction_Method(invocation, inmethod), MethodInvocation_Method(invocation, signature).
+
+/* Virtual method invocation derived relations */
+VirtualMethodInvocation_SimpleName(invocation, simplename) :- isVirtualMethodInvocation_Insn(invocation), MethodInvocation_Method(invocation, signature), Method_SimpleName(signature, simplename), Method_Descriptor(signature, descriptor).
+VirtualMethodInvocation_Descriptor(invocation, descriptor) :- isVirtualMethodInvocation_Insn(invocation), MethodInvocation_Method(invocation, signature), Method_SimpleName(signature, simplename), Method_Descriptor(signature, descriptor).
+
+/* ================================================================
+ * Phase 2: Type hierarchy (Basic analysis)
+ * ================================================================ */
+
+/* Method lookup with negation (recursive) */
+MethodLookup(simplename, descriptor, type, method) :- MethodImplemented(simplename, descriptor, type, method).
+MethodLookup(simplename, descriptor, type, method) :- DirectSuperclass(type, supertype), MethodLookup(simplename, descriptor, supertype, method), !MethodImplemented(simplename, descriptor, type, _).
+MethodLookup(simplename, descriptor, type, method) :- DirectSuperinterface(type, supertype), MethodLookup(simplename, descriptor, supertype, method), !MethodImplemented(simplename, descriptor, type, _).
+
+/* Method implementation (negation: exclude abstract) */
+MethodImplemented(simplename, descriptor, type, method) :- Method_SimpleName(method, simplename), Method_Descriptor(method, descriptor), Method_DeclaringType(method, type), !Method_Modifier(1928492, method).
+
+/* Main method declaration (zxing-specific constants) */
+MainMethodDeclaration(method) :- MainClass(type), Method_DeclaringType(method, type), method != 536048, method != 1057660, method != 796639, Method_SimpleName(method, 2648290), Method_Descriptor(method, 2671384), Method_Modifier(760051, method), Method_Modifier(841804, method).
+
+/* Subclass hierarchy (recursive) */
+DirectSubclass(a, c) :- DirectSuperclass(a, c).
+Subclass(c, a) :- DirectSubclass(a, c).
+Subclass(c, a) :- Subclass(b, a), DirectSubclass(b, c).
+Superclass(c, a) :- Subclass(a, c).
+
+/* Superinterface hierarchy (recursive) */
+Superinterface(k, c) :- DirectSuperinterface(c, k).
+Superinterface(k, c) :- DirectSuperinterface(c, j), Superinterface(k, j).
+Superinterface(k, c) :- DirectSuperclass(c, super), Superinterface(k, super).
+
+/* SubtypeOf (recursive with constants) */
+SubtypeOf(s, s) :- isClassType(s).
+SubtypeOf(t, t) :- isType(t).
+SubtypeOf(s, t) :- Subclass(t, s).
+SubtypeOf(s, s) :- isInterfaceType(s).
+SubtypeOf(s, t) :- isClassType(s), Superinterface(t, s).
+SubtypeOf(s, t) :- isInterfaceType(s), isType(t), t = 613907.
+SubtypeOf(s, t) :- isArrayType(s), isType(t), t = 613907.
+SubtypeOf(s, t) :- isInterfaceType(s), Superinterface(t, s).
+SubtypeOf(s, t) :- SubtypeOf(sc, tc), ComponentType(s, sc), ComponentType(t, tc), isReferenceType(sc), isReferenceType(tc).
+SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), isType(t), t = 935673.
+SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), isType(t), t = 619327.
+
+SupertypeOf(s, t) :- SubtypeOf(t, s).
+SubtypeOfDifferent(s, t) :- SubtypeOf(s, t), s != t.
+
+/* ================================================================
+ * Phase 3: Class initialization
+ * ================================================================ */
+
+ClassInitializer(type, method) :- MethodImplemented(777634, 2670449, type, method).
+InitializedClass(superclass) :- InitializedClass(class), DirectSuperclass(class, superclass).
+InitializedClass(superinterface) :- InitializedClass(classOrInterface), DirectSuperinterface(classOrInterface, superinterface).
+InitializedClass(class) :- MainMethodDeclaration(method), Method_DeclaringType(method, class).
+InitializedClass(class) :- Reachable(inmethod), AssignHeapAllocation(heap, _, inmethod), HeapAllocation_Type(heap, class).
+InitializedClass(class) :- Reachable(inmethod), Instruction_Method(invocation, inmethod), isStaticMethodInvocation_Insn(invocation), MethodInvocation_Method(invocation, signature), Method_DeclaringType(signature, class).
+InitializedClass(classOrInterface) :- Reachable(inmethod), StoreStaticField(_, signature, inmethod), Field_DeclaringType(signature, classOrInterface).
+InitializedClass(classOrInterface) :- Reachable(inmethod), LoadStaticField(signature, _, inmethod), Field_DeclaringType(signature, classOrInterface).
+Reachable(clinit) :- InitializedClass(class), ClassInitializer(class, clinit).
+
+/* ================================================================
+ * Phase 4: Value-based analysis (main points-to computation)
+ * ================================================================ */
+
+/* Parameter passing via call graph */
+Assign(actual, formal) :- CallGraphEdge(invocation, method), FormalParam(index, method, formal), ActualParam(index, invocation, actual).
+Assign(ret, local) :- CallGraphEdge(invocation, method), ReturnVar(ret, method), AssignReturnValue(invocation, local).
+
+/* VarPointsTo: heap allocation */
+VarPointsTo(heap, var) :- AssignHeapAllocation(heap, var, inMethod), Reachable(inMethod).
+
+/* VarPointsTo: assignment propagation */
+VarPointsTo(heap, to) :- Assign(from, to), VarPointsTo(heap, from).
+VarPointsTo(heap, to) :- Reachable(inmethod), AssignLocal(from, to, inmethod), VarPointsTo(heap, from).
+
+/* VarPointsTo: cast with type check */
+VarPointsTo(heap, to) :- Reachable(inmethod), AssignCast(type, from, to, inmethod), SupertypeOf(type, heaptype), HeapAllocation_Type(heap, heaptype), VarPointsTo(heap, from).
+
+/* ArrayIndexPointsTo: store into array (8-way join) */
+ArrayIndexPointsTo(baseheap, heap) :- Reachable(inmethod), StoreArrayIndex(from, base, inmethod), VarPointsTo(baseheap, base), VarPointsTo(heap, from), HeapAllocation_Type(heap, heaptype), HeapAllocation_Type(baseheap, baseheaptype), ComponentType(baseheaptype, componenttype), SupertypeOf(componenttype, heaptype).
+
+/* VarPointsTo: load from array (8-way join) */
+VarPointsTo(heap, to) :- Reachable(inmethod), LoadArrayIndex(base, to, inmethod), VarPointsTo(baseheap, base), ArrayIndexPointsTo(baseheap, heap), Var_Type(to, type), HeapAllocation_Type(baseheap, baseheaptype), ComponentType(baseheaptype, basecomponenttype), SupertypeOf(type, basecomponenttype).
+
+/* VarPointsTo: instance field load */
+VarPointsTo(heap, to) :- Reachable(inmethod), LoadInstanceField(base, signature, to, inmethod), VarPointsTo(baseheap, base), InstanceFieldPointsTo(heap, signature, baseheap).
+
+/* VarPointsTo: static field load */
+VarPointsTo(heap, to) :- Reachable(inmethod), LoadStaticField(fld, to, inmethod), StaticFieldPointsTo(heap, fld).
+
+/* VarPointsTo: virtual dispatch (9-way join) */
+VarPointsTo(heap, this) :- Reachable(inMethod), Instruction_Method(invocation, inMethod), VirtualMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), HeapAllocation_Type(heap, heaptype), VirtualMethodInvocation_SimpleName(invocation, simplename), VirtualMethodInvocation_Descriptor(invocation, descriptor), MethodLookup(simplename, descriptor, heaptype, toMethod), ThisVar(toMethod, this).
+
+/* InstanceFieldPointsTo: store */
+InstanceFieldPointsTo(heap, fld, baseheap) :- Reachable(inmethod), StoreInstanceField(from, base, fld, inmethod), VarPointsTo(heap, from), VarPointsTo(baseheap, base).
+
+/* StaticFieldPointsTo: store */
+StaticFieldPointsTo(heap, fld) :- Reachable(inmethod), StoreStaticField(from, fld, inmethod), VarPointsTo(heap, from).
+
+/* Reachable + CallGraphEdge: virtual dispatch (8-way join) */
+Reachable(toMethod) :- Reachable(inMethod), Instruction_Method(invocation, inMethod), VirtualMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), HeapAllocation_Type(heap, heaptype), VirtualMethodInvocation_SimpleName(invocation, simplename), VirtualMethodInvocation_Descriptor(invocation, descriptor), MethodLookup(simplename, descriptor, heaptype, toMethod).
+CallGraphEdge(invocation, toMethod) :- Reachable(inMethod), Instruction_Method(invocation, inMethod), VirtualMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), HeapAllocation_Type(heap, heaptype), VirtualMethodInvocation_SimpleName(invocation, simplename), VirtualMethodInvocation_Descriptor(invocation, descriptor), MethodLookup(simplename, descriptor, heaptype, toMethod).
+
+/* Reachable + CallGraphEdge: static method invocation */
+Reachable(tomethod) :- Reachable(inmethod), StaticMethodInvocation(invocation, tomethod, inmethod).
+CallGraphEdge(invocation, tomethod) :- Reachable(inmethod), StaticMethodInvocation(invocation, tomethod, inmethod).
+
+/* Reachable + CallGraphEdge + VarPointsTo: special method invocation */
+Reachable(tomethod) :- Reachable(inmethod), Instruction_Method(invocation, inmethod), SpecialMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), MethodInvocation_Method(invocation, tomethod), ThisVar(tomethod, this).
+CallGraphEdge(invocation, tomethod) :- Reachable(inmethod), Instruction_Method(invocation, inmethod), SpecialMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), MethodInvocation_Method(invocation, tomethod), ThisVar(tomethod, this).
+VarPointsTo(heap, this) :- Reachable(inmethod), Instruction_Method(invocation, inmethod), SpecialMethodInvocation_Base(invocation, base), VarPointsTo(heap, base), MethodInvocation_Method(invocation, tomethod), ThisVar(tomethod, this).
+
+/* Entry point */
+Reachable(method) :- MainMethodDeclaration(method).

--- a/rust/wirelog-dd/src/dataflow.rs
+++ b/rust/wirelog-dd/src/dataflow.rs
@@ -563,12 +563,25 @@ where
                 right_relation,
                 left_keys,
                 right_keys: _,
+                right_key_indices,
+                right_filter,
             } => {
                 if let Some(c) = current.take() {
                     let key_count = left_keys.len();
                     let right_coll = collections.get(right_relation).cloned();
 
                     if let Some(right) = right_coll {
+                        // Apply right-side filter if present (e.g., constants
+                        // in the negated atom like !b(42, x))
+                        let right = if let Some(ref filter) = right_filter {
+                            let filter = filter.clone();
+                            right.filter(move |row: &Row| {
+                                eval_filter_row(row, &filter).unwrap_or(false)
+                            })
+                        } else {
+                            right
+                        };
+
                         // Left: key = last key_count columns, value = full row
                         let k = key_count;
                         let left_keyed = c.map(move |row: Row| {
@@ -576,8 +589,14 @@ where
                             (key, row)
                         });
 
-                        // Right: extract just the keys
-                        let right_keys_coll = right.map(move |row: Row| row[..key_count].to_vec());
+                        // Right: extract keys by index (or first k columns)
+                        let rki = right_key_indices.clone();
+                        let right_keys_coll = if !rki.is_empty() {
+                            right
+                                .map(move |row: Row| rki.iter().map(|&i| row[i as usize]).collect())
+                        } else {
+                            right.map(move |row: Row| row[..key_count].to_vec())
+                        };
 
                         current =
                             Some(left_keyed.antijoin(&right_keys_coll).map(|(_key, row)| row));
@@ -895,6 +914,8 @@ mod tests {
                             right_relation: "b".to_string(),
                             left_keys: vec!["Y".to_string()],
                             right_keys: vec!["Y".to_string()],
+                            right_key_indices: Vec::new(),
+                            right_filter: None,
                         },
                     ],
                 }],
@@ -908,6 +929,51 @@ mod tests {
 
         let result = execute_plan(&plan, &edb, 1).unwrap();
         let r = result.tuples.get("result").unwrap();
+        assert_eq!(r.len(), 2);
+        assert!(r.contains(&vec![3, 4]));
+        assert!(r.contains(&vec![5, 6]));
+    }
+
+    #[test]
+    fn test_antijoin_with_right_filter() {
+        // r(X,Y) :- a(X,Y), !b(42, Y).
+        // b has rows (42,2) and (99,4). Only (42,2) passes filter col0=42.
+        // So antijoin removes rows with Y=2, keeping (3,4) and (5,6).
+        let plan = SafePlan {
+            strata: vec![SafeStratumPlan {
+                stratum_id: 0,
+                is_recursive: false,
+                relations: vec![SafeRelationPlan {
+                    name: "result".to_string(),
+                    ops: vec![
+                        SafeOp::Variable {
+                            relation_name: "a".to_string(),
+                        },
+                        SafeOp::Antijoin {
+                            right_relation: "b".to_string(),
+                            left_keys: vec!["Y".to_string()],
+                            right_keys: vec!["Y".to_string()],
+                            right_key_indices: vec![1],
+                            right_filter: Some(vec![
+                                ExprOp::Var("col0".to_string()),
+                                ExprOp::ConstInt(42),
+                                ExprOp::CmpEq,
+                            ]),
+                        },
+                    ],
+                }],
+            }],
+            edb_relations: vec!["a".to_string(), "b".to_string()],
+        };
+
+        let mut edb = HashMap::new();
+        edb.insert("a".to_string(), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
+        edb.insert("b".to_string(), vec![vec![42, 2], vec![99, 4]]);
+
+        let result = execute_plan(&plan, &edb, 1).unwrap();
+        let r = result.tuples.get("result").unwrap();
+        // Without filter: b keys = {2, 4}, removes (1,2) and (3,4) -> only (5,6)
+        // With filter col0=42: filtered b = {(42,2)}, keys = {2}, removes (1,2) -> (3,4) and (5,6)
         assert_eq!(r.len(), 2);
         assert!(r.contains(&vec![3, 4]));
         assert!(r.contains(&vec![5, 6]));

--- a/rust/wirelog-dd/src/plan_reader.rs
+++ b/rust/wirelog-dd/src/plan_reader.rs
@@ -55,6 +55,8 @@ pub enum SafeOp {
         right_relation: String,
         left_keys: Vec<String>,
         right_keys: Vec<String>,
+        right_key_indices: Vec<u32>,
+        right_filter: Option<Vec<ExprOp>>,
     },
 
     /// Semijoin (SIP pre-filter).
@@ -271,10 +273,27 @@ unsafe fn read_op(op: &WlFfiOp) -> Result<SafeOp, PlanReadError> {
             let right = read_cstr(op.right_relation, "op.right_relation")?;
             let lk = read_cstr_array(op.left_keys, op.key_count, "op.left_keys")?;
             let rk = read_cstr_array(op.right_keys, op.key_count, "op.right_keys")?;
+            let rki = if op.project_count > 0 && !op.project_indices.is_null() {
+                std::slice::from_raw_parts(op.project_indices, op.project_count as usize).to_vec()
+            } else {
+                Vec::new()
+            };
+            let right_filter = if !op.filter_expr.data.is_null() && op.filter_expr.size > 0 {
+                let data =
+                    std::slice::from_raw_parts(op.filter_expr.data, op.filter_expr.size as usize);
+                Some(
+                    deserialize_expr(data)
+                        .map_err(|e| PlanReadError::ExprDeserializeError(e.to_string()))?,
+                )
+            } else {
+                None
+            };
             Ok(SafeOp::Antijoin {
                 right_relation: right,
                 left_keys: lk,
                 right_keys: rk,
+                right_key_indices: rki,
+                right_filter,
             })
         }
 
@@ -771,6 +790,8 @@ mod tests {
                     right_relation: "edge".to_string(),
                     left_keys: vec!["A".to_string()],
                     right_keys: vec!["B".to_string()],
+                    right_key_indices: Vec::new(),
+                    right_filter: None,
                 }
             );
         }

--- a/wirelog/ffi/dd_marshal.c
+++ b/wirelog/ffi/dd_marshal.c
@@ -394,6 +394,23 @@ marshal_op(const wl_dd_op_t *src, wl_ffi_op_t *dst)
             dst->left_keys = (const char *const *)lk;
             dst->right_keys = (const char *const *)rk;
         }
+        /* Copy right key column indices */
+        dst->project_count = src->project_count;
+        if (src->project_count > 0 && src->project_indices) {
+            uint32_t *idx
+                = (uint32_t *)malloc(src->project_count * sizeof(uint32_t));
+            if (!idx)
+                return -1;
+            memcpy(idx, src->project_indices,
+                   src->project_count * sizeof(uint32_t));
+            dst->project_indices = idx;
+        }
+        /* Serialize right-side filter if present */
+        if (src->filter_expr) {
+            int rc = wl_ffi_expr_serialize(src->filter_expr, &dst->filter_expr);
+            if (rc != 0)
+                return rc == -1 ? -1 : -3;
+        }
         break;
 
     case WL_DD_REDUCE:

--- a/wirelog/ffi/dd_plan.c
+++ b/wirelog/ffi/dd_plan.c
@@ -119,6 +119,62 @@ rewrite_expr_vars(wl_ir_expr_t *expr, const char *const *column_names,
 }
 
 /**
+ * Walk through FILTER wrapper nodes in a right-child chain
+ * to find the underlying SCAN node.  Returns the SCAN node, or NULL.
+ */
+static const wirelog_ir_node_t *
+find_scan_in_chain(const wirelog_ir_node_t *node)
+{
+    while (node && node->type != WIRELOG_IR_SCAN) {
+        if (node->child_count > 0)
+            node = node->children[0];
+        else
+            break;
+    }
+    return (node && node->type == WIRELOG_IR_SCAN) ? node : NULL;
+}
+
+/**
+ * Collect filter expressions from a chain of FILTER wrapper nodes.
+ * Returns a cloned expression tree combining all filters with
+ * arithmetic multiplication (boolean AND for i64 filter evaluation).
+ * Returns NULL if no filters are present.
+ */
+static wl_ir_expr_t *
+collect_chain_filters(const wirelog_ir_node_t *node)
+{
+    wl_ir_expr_t *combined = NULL;
+
+    while (node && node->type == WIRELOG_IR_FILTER) {
+        if (node->filter_expr) {
+            wl_ir_expr_t *clone = wl_ir_expr_clone(node->filter_expr);
+            if (clone) {
+                if (combined) {
+                    /* Combine with multiplication (boolean AND) */
+                    wl_ir_expr_t *mul = wl_ir_expr_create(WL_IR_EXPR_ARITH);
+                    if (mul) {
+                        mul->arith_op = WL_ARITH_MUL;
+                        wl_ir_expr_add_child(mul, combined);
+                        wl_ir_expr_add_child(mul, clone);
+                        combined = mul;
+                    } else {
+                        wl_ir_expr_free(clone);
+                    }
+                } else {
+                    combined = clone;
+                }
+            }
+        }
+        if (node->child_count > 0)
+            node = node->children[0];
+        else
+            break;
+    }
+
+    return combined;
+}
+
+/**
  * Translate an IR tree node into DD ops, appended to the relation plan.
  * Walks the tree in post-order (children first, then current node).
  *
@@ -252,10 +308,12 @@ translate_ir_node(const wirelog_ir_node_t *node, wl_dd_relation_plan_t *rp,
 
     case WIRELOG_IR_JOIN:
         op.op = WL_DD_JOIN;
-        /* Right relation name from second child */
-        if (node->child_count >= 2 && node->children[1]
-            && node->children[1]->relation_name) {
-            op.right_relation = strdup_safe(node->children[1]->relation_name);
+        /* Right relation name from second child (walk through FILTERs) */
+        if (node->child_count >= 2 && node->children[1]) {
+            const wirelog_ir_node_t *scan
+                = find_scan_in_chain(node->children[1]);
+            if (scan && scan->relation_name)
+                op.right_relation = strdup_safe(scan->relation_name);
         }
         /* Copy join keys */
         if (node->join_key_count > 0) {
@@ -295,21 +353,32 @@ translate_ir_node(const wirelog_ir_node_t *node, wl_dd_relation_plan_t *rp,
             }
         }
         /* Update column context: join output = left_cols + right non-key cols */
-        if (node->child_count >= 2 && node->children[1]
-            && node->children[1]->column_names) {
-            uint32_t rkey = node->join_key_count;
-            const wirelog_ir_node_t *rc = node->children[1];
-            for (uint32_t i = rkey;
-                 i < rc->column_count && ctx->count < IR_COL_CTX_MAX; i++)
-                ctx->names[ctx->count++] = rc->column_names[i];
+        if (node->child_count >= 2 && node->children[1]) {
+            const wirelog_ir_node_t *rc = find_scan_in_chain(node->children[1]);
+            if (rc && rc->column_names) {
+                uint32_t rkey = node->join_key_count;
+                for (uint32_t i = rkey;
+                     i < rc->column_count && ctx->count < IR_COL_CTX_MAX; i++)
+                    ctx->names[ctx->count++] = rc->column_names[i];
+            }
         }
         break;
 
     case WIRELOG_IR_ANTIJOIN:
         op.op = WL_DD_ANTIJOIN;
-        if (node->child_count >= 2 && node->children[1]
-            && node->children[1]->relation_name) {
-            op.right_relation = strdup_safe(node->children[1]->relation_name);
+        if (node->child_count >= 2 && node->children[1]) {
+            const wirelog_ir_node_t *right = node->children[1];
+            const wirelog_ir_node_t *scan = find_scan_in_chain(right);
+            if (scan && scan->relation_name)
+                op.right_relation = strdup_safe(scan->relation_name);
+            /* Capture right-side filter from FILTER wrappers */
+            if (right->type == WIRELOG_IR_FILTER) {
+                op.filter_expr = collect_chain_filters(right);
+                if (op.filter_expr && scan && scan->column_names)
+                    rewrite_expr_vars(op.filter_expr,
+                                      (const char *const *)scan->column_names,
+                                      scan->column_count);
+            }
         }
         if (node->join_key_count > 0) {
             op.key_count = node->join_key_count;
@@ -324,6 +393,31 @@ translate_ir_node(const wirelog_ir_node_t *node, wl_dd_relation_plan_t *rp,
                     op.left_keys[k] = strdup_safe(node->join_left_keys[k]);
                 if (node->join_right_keys[k])
                     op.right_keys[k] = strdup_safe(node->join_right_keys[k]);
+            }
+        }
+        /* Resolve right key column positions from the right SCAN */
+        if (node->child_count >= 2 && op.key_count > 0) {
+            const wirelog_ir_node_t *scan
+                = find_scan_in_chain(node->children[1]);
+            if (scan && scan->column_names) {
+                op.project_indices
+                    = (uint32_t *)calloc(op.key_count, sizeof(uint32_t));
+                if (op.project_indices) {
+                    op.project_count = op.key_count;
+                    for (uint32_t k = 0; k < op.key_count; k++) {
+                        if (op.right_keys && op.right_keys[k]) {
+                            for (uint32_t j = 0; j < scan->column_count; j++) {
+                                if (scan->column_names[j]
+                                    && strcmp(op.right_keys[k],
+                                              scan->column_names[j])
+                                           == 0) {
+                                    op.project_indices[k] = j;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         break;
@@ -498,9 +592,11 @@ translate_ir_node(const wirelog_ir_node_t *node, wl_dd_relation_plan_t *rp,
 
     case WIRELOG_IR_SEMIJOIN:
         op.op = WL_DD_SEMIJOIN;
-        if (node->child_count >= 2 && node->children[1]
-            && node->children[1]->relation_name) {
-            op.right_relation = strdup_safe(node->children[1]->relation_name);
+        if (node->child_count >= 2 && node->children[1]) {
+            const wirelog_ir_node_t *scan
+                = find_scan_in_chain(node->children[1]);
+            if (scan && scan->relation_name)
+                op.right_relation = strdup_safe(scan->relation_name);
         }
         if (node->join_key_count > 0) {
             op.key_count = node->join_key_count;


### PR DESCRIPTION
## Summary

- Add DOOP (context-insensitive Java points-to analysis) benchmark workload with 136 rules and 34 EDB relations using the zxing dataset (4.2M input facts)
- Fix ANTIJOIN with constants bug: negated atoms with constants (e.g., `!Method_Modifier(1928492, m)`) caused `NullPointer("op.right_relation")` because FILTER-wrapped SCANs have no `relation_name`
- Add `find_scan_in_chain()` / `collect_chain_filters()` helpers to walk through FILTER wrappers for JOIN/ANTIJOIN/SEMIJOIN right children
- Compute right key column indices for ANTIJOIN so keys are extracted from correct column positions
- Rust executor applies `right_filter` to right collection before anti-joining

## Benchmark Results

| Workload | Rules | EDB Facts | IDB Tuples | Time (median) | RSS |
|----------|------:|----------:|-----------:|--------------|----:|
| DOOP (zxing) | 136 | 4,178,411 | 5,847,534 | 44.6s | 2.4 GB |

Dataset: zxing (Java barcode library), context-insensitive points-to analysis with on-the-fly call graph construction. Download script at `bench/data/doop/download.sh`.

## Test plan

- [x] `meson test` — 14/14 C test suites pass
- [x] `cargo test` — 85/85 Rust tests pass (includes new `test_antijoin_with_right_filter`)
- [x] `clang-format-18` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] DOOP benchmark runs successfully with zxing dataset