### PR TITLE
feat(Issue #169): Extend Boolean Specialization to left-side unary joins

### DIFF
--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -183,6 +183,23 @@ typedef struct {
 } col_mat_cache_t;
 
 /* ======================================================================== */
+/* Operator Profiling (WL_PROFILE)                                         */
+/* ======================================================================== */
+
+#ifdef WL_PROFILE
+typedef struct {
+    uint64_t concat_calls;
+    uint64_t concat_empty_out;
+    uint64_t concat_ns;
+    uint64_t join_calls;
+    uint64_t join_unary; /* joins where left or right ncols == 1    */
+    uint64_t join_empty_out;
+    uint64_t join_cache_hit_ns;
+    uint64_t join_compute_ns;
+} wl_profile_stats_t;
+#endif
+
+/* ======================================================================== */
 /* Arrangement Registry                                                     */
 /* ======================================================================== */
 
@@ -322,6 +339,9 @@ typedef struct {
      * $r$<name> relations. Cleared after eval completes. */
     bool retraction_seeded;
     delta_pool_t *delta_pool; /* Pool allocator for operator temporaries */
+#ifdef WL_PROFILE
+    wl_profile_stats_t profile; /* operator profiling counters */
+#endif
 } wl_col_session_t;
 
 /*

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -790,16 +790,24 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
      * Profiling shows 37.7% of DOOP-class joins are unary; this path
      * provides ~30-40% speedup for such workloads. */
     bool right_is_unary = (right->ncols == 1);
+    bool left_is_unary = (left->ncols == 1);
 #ifdef WL_PROFILE
-    if (right_is_unary && kc == 1)
+    if ((right_is_unary || left_is_unary) && kc == 1)
         sess->profile.join_unary++;
 #endif
-    if (right_is_unary && kc == 1) {
-        /* Fast-path: unary join using hash-set membership test. */
-        uint32_t nbuckets = next_pow2(right->nrows > 0 ? right->nrows * 2 : 1);
+    if ((right_is_unary || left_is_unary) && kc == 1) {
+        /* build: unary side as hash set; probe: non-unary side iterated.
+         * When both are unary, right is preferred as build side. */
+        col_rel_t *build = right_is_unary ? right : left;
+        col_rel_t *probe = right_is_unary ? left : right;
+        uint32_t build_kcol = right_is_unary ? rk[0] : lk[0];
+        uint32_t probe_kcol = right_is_unary ? lk[0] : rk[0];
+
+        /* Build hash set from the unary relation's single column. */
+        uint32_t nbuckets = next_pow2(build->nrows > 0 ? build->nrows * 2 : 1);
         uint32_t *ht_head = (uint32_t *)calloc(nbuckets, sizeof(uint32_t));
         uint32_t *ht_next = (uint32_t *)malloc(
-            (right->nrows > 0 ? right->nrows : 1) * sizeof(uint32_t));
+            (build->nrows > 0 ? build->nrows : 1) * sizeof(uint32_t));
         if (!ht_head || !ht_next) {
             free(ht_head);
             free(ht_next);
@@ -811,10 +819,8 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                 col_rel_destroy(left);
             return ENOMEM;
         }
-
-        /* Build hash set from unary right column (rk[0]). */
-        for (uint32_t rr = 0; rr < right->nrows; rr++) {
-            int64_t key = right->data[rr * right->ncols + rk[0]];
+        for (uint32_t bi = 0; bi < build->nrows; bi++) {
+            int64_t key = build->data[(size_t)bi * build->ncols + build_kcol];
             /* Inline FNV-1a hash for single int64 value */
             uint32_t h = 2166136261u;
             uint64_t v = (uint64_t)key;
@@ -822,41 +828,44 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
             h *= 16777619u;
             h ^= (uint32_t)(v >> 32);
             h *= 16777619u;
-            h = h & (nbuckets - 1);
-            ht_next[rr] = ht_head[h];
-            ht_head[h] = rr + 1; /* 1-based; 0 = end of chain */
+            h &= (nbuckets - 1);
+            ht_next[bi] = ht_head[h];
+            ht_head[h] = bi + 1; /* 1-based; 0 = end of chain */
         }
 
-        /* Iterate left rows and test membership in right hash set. */
+        /* Probe: iterate non-unary side, test membership in hash set. */
         int join_rc = 0;
-        for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
-            const int64_t *lrow = left->data + (size_t)lr * left->ncols;
-            int64_t lkey = lrow[lk[0]];
+        for (uint32_t pr = 0; pr < probe->nrows && join_rc == 0; pr++) {
+            const int64_t *prow = probe->data + (size_t)pr * probe->ncols;
+            int64_t pkey = prow[probe_kcol];
             /* Inline FNV-1a hash for single int64 value */
             uint32_t h = 2166136261u;
-            uint64_t v = (uint64_t)lkey;
+            uint64_t v = (uint64_t)pkey;
             h ^= (uint32_t)(v & 0xffffffff);
             h *= 16777619u;
             h ^= (uint32_t)(v >> 32);
             h *= 16777619u;
-            h = h & (nbuckets - 1);
+            h &= (nbuckets - 1);
 
-            /* Probe hash set for matching right row. */
             for (uint32_t e = ht_head[h]; e != 0; e = ht_next[e - 1]) {
-                uint32_t rr = e - 1;
-                int64_t rkey = right->data[rr * right->ncols + rk[0]];
-                if (lkey == rkey) {
-                    /* Match found: combine left and right rows. */
-                    const int64_t *rrow
-                        = right->data + (size_t)rr * right->ncols;
-                    memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
-                    memcpy(tmp + left->ncols, rrow,
-                           sizeof(int64_t) * right->ncols);
-                    join_rc = col_rel_append_row(out, tmp);
-                    if (join_rc != 0)
-                        break;
-                    /* For unary relations, continue checking additional matches. */
+                uint32_t bi = e - 1;
+                int64_t bkey
+                    = build->data[(size_t)bi * build->ncols + build_kcol];
+                if (pkey != bkey)
+                    continue;
+                /* Match: emit output in [left cols | right cols] order. */
+                if (right_is_unary) {
+                    /* probe=left, build=right: [prow | bkey] */
+                    memcpy(tmp, prow, sizeof(int64_t) * probe->ncols);
+                    tmp[probe->ncols] = bkey;
+                } else {
+                    /* probe=right, build=left: [bkey | prow] */
+                    tmp[0] = bkey;
+                    memcpy(tmp + 1, prow, sizeof(int64_t) * probe->ncols);
                 }
+                join_rc = col_rel_append_row(out, tmp);
+                if (join_rc != 0)
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary
Extends the Boolean Specialization optimization to handle unary relations on both the left and right sides of joins. The original implementation only optimized right-side unary relations; this enhancement generalizes it to work in both directions.

## Changes
- **wirelog/columnar/ops.c:792-875**: Detects either left OR right being unary (ncols == 1), assigns build/probe sides dynamically at runtime, maintains consistent output column ordering [left cols | right cols]
- **wirelog/columnar/internal.h:185-200**: Restored `wl_profile_stats_t` typedef and `profile` field to `wl_col_session_t` (required for WL_PROFILE=1 builds)

## Impact
- Expands optimization coverage from ~37.7% DOOP joins (right-side unary only) to effectively both sides
- Hash-set membership test now used for any unary join configuration
- Profiling infrastructure fully restored for performance monitoring
- Maintains all existing semantics and output ordering

## Test Status
- All 73 tests pass
- 1 expected failure (unrelated)
- No regressions

## Technical Details
The fast-path now:
1. Detects if left OR right input is unary
2. Designates the unary side as "build" (hash-set construction)
3. Designates the multi-column side as "probe" (membership testing)
4. Uses inline FNV-1a hashing for O(1) lookups
5. Outputs results in canonical order: [all left columns | all right columns]

Closes #169