### PR TITLE
Fix CI workflow: Add workflow_call trigger to lint-main.yml

### DIFF
--- a/.github/workflows/lint-main.yml
+++ b/.github/workflows/lint-main.yml
@@ -17,6 +17,7 @@ name: Lint Main
 on:
   push:
     branches: [main]
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION

## Summary
Fixed CI workflow error where `ci-main.yml` calls `lint-main.yml` as a reusable workflow, but `lint-main.yml` was missing the required `on.workflow_call` trigger.

## Details
- GitHub Actions reusable workflows require a `on.workflow_call` trigger
- Added `workflow_call:` to the `on:" section in lint-main.yml
- This resolves: "workflow is not reusable as it is missing a `on.workflow_call` trigger"

## Test plan
- Verify `ci-main.yml` successfully calls the linting workflow without errors
- Check that lint results are properly reported to main branch monitor
