### PR TITLE
fix: Fix MSVC build failure in CI by preserving Visual Studio environment

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,10 +96,26 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson setup builddir -Dtests=true
 
-      - name: Build
+      - name: Build (Windows / MSVC)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          meson compile -C builddir
+
+      - name: Build (Linux / macOS)
+        if: runner.os != 'Windows'
         run: meson compile -C builddir
 
-      - name: Test
+      - name: Test (Windows / MSVC)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          meson test -C builddir --print-errorlogs
+
+      - name: Test (Linux / macOS)
+        if: runner.os != 'Windows'
         run: meson test -C builddir --print-errorlogs
 
       - name: Publish results


### PR DESCRIPTION
## Problem

Windows MSVC CI build was failing with:
```
ccache: error: Could not find compiler "cl" in PATH
```

**Run:** [Build / windows-latest / msvc](https://github.com/justinjoy/wirelog/actions/runs/22991991935)

## Root Cause

Visual Studio environment (`vcvars64.bat`) was set in the Configure step's `cmd` shell, but Build and Test steps ran in a **different shell instance (bash)**, causing environment variables to be lost.

**Timeline of failure:**
1. Configure step runs in `cmd` shell → calls `vcvars64.bat` → sets MSVC environment ✓
2. Build step runs in default shell (**bash**) → loses MSVC environment → ccache can't find `cl.exe` ✗
3. Test step never executed (build failed)

## Solution

Split Build and Test steps by platform with proper shell configuration:

### Before
```yaml
- name: Build
  run: meson compile -C builddir  # ← bash shell, no vcvars64.bat!

- name: Test
  run: meson test -C builddir --print-errorlogs  # ← bash shell
```

### After
```yaml
- name: Build (Windows / MSVC)
  if: runner.os == 'Windows'
  shell: cmd
  run: |
    call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
    meson compile -C builddir

- name: Build (Linux / macOS)
  if: runner.os != 'Windows'
  run: meson compile -C builddir

- name: Test (Windows / MSVC)
  if: runner.os == 'Windows'
  shell: cmd
  run: |
    call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
    meson test -C builddir --print-errorlogs

- name: Test (Linux / macOS)
  if: runner.os != 'Windows'
  run: meson test -C builddir --print-errorlogs
```

## What This Fixes

- ✅ MSVC environment persists through Build step
- ✅ MSVC compiler (`cl.exe`) stays in PATH
- ✅ Windows build will now succeed
- ✅ Linux/macOS builds unaffected (separate steps)

## Testing

This will be validated on the next CI run when merged to main.

**Expected result:** All platforms (Linux GCC/Clang, macOS Clang, Windows MSVC) should pass Build and Test phases.

Related: Issue #88 (MSVC threading fixes)