### PR TITLE
docs(Issue #191): Document projection elimination semantic blocker

### DIFF
--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -672,12 +672,13 @@ test_jpp_antijoin_preserved(void)
 static void
 test_jpp_intermediate_projection(void)
 {
-    TEST("jpp: intermediate projection disabled (reorder-only mode)");
+    TEST("jpp: intermediate projection disabled (pending Issue #191 fix)");
 
     /*
-     * Projection insertion is currently disabled pending dd_plan
-     * column-index propagation fix.  This test verifies that JPP
-     * succeeds without inserting any projections.
+     * Projection insertion is disabled pending semantic correctness fix.
+     * Current implementation causes duplicate results in some join patterns
+     * (e.g., 3-way joins producing duplicates).
+     * Issue #191 tracks investigation and fix for projection semantics.
      */
     wirelog_error_t err;
     wirelog_program_t *prog

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -728,14 +728,16 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
     free(joins);
     free(order);
 
-    /* TODO: intermediate projection insertion is disabled pending
-     * dd_plan column-index propagation fix (causes index-out-of-bounds
-     * in the DD executor for multi-atom rules).  Join reordering alone
-     * is active and provides the primary optimisation benefit.
+    /* TODO: Intermediate column projection elimination (Issue #191).
+     * Projection insertion currently causes semantic issues in some cases
+     * (e.g., test_option2_cse 3-way join produces duplicate results).
+     * Requires investigation into why projections break join semantics.
+     * DD backend removed in Phase 2C - original blocking issue resolved.
      */
     (void)insert_projections; /* suppress unused warning */
     (void)head_vars;
     (void)head_var_count;
+    result.projections_inserted = 0;
 
     return result;
 }


### PR DESCRIPTION
## Summary

Investigation of Issue #191 (Enable intermediate column projection elimination) discovered that the DD backend-specific blocking issue has been resolved (DD backend was removed in Phase 2C). However, a new semantic correctness issue was identified.

## Problem

When `insert_projections()` is enabled, the JPP pass causes duplicate results in certain join patterns, specifically 3-way joins:
- Test: `test_option2_cse` test 15 (3-way join correctness)
- Expected: 1 result (path3(1, 4))
- Actual: 2 results (path3(1, 4) duplicated)

## Current Status

- The optimization remains **disabled** pending investigation
- All tests pass with projection insertion disabled (73 OK, 1 expected fail)
- Updated test comments to reflect the new semantic issue rather than obsolete DD backend concerns

## Next Steps

The feature cannot be safely enabled until the semantic issue is resolved. Investigation needed to identify:

1. **Column Removal Bug**: Are projections removing columns needed for join correctness?
2. **Join Key Recalculation**: Is `jpp_setup_join_keys()` producing incorrect mappings after projection?
3. **Projection Logic**: Is there a subtle bug in how `insert_projections()` identifies needed variables?

Recommend creating a separate investigation issue to track the root cause analysis.

## Testing

✓ All 74 tests pass (73 OK, 1 expected fail)
✓ Build succeeds with no errors

Co-Authored-By: Claude