### PR TITLE
chore: Update actions/checkout from v4 to v5

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -64,7 +64,7 @@ jobs:
             cc: cl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -141,7 +141,7 @@ jobs:
             cc: clang
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -55,7 +55,7 @@ jobs:
             cc: clang
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -102,7 +102,7 @@ jobs:
             cc: clang
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint-main.yml
+++ b/.github/workflows/lint-main.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install editorconfig-checker
         env:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install LLVM 18
         run: |
@@ -122,7 +122,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install LLVM 18
         run: |

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -22,7 +22,7 @@ jobs:
     name: EditorConfig check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install editorconfig-checker
         env:
@@ -63,7 +63,7 @@ jobs:
     needs: [editorconfig-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install LLVM 18
         run: |
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install LLVM 18
         run: |


### PR DESCRIPTION
## Summary

Update all GitHub Actions workflows to use  instead of .

## Reason

Node.js 20 is deprecated for GitHub Actions. Node.js 24 will become the default on June 2, 2026.

**Current warning:**
```
Warning: Node.js 20 actions are deprecated.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

## Changes

- Update `actions/checkout@v4` → `actions/checkout@v5` (Node.js 20/24 compatible)
- All workflow files updated (4 files, 10 occurrences)

## Files Modified
- .github/workflows/ci-main.yml (2 occurrences)
- .github/workflows/ci-pr.yml (2 occurrences)
- .github/workflows/lint-main.yml (3 occurrences)
- .github/workflows/lint-pr.yml (3 occurrences)