### PR TITLE
fix: Error-path delta cleanup & profile counter merge (Issue #177)

### DIFF
--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2350,6 +2350,27 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     }
     COL_SESSION(sess)->kfusion_dispatch_ns += now_ns() - _phase_t0;
 
+    /* Issue #177: Merge worker profile counters back to session.
+     * K-fusion workers accumulate profiling stats (join_calls, join_unary,
+     * etc.) during parallel evaluation. Aggregate these counters to the
+     * session profile for comprehensive profiling. */
+#ifdef WL_PROFILE
+    {
+        wl_profile_t base_profile = sess->profile;
+        for (uint32_t d = 0; d < k; d++) {
+            /* Merge counters: sum increments from baseline */
+            sess->profile.join_calls
+                += worker_sess[d].profile.join_calls - base_profile.join_calls;
+            sess->profile.join_unary
+                += worker_sess[d].profile.join_unary - base_profile.join_unary;
+            sess->profile.join_binary += worker_sess[d].profile.join_binary
+                                         - base_profile.join_binary;
+            sess->profile.seminaive_ops += worker_sess[d].profile.seminaive_ops
+                                           - base_profile.seminaive_ops;
+        }
+    }
+#endif
+
     /* Collect results from each worker's eval_stack */
     _phase_t0 = now_ns();
     for (uint32_t d = 0; d < k; d++) {

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -931,8 +931,27 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
         if ((affected_mask & ((uint64_t)1 << si)) == 0)
             continue;
         int rc = col_eval_stratum(&plan->strata[si], sess, si);
-        if (rc != 0)
+        if (rc != 0) {
+            /* Issue #177: Cleanup pre-seeded $d$ deltas on error.
+             * If evaluation fails, remove temporary delta relations created
+             * during delta-seeded incremental eval. Benign to leave them
+             * (replaced on next snapshot), but cleaner to remove. */
+            for (uint32_t i = 0; i < sess->nrels; i++) {
+                col_rel_t *r = sess->rels[i];
+                if (r && strncmp(r->name, "$d$", 3) == 0) {
+                    col_rel_destroy(r);
+                    sess->rels[i] = NULL;
+                }
+            }
+            /* Compact rels[] to close holes */
+            uint32_t out = 0;
+            for (uint32_t in = 0; in < sess->nrels; in++) {
+                if (sess->rels[in] != NULL)
+                    sess->rels[out++] = sess->rels[in];
+            }
+            sess->nrels = out;
             return rc;
+        }
         if (sess->eval_arena)
             wl_arena_reset(sess->eval_arena);
     }


### PR DESCRIPTION
## Summary

Implements two improvements for Issue #177:

- **P2-a**: Error-path delta cleanup - cleanup pre-seeded $d$ delta relations when stratum evaluation fails
- **P2-b**: Profile counter merge - aggregate K-fusion worker profiling stats to session profile

## Changes

### wirelog/columnar/session.c
- Added error-path cleanup in `col_session_snapshot()` (lines ~934-956)
- When `col_eval_stratum()` fails, remove pre-seeded $d$ delta relations and compact rels[]
- Prevents leaving temporary relations from delta-seeded incremental evaluation

### wirelog/columnar/ops.c
- Added profile counter merging in `col_op_k_fusion()` (lines ~2353-2371)
- After K-fusion barrier, merge worker session profile counters to main session
- Aggregates: join_calls, join_unary, join_binary, seminaive_ops
- Gated with WL_PROFILE for comprehensive parallel execution profiling

## Testing
- All 74 tests pass (73 OK, 1 EXPECTEDFAIL)
- Code formatted with clang-format