### PR TITLE
docs: Document new CI workflow structure (Issues #116, #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,125 @@ For proprietary or commercial use cases that require different terms:
 
 See [LICENSE.md](LICENSE.md) for full details.
 
+## CI Workflow
+
+wirelog uses a two-track CI strategy: strict quality gates on pull requests, and comprehensive non-blocking monitoring on the main branch.
+
+### Pull Request Workflows (Blocking)
+
+Every PR targeting `main` runs through three sequential phases. A failure in an earlier phase stops later phases from running.
+
+```
+Phase 1: Lint  (lint-pr.yml)
+  editorconfig-check
+      |
+  clang-format-18 check  [blocks if formatting differs from .clang-format]
+      |
+  clang-tidy-18 check    [blocks if static analysis warnings or errors found]
+      |
+Phase 2: Build  (ci-pr.yml)
+  Linux / GCC ─┐
+  Linux / Clang ┼─ fail-fast: first failure cancels remaining matrix jobs
+  macOS / Clang ┘
+      |
+Phase 3: Sanitizers  (ci-pr.yml)
+  Linux / GCC  (ASan + UBSan) ─┐
+  Linux / Clang (ASan + UBSan) ┘  fail-fast
+```
+
+**Phase 1 — Lint** (`lint-pr.yml`, triggered by `ci-pr.yml`):
+- EditorConfig: whitespace, encoding, and line-ending consistency (seconds)
+- clang-format 18: formatting must exactly match `.clang-format` style
+- clang-tidy 18: static analysis; warnings and errors both block the PR (up to 30 min)
+
+**Phase 2 — Build and Test** (`ci-pr.yml`):
+- Platforms: Linux GCC, Linux Clang, macOS Clang
+- Runs `meson test` with `--print-errorlogs`; all tests must pass
+
+**Phase 3 — Sanitizers** (`ci-pr.yml`):
+- Linux GCC and Clang with `-Db_sanitize=address,undefined`
+- `ASAN_OPTIONS=abort_on_error=1:halt_on_error=1`
+- `UBSAN_OPTIONS=abort_on_error=1:halt_on_error=1:print_stacktrace=1`
+
+A PR cannot be merged unless all three phases pass.
+
+### Main Branch Workflows (Non-Blocking Monitoring)
+
+Pushes to `main` trigger broader coverage that runs to completion regardless of individual failures. Results appear in GitHub Actions step summaries as informational annotations.
+
+```
+All phases run in parallel, continue-on-error: true
+
+Lint monitor        (lint-main.yml)
+  editorconfig-check (monitor)
+  clang-format-18    (monitor)
+  clang-tidy-18      (monitor)
+
+Build monitor       (ci-main.yml)
+  Linux / GCC
+  Linux / Clang
+  macOS / Clang
+  Windows / MSVC      <-- additional platform vs PR workflow
+
+Sanitizers monitor  (ci-main.yml)
+  Linux / GCC   (ASan + UBSan)
+  Linux / Clang (ASan + UBSan)
+  macOS / Clang (ASan + UBSan)  <-- additional platform vs PR workflow
+```
+
+The main branch monitor adds Windows MSVC builds and macOS sanitizer runs that are too slow to gate PRs. Failures are visible in the Actions tab but do not block subsequent commits.
+
+### Workflow File Reference
+
+| File | Trigger | Mode | Purpose |
+|------|---------|------|---------|
+| `lint-pr.yml` | PR to `main` (also called by `ci-pr.yml`) | Blocking | Sequential lint gates |
+| `ci-pr.yml` | PR to `main` | Blocking | Build + sanitizer gates |
+| `lint-main.yml` | Push to `main` | Non-blocking | Lint health monitoring |
+| `ci-main.yml` | Push to `main` | Non-blocking | Comprehensive build + sanitizer monitoring |
+
+### Developer Guide
+
+**Before opening a PR**, run these checks locally to avoid CI failures:
+
+```bash
+# 1. Format all modified C files (required — CI hard-gates on this)
+/opt/homebrew/opt/llvm@18/bin/clang-format --style=file -i wirelog/*.c wirelog/*.h
+
+# 2. Verify no formatting diff remains
+git diff wirelog/ tests/
+
+# 3. Run the full test suite
+meson test -C build --print-errorlogs
+
+# 4. Optional: run with sanitizers locally
+meson setup build-san -Db_sanitize=address,undefined -Db_lundef=false -Dtests=true --buildtype=debug
+meson test -C build-san --print-errorlogs
+```
+
+**Pre-commit hook (recommended)**: Add this to `.git/hooks/pre-commit` to enforce formatting automatically:
+
+```bash
+#!/bin/sh
+CLANG_FORMAT=/opt/homebrew/opt/llvm@18/bin/clang-format
+changed=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|h)$')
+if [ -n "$changed" ]; then
+    echo "$changed" | xargs "$CLANG_FORMAT" --style=file -i
+    echo "$changed" | xargs git add
+fi
+```
+
+**PR merge requirements:**
+1. All three CI phases must be green (lint, build, sanitizers)
+2. clang-format 18 must report zero violations
+3. clang-tidy 18 must report zero warnings or errors
+4. All tests must pass on Linux GCC, Linux Clang, and macOS Clang
+
+**Interpreting main branch CI failures:**
+- Failures in `CI Main` and `Lint Main` are informational and do not need to be resolved before the next commit
+- They should be investigated and addressed in a follow-up PR
+- The Windows MSVC job and macOS sanitizer job exist only in the main monitor; failures there should be triaged as normal bugs
+
 ## Contributing
 
 wirelog is open source under LGPL-3.0. Contributions are welcome!


### PR DESCRIPTION
## Summary

- Add **CI Workflow** section documenting the two-track CI strategy: blocking 3-phase PR validation and non-blocking comprehensive main branch monitoring
- Add **Workflow File Reference** table mapping each `.yml` file to its trigger, mode, and purpose
- Add **Developer Guide** with local clang-format and test commands, a pre-commit hook template, PR merge requirements, and guidance on interpreting main branch CI failures

## Workflow coverage documented

**PR workflows (blocking):**
- `lint-pr.yml`: sequential EditorConfig -> clang-format 18 -> clang-tidy 18 gates
- `ci-pr.yml`: Linux GCC + Clang + macOS Clang build/test matrix, then Linux ASan/UBSan sanitizers

**Main branch workflows (non-blocking monitoring):**
- `lint-main.yml`: parallel EditorConfig, clang-format 18, clang-tidy 18 with `continue-on-error: true`
- `ci-main.yml`: Linux + macOS + Windows MSVC builds, Linux + macOS sanitizers, all non-blocking

## Test plan

- [ ] Verify README renders correctly on GitHub (headings, code blocks, ASCII diagrams, table)
- [ ] Confirm pre-commit hook snippet is copy-pasteable and syntactically correct
- [ ] Confirm all workflow file names match actual files under `.github/workflows/`
- [ ] Confirm PR is NOT merged to main

Closes #116, #117