### PR TITLE
Modify CodeQL config for path inclusion and exclusion

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,13 +5,14 @@ queries:
 
 paths:
   - wirelog
-  # - rust/wirelog-dd/src  # Disabled: Rust analysis not required for Phase 4+
   - tests
 
 paths-ignore:
   - bench
   - build*
-  - third_party
+  - scripts
+  - examples
+  - subprojects
 
 threat-models:
   - remote


### PR DESCRIPTION
Updated CodeQL configuration to include additional paths and ignore scripts, examples, and subprojects.