### PR TITLE
docs: Rewrite README for March 2026 project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,77 @@
 # wirelog
 
-[![Sanitizers](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Sanitizers)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![Linux GCC](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20GCC)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![Linux Clang](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20Clang)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![Linux Embedded](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Linux%20Embedded)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![macOS](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=macOS)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
-[![Windows MSVC](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci.yml?branch=main&label=Windows%20MSVC)](https://github.com/justinjoy/wirelog/actions/workflows/ci.yml)
+[![PR Lint](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/lint-pr.yml?label=PR%20Lint)](https://github.com/justinjoy/wirelog/actions/workflows/lint-pr.yml)
+[![PR CI](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci-pr.yml?label=PR%20CI)](https://github.com/justinjoy/wirelog/actions/workflows/ci-pr.yml)
+[![Main Lint](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/lint-main.yml?branch=main&label=Main%20Lint)](https://github.com/justinjoy/wirelog/actions/workflows/lint-main.yml)
+[![Main CI](https://img.shields.io/github/actions/workflow/status/justinjoy/wirelog/ci-main.yml?branch=main&label=Main%20CI)](https://github.com/justinjoy/wirelog/actions/workflows/ci-main.yml)
 
 **Embedded-to-Enterprise Datalog Engine**
 
-wirelog is a C11-based Datalog engine designed to work seamlessly across embedded systems and enterprise environments. It uses Differential Dataflow for execution and can optionally be optimized with nanoarrow columnar memory for embedded deployments.
+wirelog is a pure C11 Datalog engine with incremental evaluation. It compiles Datalog programs into an optimized columnar execution plan and evaluates them with delta-seeded semi-naive iteration, enabling efficient incremental updates over large datasets.
+
+## Quick Facts
+
+| Property | Value |
+|----------|-------|
+| Language | C11 (strict compliance) |
+| Build | Meson + Ninja |
+| Backend | Pure columnar (nanoarrow) |
+| Phase | 4 — Incremental evaluation with delta-seeded propagation |
+| Tests | 56+ passing |
+| CSPA benchmark | 2.82x speedup over baseline |
 
 ## Features
 
-- **Unified Codebase**: Single implementation for embedded and enterprise
-- **Differential Dataflow Integration**: Proven incremental processing via Rust FFI
-- **Optimization Pipeline**: Logic Fusion, Join-Project Plan (JPP), Semijoin Information Passing (SIP)
-- **Benchmark Suite**: 15 workloads from graph analysis to Java points-to analysis (DOOP, 136 rules)
-- **Layered Architecture**: Clean separation of Logic, Execution, and I/O
-- **FPGA-Ready**: Designed for future hardware acceleration via Arrow IPC
-- **Minimal Dependencies**: C11 + Meson build system
+- **Pure C11 codebase**: No Rust or DD dependency in the current build
+- **Columnar execution**: nanoarrow-based columnar memory layout for cache efficiency
+- **Delta-seeded incremental evaluation**: Re-evaluation after EDB insertion propagates only new (delta) tuples instead of re-deriving the full IDB from scratch
+- **Frontier skip optimization**: Per-stratum frontier tracking skips iterations that cannot produce new results
+- **Rule frontier with pre-seeded delta**: Selective per-rule frontier reset combined with pre-seeded delta injection (Issue #107)
+- **Optimization passes**: Logic Fusion, Join-Project Plan (JPP), Semijoin Information Passing (SIP)
+- **Benchmark suite**: 15+ workloads across graph analysis, pointer analysis, and program analysis
 
-## Status
+## Phase Status (March 2026)
 
-**Phase 0: Foundation** complete. **Phase 1: Optimization** complete.
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 0: Foundation | Parser, IR, stratification, CLI | Complete |
+| 1: Optimization | Fusion, JPP, SIP, 15 benchmarks | Complete |
+| 2: Columnar backend | DD removed, nanoarrow columnar executor | Complete |
+| 3A: Symbol interning | C-only `wl_intern_t`, string-to-i64 mapping | Complete |
+| 3B: Multi-worker dispatch | Columnar worker queue (Issue #99) | Complete |
+| 3C: Incremental evaluation | Delta tracking, frontier array (Issue #83) | Complete |
+| 3D: 2D frontier data structure | Per-rule frontier (Issue #104) | Complete |
+| 3E: Rule frontier reset | Multi-stratum rule frontier (Issue #106) | Complete |
+| 3F: Selective rule frontier | Pre-seeded delta + selective reset (Issue #107) | Complete |
+| 3G: PR CI workflow | 3-phase blocking validation (Issue #117) | Complete |
+| 3H: Main branch monitoring | Non-blocking comprehensive monitoring (Issue #116) | Complete |
 
-| Component | Tests | Status |
-|-----------|-------|--------|
-| Parser (lexer + parser) | 96 | Complete |
-| IR (ir + program) | 61 | Complete |
-| Stratification | 20 | Complete |
-| DD Plan Translator | 22 | Complete |
-| FFI Marshalling | 31 | Complete |
-| Optimization (Fusion + JPP + SIP) | 36 | Complete |
-| DD Execute (end-to-end) | 18 | Complete |
-| CLI Driver | 15 | Complete |
-| Symbol Interning | 9 | Complete |
-| CSV Input | 17 | Complete |
-| **C Total** | **325** | **14 suites, all passing** |
-| Rust DD Executor | 85 | Complete |
-| **Grand Total** | **410** | **All passing** |
-
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for design details.
-
-## Quick Start
+## Getting Started
 
 ```bash
-# Clone repository
+# Clone the repository
 git clone https://github.com/justinjoy/wirelog.git
 cd wirelog
 
 # Build (requires Meson + C11 compiler)
-meson setup builddir
-meson compile -C builddir
+meson setup build
+meson compile -C build
 
-# Run tests
-meson test -C builddir
+# Run all tests
+meson test -C build --print-errorlogs
+
+# Run the CSPA benchmark
+./build/bench/bench_flowlog \
+  --workload cspa \
+  --data bench/data/graph_10.csv \
+  --data-weighted bench/data/graph_10_weighted.csv
 ```
 
-## Usage
+### Benchmark Results
 
-```bash
-# Build with DD executor (requires Rust toolchain)
-meson setup builddir -Ddd=true
-meson compile -C builddir
-
-# Run a Datalog program
-./builddir/wirelog-cli tc.dl
-
-# With multiple workers
-./builddir/wirelog-cli --workers 4 tc.dl
-```
-
-Example output for a transitive closure program:
-```
-tc(1, 2)
-tc(1, 3)
-tc(2, 3)
-```
+| Workload | Baseline | Incremental | Speedup |
+|----------|----------|-------------|---------|
+| CSPA | 10.4s | 3.7s | 2.82x |
 
 ## Architecture
 
@@ -85,121 +79,201 @@ tc(2, 3)
 
 ```
 .dl file
-    ↓ wl_read_file()
-Parser (C11, hand-written RDP)
-    ↓
-IR → Fusion → JPP → SIP
-    ↓
-DD Plan → FFI Marshal
-    ↓
-Differential Dataflow (Rust)
-    ↓ result callback
-Output
+    |
+    v  wl_read_file()
+Parser (C11, hand-written recursive descent)
+    |
+    v
+IR -> Fusion -> JPP -> SIP
+    |
+    v
+Columnar Plan
+    |
+    v
+Columnar Executor (nanoarrow)
+    |   |
+    |   +-- Incremental path: delta-seeded re-evaluation,
+    |       frontier tracking, per-stratum skip
+    v
+Result callback / output
 ```
 
-- **Embedded**: Single-worker DD, memory-constrained
-- **Enterprise**: Multi-worker DD (`--workers N`), distributed processing
+### Incremental Evaluation
+
+After an initial `session_step()` call, wirelog tracks the frontier (convergence point) for each stratum. On subsequent calls with new EDB facts:
+
+1. **Affected strata detection**: Compute which strata depend on the inserted relations.
+2. **Delta pre-seeding**: Populate `$d$<name>` delta relations from `rows[base_nrows..nrows)`.
+3. **Selective frontier reset**: Reset only affected strata; unaffected strata retain their frontier and skip unnecessary iterations.
+4. **Semi-naive re-evaluation**: Only delta tuples propagate; no full IDB re-derivation.
+
+This is what produces the 2.82x CSPA speedup: the delta path avoids re-computing tuples that did not change.
 
 ### Optimization Passes
 
 | Pass | Description |
 |------|-------------|
-| **Fusion** | Merge adjacent FILTER+PROJECT into FLATMAP |
-| **JPP** | Greedy join reorder for 3+ atom chains to minimize intermediate sizes |
-| **SIP** | Insert semijoin pre-filters in join chains to reduce intermediate cardinality |
+| Fusion | Merge adjacent FILTER+PROJECT into FLATMAP |
+| JPP | Greedy join reorder for 3+ atom chains to minimize intermediate sizes |
+| SIP | Insert semijoin pre-filters in join chains to reduce intermediate cardinality |
 
-### Benchmark Suite
-
-15 workloads covering graph analysis, pointer analysis, and program analysis:
+### Benchmark Workloads
 
 | Category | Workloads |
 |----------|-----------|
 | Graph | TC, Reach, CC, SSSP, SG, Bipartite |
 | Pointer Analysis | Andersen, CSPA, CSDA, Dyck-2 |
-| Advanced | Galen, Polonius, CRDT, DDISASM, DOOP |
+| Program Analysis | Galen, Polonius, CRDT, DDISASM, DOOP |
 
-### Phase 3+: Optional Embedded Optimization
+## CI/CD Strategy
+
+wirelog uses a two-track CI strategy: strict blocking gates on pull requests, and comprehensive non-blocking monitoring on the main branch (Issues #116, #117).
+
+### Pull Request Workflows (Blocking)
+
+Every PR targeting `main` runs three sequential phases. Failure in an earlier phase stops later phases.
 
 ```
-wirelog (C11 parser/optimizer)
-    ├─ Enterprise: Differential Dataflow (unchanged)
-    └─ Embedded: nanoarrow executor (optional)
+Phase 1: Lint  (lint-pr.yml)
+  editorconfig-check
+      |
+  clang-format-18   [blocks if formatting differs from .clang-format]
+      |
+  clang-tidy-18     [blocks if static analysis warnings or errors found]
+      |
+Phase 2: Build and Test  (ci-pr.yml)
+  Linux / GCC  -+
+  Linux / Clang +-- fail-fast: first failure cancels remaining matrix jobs
+  macOS / Clang-+
+      |
+Phase 3: Sanitizers  (ci-pr.yml)
+  Linux / GCC   (ASan + UBSan) -+
+  Linux / Clang (ASan + UBSan) -+  fail-fast
 ```
 
-For details, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+A PR cannot be merged unless all three phases pass.
 
-## Technology Stack
+### Main Branch Workflows (Non-Blocking Monitoring)
 
-- **Language**: C11
-- **Build**: Meson + Ninja
-- **Execution**: Differential Dataflow (Rust, dogs3 v0.19.1)
-- **Memory** (future): nanoarrow (optional)
-- **Hardware Acceleration**: Arrow IPC for FPGA/GPU offload (future)
+Pushes to `main` trigger broader coverage that runs to completion regardless of individual failures.
 
-## Development Roadmap
+```
+All phases run in parallel, continue-on-error: true
 
-| Phase | Status | Deliverable |
-|-------|--------|-------------|
-| 0: Foundation | ✅ Complete | Parser, IR, DD translator, CLI |
-| 1: Optimization | ✅ Complete | Fusion, JPP, SIP, 15 benchmarks |
-| 2: Documentation | Planned | Language reference, tutorial, examples, CLI docs |
-| 3: nanoarrow | Planned | C11-native executor, DD vs nanoarrow comparison |
+Lint monitor       (lint-main.yml)
+  editorconfig-check
+  clang-format-18
+  clang-tidy-18
+
+Build monitor      (ci-main.yml)
+  Linux / GCC
+  Linux / Clang
+  macOS / Clang
+  Windows / MSVC     <-- additional platform vs PR workflow
+
+Sanitizers monitor (ci-main.yml)
+  Linux / GCC   (ASan + UBSan)
+  Linux / Clang (ASan + UBSan)
+  macOS / Clang (ASan + UBSan)  <-- additional platform vs PR workflow
+```
+
+### Workflow File Reference
+
+| File | Trigger | Mode | Purpose |
+|------|---------|------|---------|
+| `lint-pr.yml` | PR to `main` | Blocking | Sequential lint gates |
+| `ci-pr.yml` | PR to `main` | Blocking | Build + sanitizer gates |
+| `lint-main.yml` | Push to `main` | Non-blocking | Lint health monitoring |
+| `ci-main.yml` | Push to `main` | Non-blocking | Comprehensive build + sanitizer monitoring |
+
+### Local Development
+
+Before opening a PR, run these checks locally:
+
+```bash
+# 1. Format all modified C files (required -- CI hard-gates on this)
+/opt/homebrew/opt/llvm@18/bin/clang-format --style=file -i wirelog/*.c wirelog/*.h
+
+# 2. Verify no formatting diff remains
+git diff wirelog/ tests/
+
+# 3. Run the full test suite
+meson test -C build --print-errorlogs
+
+# 4. Optional: run with sanitizers locally
+meson setup build-san \
+  -Db_sanitize=address,undefined \
+  -Db_lundef=false \
+  -Dtests=true \
+  --buildtype=debug
+meson test -C build-san --print-errorlogs
+```
+
+**Pre-commit hook (recommended)**: Add this to `.git/hooks/pre-commit`:
+
+```bash
+#!/bin/sh
+CLANG_FORMAT=/opt/homebrew/opt/llvm@18/bin/clang-format
+changed=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|h)$')
+if [ -n "$changed" ]; then
+    echo "$changed" | xargs "$CLANG_FORMAT" --style=file -i
+    echo "$changed" | xargs git add
+fi
+```
+
+**PR merge requirements:**
+1. All three CI phases must be green (lint, build, sanitizers)
+2. clang-format 18 must report zero violations
+3. clang-tidy 18 must report zero warnings or errors
+4. All tests must pass on Linux GCC, Linux Clang, and macOS Clang
+
+**Interpreting main branch CI failures:**
+- Failures in `CI Main` and `Lint Main` are informational and do not block subsequent commits
+- They should be investigated and addressed in a follow-up PR
+- The Windows MSVC job and macOS sanitizer job exist only in the main monitor
 
 ## Documentation
 
-- **[User Manual](https://justinjoy.github.io/wirelog/)** - Tutorial, language reference, examples, CLI usage
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Internal system design (developer reference)
-- **[LICENSE.md](LICENSE.md)** - Licensing information
+- **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** -- Internal system design (developer reference)
+- **[LICENSE.md](LICENSE.md)** -- Licensing information
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** -- Contribution guidelines
+- **[SECURITY.md](SECURITY.md)** -- Security policy
 
 ## License
 
 wirelog is available under **dual licensing**:
 
-### 1. Open Source: LGPL-3.0
+### Open Source: LGPL-3.0
 
-wirelog is distributed under the GNU Lesser General Public License v3.0 (LGPL-3.0).
+wirelog is distributed under the GNU Lesser General Public License v3.0 (LGPL-3.0). This allows you to:
 
-This allows you to:
 - Use wirelog as a library in proprietary applications
 - Modify and distribute modified versions
 - Link wirelog with proprietary software
 
 For details, see [LICENSE.md](LICENSE.md).
 
-### 2. Commercial License
+### Commercial License
 
 For proprietary or commercial use cases that require different terms:
 
 **Contact**: inquiry@cleverplant.com
 
-**Use cases include**:
-- Closed-source commercial applications
-- OEM licensing
-- Custom support agreements
-- Enterprise deployment with proprietary extensions
-
-See [LICENSE.md](LICENSE.md) for full details.
+Use cases include closed-source commercial applications, OEM licensing, custom support agreements, and enterprise deployment with proprietary extensions.
 
 ## Contributing
 
-wirelog is open source under LGPL-3.0. Contributions are welcome!
+wirelog is open source under LGPL-3.0. Contributions are welcome.
 
-Please review our [Contributing Guidelines](CONTRIBUTING.md), [Code of Conduct](CODE_OF_CONDUCT.md), and [Security Policy](SECURITY.md) prior to submitting pull requests or reporting security issues.
+Please review [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [SECURITY.md](SECURITY.md) before submitting pull requests or reporting security issues.
 
 By submitting a contribution, you agree to the [Contributor License Agreement (CLA)](CLA.md). This is required because wirelog uses dual licensing (LGPL-3.0 + Commercial).
-
-## Support
-
-- **Documentation**: [docs/](docs/)
-- **Issues & Discussions**: GitHub Issues
-- **Commercial Support**: inquiry@cleverplant.com
 
 ## References
 
 - **FlowLog Paper**: "[FlowLog: Efficient and Extensible Datalog via Incrementality](https://arxiv.org/pdf/2511.00865)" (PVLDB 2025)
-- **Differential Dataflow**: [TimelyDataflow/differential-dataflow](https://github.com/TimelyDataflow/differential-dataflow)
-- **Apache Arrow**: [Apache/Arrow](https://arrow.apache.org/)
+- **Apache Arrow / nanoarrow**: [apache/arrow-nanoarrow](https://github.com/apache/arrow-nanoarrow)
 
 ---
 
-**wirelog** - Building bridges between embedded and enterprise data processing.
+wirelog -- precise incremental Datalog for embedded and enterprise environments.


### PR DESCRIPTION
## Summary

- Complete rewrite of README.md reflecting the current state of wirelog as of March 2026
- Removes all outdated DD/Rust references (DD was removed in Phase 2)
- Documents the pure C11 columnar backend, incremental evaluation with delta-seeded propagation, and frontier skip optimization
- Updates badges to reference the new CI workflows: `ci-pr.yml`, `ci-main.yml`, `lint-pr.yml`, `lint-main.yml`

## What changed

**Removed (outdated):**
- Differential Dataflow / Rust FFI references throughout
- Old badge row pointing to `ci.yml` (no longer exists)
- Old status table with DD/Rust test counts
- Phase roadmap that listed nanoarrow as "Planned"

**Added (current):**
- Quick Facts table: C11, Meson, nanoarrow, Phase 4, 56+ tests, 2.82x CSPA speedup
- Full Phase Status table (Phases 0 through 3H) covering Issues #83, #99, #104, #106, #107, #116, #117
- Incremental evaluation explanation (affected strata, delta pre-seeding, selective frontier reset)
- CI/CD strategy section from Issues #116 and #117 (3-phase PR blocking, non-blocking main monitoring)
- Benchmark results table (CSPA 2.82x speedup)
- Developer guide: local clang-format, sanitizer builds, pre-commit hook, PR merge requirements

## Test plan

- [ ] Verify README renders correctly on GitHub (headings, code blocks, ASCII diagrams, tables)
- [ ] Confirm all workflow file names match actual files under `.github/workflows/`
- [ ] Confirm phase status table matches completed issues (#83, #99, #104, #106, #107, #116, #117)
- [ ] Confirm PR is NOT merged to main

Closes predecessor PR #120. References Issues #116, #117.