### PR TITLE
feat(Issue #206): Implement Magic Sets demand-driven optimization pass

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,6 +27,7 @@ optimizer_src = files(
   '../wirelog/passes/jpp.c',
   '../wirelog/passes/sip.c',
   '../wirelog/passes/subsumption.c',
+  '../wirelog/passes/magic_sets.c',
 )
 
 intern_src = files(
@@ -1380,3 +1381,19 @@ test('session', test_session_exe)
 #
 # test_recursive_agg_plan depends on deleted DD backend (dd_plan.h)
 # This test is disabled until columnar backend provides equivalent plan generation
+
+# ============================================================================
+# Magic Sets Optimization Pass Tests (Issue #206)
+# ============================================================================
+
+test_magic_sets_exe = executable(
+  'test_magic_sets',
+  files('test_magic_sets.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  csv_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+
+test('magic_sets', test_magic_sets_exe)

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -1,0 +1,852 @@
+/*
+ * test_magic_sets.c - Tests for Magic Sets Optimization Pass
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Tests verify:
+ *   1. Adornment computation (bound/free positions propagated correctly)
+ *   2. Magic relation and rule generation
+ *   3. All-free adornment optimization (skip magic)
+ *   4. No demand through negation (ANTIJOIN right child)
+ *   5. Multiple adornments for the same relation
+ *   6. EDB relations do not get magic relations
+ *   7. Correctness: magic-optimized result == full result (integration)
+ */
+
+#include "../wirelog/passes/magic_sets.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/subsumption.h"
+#include "../wirelog/ir/program.h"
+#include "../wirelog/ir/stratify.h"
+#include "../wirelog/wirelog-parser.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+    do {                                      \
+        tests_run++;                          \
+        printf("  [%d] %s", tests_run, name); \
+    } while (0)
+
+#define PASS()                 \
+    do {                       \
+        tests_passed++;        \
+        printf(" ... PASS\n"); \
+    } while (0)
+
+#define FAIL(msg)                         \
+    do {                                  \
+        tests_failed++;                   \
+        printf(" ... FAIL: %s\n", (msg)); \
+    } while (0)
+
+/* ======================================================================== */
+/* Helper: check if a magic relation exists in the program                 */
+/* ======================================================================== */
+
+static bool
+has_relation(const struct wirelog_program *prog, const char *name)
+{
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (prog->relations[i].name
+            && strcmp(prog->relations[i].name, name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool
+has_rule_for(const struct wirelog_program *prog, const char *head_name)
+{
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (prog->rules[i].head_relation
+            && strcmp(prog->rules[i].head_relation, head_name) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* ======================================================================== */
+/* Helper: parse a program with standard optimizer passes applied          */
+/* ======================================================================== */
+
+static struct wirelog_program *
+parse_and_optimize(const char *src)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+    wl_subsumption_apply(prog, NULL);
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+    return prog;
+}
+
+/* ======================================================================== */
+/* Test 1: test_adornment_basic                                             */
+/* Single non-recursive IDB rule: demand propagates to IDB body atom.      */
+/* ======================================================================== */
+
+static void
+test_adornment_basic(void)
+{
+    TEST("test_adornment_basic");
+
+    /*
+     * Edge(x, y) is EDB (no rules).
+     * Reach(x, y) is IDB (has rules).
+     * Out(x) :- Reach(x, y), Edge(y, z).
+     *
+     * With demand Out_b (position 0 = x bound):
+     *   - Reach(x, y): x is bound -> adornment bf -> $m$Reach_bf created
+     *   - Edge is EDB -> skip
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Reach(x: int32, y: int32)\n"
+                      ".decl Out(x: int32)\n"
+                      ".output Out\n"
+                      "Reach(x, y) :- Edge(x, y).\n"
+                      "Out(x) :- Reach(x, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Out";
+    demands[0].bound_mask = 0x1; /* position 0 bound */
+    demands[0].arity = 1;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* Out is the demand root -> $m$Out_b may or may not be created depending
+     * on whether Out itself is IDB. Out IS IDB (has rule Out(x) :- Reach(x,y)).
+     * With demand Out_b: x is bound, walk Out's rule body:
+     *   atom Reach(x, y): x is bound -> adornment bf -> $m$Reach_bf created.
+     * Also Out gets guard $m$Out_b.
+     */
+    bool has_out_magic = has_relation(prog, "$m$Out_b");
+    bool has_reach_magic = has_relation(prog, "$m$Reach_bf");
+
+    if (!has_out_magic || !has_reach_magic) {
+        wirelog_program_free(prog);
+        FAIL("expected $m$Out_b and $m$Reach_bf to be created");
+        return;
+    }
+
+    if (stats.adorned_predicates == 0) {
+        wirelog_program_free(prog);
+        FAIL("expected adorned_predicates > 0");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 2: test_adornment_recursive                                         */
+/* Recursive TC rule: adornment propagates through recursive body atom.    */
+/* ======================================================================== */
+
+static void
+test_adornment_recursive(void)
+{
+    TEST("test_adornment_recursive");
+
+    /*
+     * TC with Edge-first rule (allows meaningful demand propagation):
+     *   Path(x, y) :- Edge(x, y).
+     *   Path(x, y) :- Edge(x, z), Path(z, y).
+     *
+     * With demand Path_bf (x bound):
+     *   Rule 2: bound_vars = {x}
+     *     atom Edge(x, z): EDB, adds {x, z}
+     *     atom Path(z, y): z is bound -> adornment bf -> $m$Path_bf (already in set)
+     *   -> adorned_predicates = 1 (only Path_bf)
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0x1; /* position 0 (x) bound */
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* $m$Path_bf must be created */
+    if (!has_relation(prog, "$m$Path_bf")) {
+        wirelog_program_free(prog);
+        FAIL("$m$Path_bf relation not created");
+        return;
+    }
+
+    /* adorned_predicates should be 1 (only Path_bf) */
+    if (stats.adorned_predicates != 1) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected adorned_predicates=1, got %u",
+                 stats.adorned_predicates);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 3: test_magic_rule_generation                                       */
+/* Verify correct demand propagation rule is generated for TC.             */
+/* ======================================================================== */
+
+static void
+test_magic_rule_generation(void)
+{
+    TEST("test_magic_rule_generation");
+
+    /*
+     * Path(x, y) :- Edge(x, z), Path(z, y).
+     * With Path_bf:
+     *   prefix = [Edge(x,z)], target = Path(z,y), z bound
+     *   Demand rule: $m$Path_bf(z) :- $m$Path_bf(x), Edge(x, z).
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* A demand propagation rule for $m$Path_bf must be generated */
+    if (stats.magic_rules_generated == 0) {
+        wirelog_program_free(prog);
+        FAIL("expected at least one magic demand rule generated");
+        return;
+    }
+
+    /* The magic rule must have head $m$Path_bf */
+    if (!has_rule_for(prog, "$m$Path_bf")) {
+        wirelog_program_free(prog);
+        FAIL("no rule with head $m$Path_bf found");
+        return;
+    }
+
+    /* Both original Path rules must have magic guards inserted */
+    if (stats.original_rules_modified != 2) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected original_rules_modified=2, got %u",
+                 stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 4: test_all_free_skip                                               */
+/* All-free adornment (bound_mask=0) triggers optimization skip.           */
+/* ======================================================================== */
+
+static void
+test_all_free_skip(void)
+{
+    TEST("test_all_free_skip");
+
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0; /* All-free */
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* No magic relations should be created */
+    if (has_relation(prog, "$m$Path_ff")) {
+        wirelog_program_free(prog);
+        FAIL("all-free optimization should skip $m$Path_ff");
+        return;
+    }
+
+    /* adorned_predicates must be 0 */
+    if (stats.adorned_predicates != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected adorned_predicates=0, got %u",
+                 stats.adorned_predicates);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    /* skipped_all_free must be > 0 */
+    if (stats.skipped_all_free == 0) {
+        wirelog_program_free(prog);
+        FAIL("expected skipped_all_free > 0");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 5: test_negation_no_demand                                          */
+/* Demand does NOT flow through ANTIJOIN (negated atoms).                  */
+/* ======================================================================== */
+
+static void
+test_negation_no_demand(void)
+{
+    TEST("test_negation_no_demand");
+
+    /*
+     * IDB(x) :- Base(x), !Exclude(x).
+     * Exclude(x) :- BadBase(x).
+     *
+     * With demand IDB_b (x bound):
+     *   Rule body: [Base(x), !Exclude(x)]
+     *   Base is EDB -> skip.
+     *   Exclude is in ANTIJOIN right child -> demand does NOT flow.
+     *   -> NO magic relation for Exclude.
+     */
+    const char *src = ".decl Base(x: int32)\n"
+                      ".decl BadBase(x: int32)\n"
+                      ".decl Exclude(x: int32)\n"
+                      ".decl IDB(x: int32)\n"
+                      ".output IDB\n"
+                      "Exclude(x) :- BadBase(x).\n"
+                      "IDB(x) :- Base(x), !Exclude(x).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "IDB";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 1;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* No magic relation for Exclude (demand must NOT flow through negation) */
+    if (has_relation(prog, "$m$Exclude_b")) {
+        wirelog_program_free(prog);
+        FAIL("demand must not flow through negation: $m$Exclude_b should not "
+             "exist");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 6: test_multiple_adornments                                         */
+/* Same relation used with both bf and fb adornments.                      */
+/* ======================================================================== */
+
+static void
+test_multiple_adornments(void)
+{
+    TEST("test_multiple_adornments");
+
+    /*
+     * A(x, y) :- Edge(x, z), B(z, y).     // B with first arg bound -> B_bf
+     * B(x, y) :- Edge(y, z), A(z, x).     // A with first arg bound -> A_bf
+     *
+     * With demand A_bf (x bound):
+     *   Rule for A: bound={x}, atoms=[Edge(x,z), B(z,y)]
+     *     Edge EDB, adds {x,z}
+     *     B(z,y): z bound -> adornment bf -> $m$B_bf
+     *   Process B_bf:
+     *     Rule for B: bound={z}, atoms=[Edge(y,z), A(z,x)]
+     *       Edge EDB, adds {y,z}  (note: z already bound)
+     *       A(z,x): z bound -> adornment bf -> $m$A_bf (already in set)
+     *   -> adorned: {A_bf, B_bf}
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl A(x: int32, y: int32)\n"
+                      ".decl B(x: int32, y: int32)\n"
+                      ".output A\n"
+                      "A(x, y) :- Edge(x, z), B(z, y).\n"
+                      "B(x, y) :- Edge(y, z), A(z, x).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "A";
+    demands[0].bound_mask = 0x1; /* x bound */
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    bool has_a_magic = has_relation(prog, "$m$A_bf");
+    bool has_b_magic = has_relation(prog, "$m$B_bf");
+
+    if (!has_a_magic || !has_b_magic) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected $m$A_bf=%s $m$B_bf=%s",
+                 has_a_magic ? "yes" : "NO", has_b_magic ? "yes" : "NO");
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    /* At least A_bf and B_bf must be adorned; mutual recursion may
+     * discover additional adornments (A_bb, B_bb) as bound vars propagate. */
+    if (stats.adorned_predicates < 2) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected adorned_predicates>=2, got %u",
+                 stats.adorned_predicates);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 7: test_mutual_recursion                                            */
+/* Two mutually recursive relations with demand propagation.               */
+/* ======================================================================== */
+
+static void
+test_mutual_recursion(void)
+{
+    TEST("test_mutual_recursion");
+
+    /*
+     * VPT(h, v) :- Assign(v, h).
+     * VPT(h, v) :- VPT(h, u), Load(u, v).
+     * CGE(m, n) :- Reachable(m), Calls(m, n).
+     * Reachable(m) :- Root(m).
+     * Reachable(m) :- Reachable(n), CGE(n, m).
+     *
+     * With demand VPT_bf (h bound):
+     *   VPT rule 2: bound={h}, atoms = [VPT(h,u), Load(u,v)]
+     *     VPT(h,u): h bound -> adornment bf -> $m$VPT_bf (already in set)
+     *     Load EDB, adds {u,v}
+     *   -> adorned: {VPT_bf}
+     */
+    const char *src = ".decl Assign(v: int32, h: int32)\n"
+                      ".decl Load(u: int32, v: int32)\n"
+                      ".decl VPT(h: int32, v: int32)\n"
+                      ".output VPT\n"
+                      "VPT(h, v) :- Assign(v, h).\n"
+                      "VPT(h, v) :- VPT(h, u), Load(u, v).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "VPT";
+    demands[0].bound_mask = 0x1; /* h bound */
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (!has_relation(prog, "$m$VPT_bf")) {
+        wirelog_program_free(prog);
+        FAIL("$m$VPT_bf relation not created");
+        return;
+    }
+
+    /* Both VPT rules should have magic guards */
+    if (stats.original_rules_modified != 2) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected original_rules_modified=2, got %u",
+                 stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 8: test_edb_skip                                                    */
+/* EDB relations (no defining rules) do not get magic relations.           */
+/* ======================================================================== */
+
+static void
+test_edb_skip(void)
+{
+    TEST("test_edb_skip");
+
+    /*
+     * Edge is EDB (no rules).
+     * Path is IDB (has rules).
+     *
+     * With demand Path_bf (x bound):
+     *   $m$Path_bf created (IDB).
+     *   Edge: EDB -> no $m$Edge_XX created.
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* No magic relation for EDB Edge */
+    if (has_relation(prog, "$m$Edge_bf") || has_relation(prog, "$m$Edge_bb")
+        || has_relation(prog, "$m$Edge_fb")
+        || has_relation(prog, "$m$Edge_ff")) {
+        wirelog_program_free(prog);
+        FAIL("EDB relation Edge must not get a magic relation");
+        return;
+    }
+
+    /* $m$Path_bf must exist */
+    if (!has_relation(prog, "$m$Path_bf")) {
+        wirelog_program_free(prog);
+        FAIL("$m$Path_bf should be created");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 9: test_standard_apply_noop                                        */
+/* wl_magic_sets_apply (all-free from .output) is a no-op.                */
+/* ======================================================================== */
+
+static void
+test_standard_apply_noop(void)
+{
+    TEST("test_standard_apply_noop");
+
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    uint32_t rule_count_before = prog->rule_count;
+    uint32_t relation_count_before = prog->relation_count;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply(prog, &stats);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* No magic relations or rules added (all-free optimization) */
+    if (prog->rule_count != rule_count_before) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "rule count changed: before=%u after=%u",
+                 rule_count_before, prog->rule_count);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    if (prog->relation_count != relation_count_before) {
+        wirelog_program_free(prog);
+        FAIL("relation count changed (should be no-op for all-free)");
+        return;
+    }
+
+    if (prog->magic_sets_applied) {
+        wirelog_program_free(prog);
+        FAIL("magic_sets_applied should be false for all-free no-op");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Integration Test 1: magic sets does not change result for all-free      */
+/* ======================================================================== */
+
+static void
+test_magic_correctness_noop(void)
+{
+    TEST("test_magic_correctness_noop (integration)");
+
+    /*
+     * Run TC program through the full pipeline with magic sets (all-free = noop).
+     * Verify no crash and program still stratified.
+     */
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Edge(1, 2).\n"
+                      "Edge(2, 3).\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_subsumption_apply(prog, NULL);
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+    wl_magic_sets_apply(prog, NULL);
+
+    /* Rebuild and re-stratify only if magic was applied */
+    if (prog->magic_sets_applied) {
+        wl_ir_program_rebuild_relation_irs(prog);
+        wl_ir_program_free_strata(prog);
+        wl_ir_stratify_program(prog);
+    }
+
+    /* Program must still be stratified */
+    if (!prog->is_stratified) {
+        wirelog_program_free(prog);
+        FAIL("program is not stratified after magic sets");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Integration Test 2: magic sets with bound demand + rebuild               */
+/* ======================================================================== */
+
+static void
+test_magic_rebuild_and_stratify(void)
+{
+    TEST("test_magic_rebuild_and_stratify (integration)");
+
+    const char *src = ".decl Edge(x: int32, y: int32)\n"
+                      ".decl Path(x: int32, y: int32)\n"
+                      ".output Path\n"
+                      "Path(x, y) :- Edge(x, y).\n"
+                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, NULL);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    /* Rebuild and re-stratify */
+    if (wl_ir_program_rebuild_relation_irs(prog) != 0) {
+        wirelog_program_free(prog);
+        FAIL("rebuild_relation_irs failed");
+        return;
+    }
+
+    wl_ir_program_free_strata(prog);
+    if (wl_ir_stratify_program(prog) != 0) {
+        wirelog_program_free(prog);
+        FAIL("re-stratification failed");
+        return;
+    }
+
+    if (!prog->is_stratified) {
+        wirelog_program_free(prog);
+        FAIL("program not stratified after magic sets + rebuild");
+        return;
+    }
+
+    /* $m$Path_bf must be in the rebuilt relation_irs */
+    bool found_magic_ir = false;
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (prog->relations[i].name
+            && strcmp(prog->relations[i].name, "$m$Path_bf") == 0) {
+            found_magic_ir = true;
+            break;
+        }
+    }
+    if (!found_magic_ir) {
+        wirelog_program_free(prog);
+        FAIL("$m$Path_bf not in program after rebuild");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("=== Magic Sets Tests ===\n\n");
+
+    printf("Unit Tests:\n");
+    test_adornment_basic();
+    test_adornment_recursive();
+    test_magic_rule_generation();
+    test_all_free_skip();
+    test_negation_no_demand();
+    test_multiple_adornments();
+    test_mutual_recursion();
+    test_edb_skip();
+    test_standard_apply_noop();
+
+    printf("\nIntegration Tests:\n");
+    test_magic_correctness_noop();
+    test_magic_rebuild_and_stratify();
+
+    printf("\n=== Results ===\n");
+    printf("Tests run:    %d\n", tests_run);
+    printf("Tests passed: %d\n", tests_passed);
+    printf("Tests failed: %d\n", tests_failed);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -15,8 +15,10 @@
 #include "../exec_plan_gen.h"
 #include "../intern.h"
 #include "../ir/program.h"
+#include "../ir/stratify.h"
 #include "../passes/fusion.h"
 #include "../passes/jpp.h"
+#include "../passes/magic_sets.h"
 #include "../passes/sip.h"
 #include "../passes/subsumption.h"
 #include "../session.h"
@@ -358,6 +360,14 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
     wl_fusion_apply(prog, NULL);
     wl_jpp_apply(prog, NULL);
     wl_sip_apply(prog, NULL);
+    wl_magic_sets_apply(prog, NULL);
+
+    /* 2a. Rebuild relation IR and re-stratify after magic sets */
+    if (prog->magic_sets_applied) {
+        wl_ir_program_rebuild_relation_irs(prog);
+        wl_ir_program_free_strata(prog);
+        wl_ir_stratify_program(prog);
+    }
 
     /* 3. Generate execution plan */
     wl_plan_t *plan = NULL;

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1167,3 +1167,121 @@ wl_ir_program_merge_unions(struct wirelog_program *program)
 
     return 0;
 }
+
+/* ======================================================================== */
+/* Magic Sets Support API                                                   */
+/* ======================================================================== */
+
+int
+wl_ir_program_add_magic_relation(struct wirelog_program *prog, const char *name,
+                                 uint32_t column_count)
+{
+    if (!prog || !name)
+        return -1;
+
+    /* No-op if already exists */
+    if (find_relation(prog, name))
+        return 0;
+
+    wl_ir_relation_info_t *rel = add_relation(prog, name);
+    if (!rel)
+        return -1;
+
+    /* Keep relation_irs in sync with relation_count so wl_ir_program_free
+     * doesn't walk past the end of the array.  The new entry is NULL; it
+     * will be filled in by the subsequent wl_ir_program_rebuild_relation_irs
+     * call.  If realloc fails, NULL out relation_irs so free() is safe. */
+    if (prog->relation_irs) {
+        void *new_irs_v
+            = realloc((void *)prog->relation_irs,
+                      prog->relation_count * sizeof(wirelog_ir_node_t *));
+        if (new_irs_v) {
+            prog->relation_irs = (wirelog_ir_node_t **)new_irs_v;
+            prog->relation_irs[prog->relation_count - 1] = NULL;
+        } else {
+            free((void *)prog->relation_irs);
+            prog->relation_irs = NULL;
+        }
+    }
+
+    if (column_count > 0) {
+        rel->columns = (wirelog_column_t *)calloc(column_count,
+                                                  sizeof(wirelog_column_t));
+        if (!rel->columns)
+            return -1;
+        rel->column_count = column_count;
+        for (uint32_t i = 0; i < column_count; i++) {
+            char col_name[32];
+            snprintf(col_name, sizeof(col_name), "c%u", i);
+            rel->columns[i].name = strdup_safe(col_name);
+            rel->columns[i].type = WIRELOG_TYPE_INT64;
+        }
+    }
+
+    return 0;
+}
+
+int
+wl_ir_program_add_magic_rule(struct wirelog_program *prog,
+                             const char *head_relation,
+                             wirelog_ir_node_t *ir_root)
+{
+    if (!prog || !head_relation || !ir_root)
+        return -1;
+
+    if (prog->rule_count >= prog->rule_capacity) {
+        uint32_t new_cap = prog->rule_capacity == 0 ? INITIAL_CAPACITY
+                                                    : prog->rule_capacity * 2;
+        wl_ir_rule_ir_t *new_rules = (wl_ir_rule_ir_t *)realloc(
+            prog->rules, new_cap * sizeof(wl_ir_rule_ir_t));
+        if (!new_rules)
+            return -1;
+        prog->rules = new_rules;
+        prog->rule_capacity = new_cap;
+    }
+
+    wl_ir_rule_ir_t *rule = &prog->rules[prog->rule_count++];
+    memset(rule, 0, sizeof(wl_ir_rule_ir_t));
+    rule->head_relation = strdup_safe(head_relation);
+    rule->ir_root = ir_root;
+    return 0;
+}
+
+int
+wl_ir_program_rebuild_relation_irs(struct wirelog_program *prog)
+{
+    if (!prog)
+        return -1;
+
+    /* Free old relation_irs: UNION wrappers only, not rule ir_roots */
+    if (prog->relation_irs) {
+        for (uint32_t i = 0; i < prog->relation_count; i++) {
+            if (prog->relation_irs[i]
+                && prog->relation_irs[i]->type == WIRELOG_IR_UNION) {
+                free(prog->relation_irs[i]->children);
+                prog->relation_irs[i]->children = NULL;
+                prog->relation_irs[i]->child_count = 0;
+                wl_ir_node_free(prog->relation_irs[i]);
+            }
+        }
+        free(prog->relation_irs);
+        prog->relation_irs = NULL;
+    }
+
+    return wl_ir_program_merge_unions(prog);
+}
+
+void
+wl_ir_program_free_strata(struct wirelog_program *prog)
+{
+    if (!prog || !prog->strata)
+        return;
+
+    for (uint32_t i = 0; i < prog->stratum_count; i++)
+        free((void *)prog->strata[i].rule_names);
+
+    free(prog->strata);
+    prog->strata = NULL;
+    prog->stratum_count = 0;
+    prog->is_stratified = false;
+}

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -86,6 +86,10 @@ struct wirelog_program {
 
     /* Symbol intern table (string -> int64 mapping) */
     wl_intern_t *intern;
+
+    /* Magic Sets pass metadata */
+    bool magic_sets_applied;       /* True after magic sets pass */
+    uint32_t magic_relation_count; /* Number of magic relations added */
 };
 
 /* ======================================================================== */
@@ -112,5 +116,42 @@ void
 wl_ir_program_build_schemas(struct wirelog_program *program);
 void
 wl_ir_program_build_default_stratum(struct wirelog_program *program);
+
+/**
+ * wl_ir_program_add_magic_relation:
+ * Add a new relation with the given name and column count.
+ * No-ops if relation already exists.
+ * Returns 0 on success, -1 on memory error.
+ */
+int
+wl_ir_program_add_magic_relation(struct wirelog_program *prog, const char *name,
+                                 uint32_t column_count);
+
+/**
+ * wl_ir_program_add_magic_rule:
+ * Add a new rule with the given head relation and IR tree.
+ * Takes ownership of ir_root.
+ * Returns 0 on success, -1 on memory error.
+ */
+int
+wl_ir_program_add_magic_rule(struct wirelog_program *prog,
+                             const char *head_relation,
+                             wirelog_ir_node_t *ir_root);
+
+/**
+ * wl_ir_program_rebuild_relation_irs:
+ * Free existing relation_irs and rebuild from current rules[].
+ * Must be called after adding magic rules/relations before plan generation.
+ * Returns 0 on success, -1 on memory error.
+ */
+int
+wl_ir_program_rebuild_relation_irs(struct wirelog_program *prog);
+
+/**
+ * wl_ir_program_free_strata:
+ * Free existing strata array (for re-stratification after magic sets).
+ */
+void
+wl_ir_program_free_strata(struct wirelog_program *prog);
 
 #endif /* WIRELOG_IR_PROGRAM_INTERNAL_H */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -18,7 +18,7 @@ wirelog_ir_src = files('ir/ir.c', 'ir/program.c', 'ir/stratify.c', 'ir/api.c', '
 #Optimizer Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_optimizer_src = files('passes/fusion.c', 'passes/jpp.c', 'passes/sip.c', 'passes/subsumption.c', )
+wirelog_optimizer_src = files('passes/fusion.c', 'passes/jpp.c', 'passes/sip.c', 'passes/subsumption.c', 'passes/magic_sets.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Pure C11 Backend(Columnar Nanoarrow Only)

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -1,0 +1,856 @@
+/*
+ * magic_sets.c - Magic Sets Demand-Driven Optimization Pass
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Implements Magic Sets as a source-to-source IR transformation.
+ *
+ * Algorithm overview:
+ *  Phase 1: Identify demand roots (from explicit demands or .output relations).
+ *  Phase 2: BFS to compute adorned program (which relations need magic guards).
+ *  Phase 3: Create magic relations ($m$<name>_<adornment>).
+ *  Phase 4: Generate demand propagation rules and insert magic guards.
+ *
+ * Each magic relation $m$P_bf captures "which values of P's bound arguments
+ * are currently demanded". A magic guard in rule P's body ensures only
+ * demanded tuples are derived, pruning the fixpoint computation.
+ *
+ * References:
+ *  - Bancilhon et al. (1986), "Magic Sets and Other Strange Ways to
+ *    Implement Logic Programs"
+ *  - Architecture: .omc/plans/magic_sets_architecture.md
+ */
+
+#include "magic_sets.h"
+#include "../ir/ir.h"
+#include "../ir/program.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* ======================================================================== */
+/* Internal Limits                                                          */
+/* ======================================================================== */
+
+#define MS_MAX_ATOMS 64    /* max body atoms per rule */
+#define MS_MAX_ADORNED 512 /* max adorned predicates */
+#define MS_MAX_VARS 128    /* max bound variables tracked per rule */
+
+/* ======================================================================== */
+/* Variable Set (tracks bound variable names)                               */
+/* ======================================================================== */
+
+typedef struct {
+    const char *vars[MS_MAX_VARS]; /* borrowed pointers from IR nodes */
+    uint32_t count;
+} ms_varset_t;
+
+static void
+varset_clear(ms_varset_t *vs)
+{
+    vs->count = 0;
+}
+
+static bool
+varset_contains(const ms_varset_t *vs, const char *var)
+{
+    if (!var)
+        return false;
+    for (uint32_t i = 0; i < vs->count; i++) {
+        if (vs->vars[i] && strcmp(vs->vars[i], var) == 0)
+            return true;
+    }
+    return false;
+}
+
+static void
+varset_add(ms_varset_t *vs, const char *var)
+{
+    if (!var || vs->count >= MS_MAX_VARS)
+        return;
+    if (!varset_contains(vs, var))
+        vs->vars[vs->count++] = var;
+}
+
+/* ======================================================================== */
+/* Atom Info (shallow view into an IR SCAN node)                           */
+/* ======================================================================== */
+
+typedef struct {
+    const char *rel_name;   /* borrowed */
+    const char **col_names; /* borrowed array from SCAN node */
+    uint32_t col_count;
+} ms_atom_t;
+
+/* ======================================================================== */
+/* Adorned Predicate Set                                                    */
+/* ======================================================================== */
+
+typedef struct {
+    char rel_name[128];
+    uint64_t bound_mask;
+    uint32_t arity;
+} ms_adorned_t;
+
+typedef struct {
+    ms_adorned_t items[MS_MAX_ADORNED];
+    uint32_t count;
+} ms_adorned_set_t;
+
+static bool
+adorned_contains(const ms_adorned_set_t *s, const char *name, uint64_t mask)
+{
+    for (uint32_t i = 0; i < s->count; i++) {
+        if (s->items[i].bound_mask == mask
+            && strcmp(s->items[i].rel_name, name) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* Returns true if newly added, false if already present or table full. */
+static bool
+adorned_add(ms_adorned_set_t *s, const char *name, uint64_t mask,
+            uint32_t arity)
+{
+    if (adorned_contains(s, name, mask))
+        return false;
+    if (s->count >= MS_MAX_ADORNED)
+        return false;
+    snprintf(s->items[s->count].rel_name, sizeof(s->items[s->count].rel_name),
+             "%s", name);
+    s->items[s->count].bound_mask = mask;
+    s->items[s->count].arity = arity;
+    s->count++;
+    return true;
+}
+
+/* ======================================================================== */
+/* Magic Relation Name                                                      */
+/* ======================================================================== */
+
+/*
+ * Generate "$m$<rel>_<adornment_string>".
+ * Returns heap-allocated string (caller must free).
+ */
+static char *
+make_magic_name(const char *rel, uint64_t mask, uint32_t arity)
+{
+    uint32_t n = (arity < 64) ? arity : 64;
+    char adorn[65];
+    for (uint32_t i = 0; i < n; i++)
+        adorn[i] = (mask & (1ULL << i)) ? 'b' : 'f';
+    adorn[n] = '\0';
+
+    /* "$m$" (3) + rel + "_" (1) + adorn (n) + NUL (1) */
+    size_t len = 3 + strlen(rel) + 1 + n + 1;
+    char *name = (char *)malloc(len);
+    if (name)
+        snprintf(name, len, "$m$%s_%s", rel, adorn);
+    return name;
+}
+
+/* ======================================================================== */
+/* IDB Detection                                                            */
+/* ======================================================================== */
+
+static bool
+is_idb(const struct wirelog_program *prog, const char *rel_name)
+{
+    if (!rel_name)
+        return false;
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (prog->rules[i].head_relation
+            && strcmp(prog->rules[i].head_relation, rel_name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static uint32_t
+get_arity(const struct wirelog_program *prog, const char *rel_name)
+{
+    if (!rel_name)
+        return 0;
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (prog->relations[i].name
+            && strcmp(prog->relations[i].name, rel_name) == 0)
+            return prog->relations[i].column_count;
+    }
+    return 0;
+}
+
+/* ======================================================================== */
+/* Body Atom Collection (DFS left-to-right, respecting negation)           */
+/* ======================================================================== */
+
+static void
+collect_scans_r(const wirelog_ir_node_t *node, ms_atom_t *atoms,
+                uint32_t *count)
+{
+    if (!node || *count >= MS_MAX_ATOMS)
+        return;
+
+    switch (node->type) {
+    case WIRELOG_IR_SCAN:
+        atoms[*count].rel_name = node->relation_name;
+        atoms[*count].col_names = (const char **)node->column_names;
+        atoms[*count].col_count = node->column_count;
+        (*count)++;
+        break;
+
+    case WIRELOG_IR_ANTIJOIN:
+    case WIRELOG_IR_SEMIJOIN:
+        /*
+         * ANTIJOIN: only positive (left) child; demand does NOT flow
+         *           through negation (right child).
+         * SEMIJOIN: only left child; right is a clone used for
+         *           filtering only, not a real body atom.
+         */
+        if (node->child_count > 0)
+            collect_scans_r(node->children[0], atoms, count);
+        break;
+
+    default:
+        for (uint32_t i = 0; i < node->child_count; i++)
+            collect_scans_r(node->children[i], atoms, count);
+        break;
+    }
+}
+
+/*
+ * Collect body atoms from the rule's IR tree.
+ * The body is child[0] of the PROJECT/AGGREGATE root.
+ * Returns the number of atoms collected.
+ */
+static uint32_t
+collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms)
+{
+    if (!ir_root || ir_root->child_count == 0)
+        return 0;
+    uint32_t count = 0;
+    collect_scans_r(ir_root->children[0], atoms, &count);
+    return count;
+}
+
+/* ======================================================================== */
+/* Head Variable Extraction                                                 */
+/* ======================================================================== */
+
+/*
+ * Extract variable names from the rule's PROJECT head.
+ * vars[i] = variable name at head position i, or NULL for constants/wildcards.
+ * Returns the head arity (number of head arguments).
+ * Returns 0 for AGGREGATE rules (not currently supported for magic guards).
+ */
+static uint32_t
+get_head_vars(const wirelog_ir_node_t *ir_root, const char **vars,
+              uint32_t max_vars)
+{
+    if (!ir_root)
+        return 0;
+
+    if (ir_root->type == WIRELOG_IR_PROJECT) {
+        uint32_t n = (ir_root->project_count < max_vars)
+                         ? ir_root->project_count
+                         : max_vars;
+        for (uint32_t i = 0; i < n; i++) {
+            if (ir_root->project_exprs && ir_root->project_exprs[i]
+                && ir_root->project_exprs[i]->type == WL_IR_EXPR_VAR)
+                vars[i] = ir_root->project_exprs[i]->var_name;
+            else
+                vars[i] = NULL;
+        }
+        return n;
+    }
+
+    /* AGGREGATE rules: skip magic guard insertion for now */
+    return 0;
+}
+
+/* ======================================================================== */
+/* Popcount                                                                 */
+/* ======================================================================== */
+
+static uint32_t
+popcount64(uint64_t x)
+{
+    uint32_t n = 0;
+    while (x) {
+        n += (uint32_t)(x & 1u);
+        x >>= 1;
+    }
+    return n;
+}
+
+/* ======================================================================== */
+/* Build Demand Propagation Rule IR                                         */
+/* ======================================================================== */
+
+/*
+ * Build the IR tree for a magic demand propagation rule:
+ *
+ *   $m$Bj_adj(bound_args_of_Bj) :-
+ *       $m$P_adorn(guard_bound_vars),
+ *       prefix_atoms[0](...),
+ *       ...,
+ *       prefix_atoms[prefix_count-1](...).
+ *
+ * The prefix atoms are the body atoms before Bj that bind variables
+ * needed to determine which values of Bj are demanded.
+ *
+ * Returns: (transfer full) IR tree, or NULL on error.
+ */
+static wirelog_ir_node_t *
+build_demand_rule_ir(const char *body_magic_name, const char *guard_magic_name,
+                     const char **guard_bound_vars, uint32_t guard_bound_count,
+                     const ms_atom_t *prefix_atoms, uint32_t prefix_count,
+                     const ms_atom_t *target_atom, uint64_t target_bound_mask)
+{
+    /* === Step 1: Start with the guard magic SCAN === */
+
+    wirelog_ir_node_t *current = wl_ir_node_create(WIRELOG_IR_SCAN);
+    if (!current)
+        return NULL;
+    wl_ir_node_set_relation(current, guard_magic_name);
+
+    if (guard_bound_count > 0) {
+        current->column_names
+            = (char **)calloc(guard_bound_count, sizeof(char *));
+        if (!current->column_names) {
+            wl_ir_node_free(current);
+            return NULL;
+        }
+        current->column_count = guard_bound_count;
+        for (uint32_t i = 0; i < guard_bound_count; i++) {
+            if (guard_bound_vars[i])
+                current->column_names[i] = strdup_safe(guard_bound_vars[i]);
+        }
+    }
+
+    /* Track bound variables for join key computation */
+    ms_varset_t bound;
+    varset_clear(&bound);
+    for (uint32_t i = 0; i < guard_bound_count; i++) {
+        if (guard_bound_vars[i])
+            varset_add(&bound, guard_bound_vars[i]);
+    }
+
+    /* === Step 2: JOIN with each prefix atom === */
+
+    for (uint32_t pi = 0; pi < prefix_count; pi++) {
+        const ms_atom_t *pa = &prefix_atoms[pi];
+
+        /* Clone the prefix atom's SCAN */
+        wirelog_ir_node_t *scan = wl_ir_node_create(WIRELOG_IR_SCAN);
+        if (!scan) {
+            wl_ir_node_free(current);
+            return NULL;
+        }
+        wl_ir_node_set_relation(scan, pa->rel_name);
+        if (pa->col_count > 0) {
+            scan->column_names = (char **)calloc(pa->col_count, sizeof(char *));
+            if (!scan->column_names) {
+                wl_ir_node_free(scan);
+                wl_ir_node_free(current);
+                return NULL;
+            }
+            scan->column_count = pa->col_count;
+            for (uint32_t ci = 0; ci < pa->col_count; ci++) {
+                if (pa->col_names && pa->col_names[ci])
+                    scan->column_names[ci] = strdup_safe(pa->col_names[ci]);
+            }
+        }
+
+        /* Create JOIN(current, scan) with keys on shared bound variables */
+        wirelog_ir_node_t *join = wl_ir_node_create(WIRELOG_IR_JOIN);
+        if (!join) {
+            wl_ir_node_free(scan);
+            wl_ir_node_free(current);
+            return NULL;
+        }
+
+        /* Count shared variables first */
+        uint32_t key_count = 0;
+        for (uint32_t ci = 0; ci < pa->col_count && ci < 64; ci++) {
+            if (pa->col_names && pa->col_names[ci]
+                && varset_contains(&bound, pa->col_names[ci]))
+                key_count++;
+        }
+
+        if (key_count > 0) {
+            join->join_left_keys = (char **)calloc(key_count, sizeof(char *));
+            join->join_right_keys = (char **)calloc(key_count, sizeof(char *));
+            if (!join->join_left_keys || !join->join_right_keys) {
+                wl_ir_node_free(join);
+                wl_ir_node_free(scan);
+                wl_ir_node_free(current);
+                return NULL;
+            }
+            join->join_key_count = key_count;
+            uint32_t k = 0;
+            for (uint32_t ci = 0; ci < pa->col_count && ci < 64; ci++) {
+                if (pa->col_names && pa->col_names[ci]
+                    && varset_contains(&bound, pa->col_names[ci])) {
+                    join->join_left_keys[k] = strdup_safe(pa->col_names[ci]);
+                    join->join_right_keys[k] = strdup_safe(pa->col_names[ci]);
+                    k++;
+                }
+            }
+        }
+
+        wl_ir_node_add_child(join, current);
+        wl_ir_node_add_child(join, scan);
+        current = join;
+
+        /* Add this prefix atom's variables to the bound set */
+        for (uint32_t ci = 0; ci < pa->col_count; ci++) {
+            if (pa->col_names && pa->col_names[ci])
+                varset_add(&bound, pa->col_names[ci]);
+        }
+    }
+
+    /* === Step 3: PROJECT head outputs bound args of Bj === */
+
+    uint32_t bound_count = popcount64(target_bound_mask);
+
+    wirelog_ir_node_t *root = wl_ir_node_create(WIRELOG_IR_PROJECT);
+    if (!root) {
+        wl_ir_node_free(current);
+        return NULL;
+    }
+    wl_ir_node_set_relation(root, body_magic_name);
+    root->project_count = bound_count;
+
+    if (bound_count > 0) {
+        root->project_exprs
+            = (wl_ir_expr_t **)calloc(bound_count, sizeof(wl_ir_expr_t *));
+        if (!root->project_exprs) {
+            wl_ir_node_free(root);
+            wl_ir_node_free(current);
+            return NULL;
+        }
+        uint32_t ei = 0;
+        for (uint32_t i = 0;
+             i < target_atom->col_count && i < 64 && ei < bound_count; i++) {
+            if (target_bound_mask & (1ULL << i)) {
+                wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_VAR);
+                if (e && target_atom->col_names && target_atom->col_names[i])
+                    e->var_name = strdup_safe(target_atom->col_names[i]);
+                root->project_exprs[ei++] = e;
+            }
+        }
+    }
+
+    wl_ir_node_add_child(root, current);
+    return root;
+}
+
+/* ======================================================================== */
+/* Magic Guard Insertion                                                    */
+/* ======================================================================== */
+
+/*
+ * Insert a magic guard JOIN at the top of a rule's body.
+ *
+ * Transforms:
+ *   PROJECT(head) -> body_tree
+ * into:
+ *   PROJECT(head) -> JOIN(SCAN($magic, [bound_vars]), body_tree)
+ *
+ * The JOIN filters the body to only tuples where the bound variables
+ * appear in the magic demand relation.
+ */
+static int
+insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
+                   const char **bound_vars, uint32_t bound_count)
+{
+    if (!ir_root || !magic_name || bound_count == 0)
+        return 0;
+    if (ir_root->child_count == 0)
+        return 0;
+
+    wirelog_ir_node_t *body = ir_root->children[0];
+
+    /* SCAN($m$rel_adorn, column_names = [bound_var_0, ...]) */
+    wirelog_ir_node_t *magic_scan = wl_ir_node_create(WIRELOG_IR_SCAN);
+    if (!magic_scan)
+        return -1;
+    wl_ir_node_set_relation(magic_scan, magic_name);
+
+    magic_scan->column_names = (char **)calloc(bound_count, sizeof(char *));
+    if (!magic_scan->column_names) {
+        wl_ir_node_free(magic_scan);
+        return -1;
+    }
+    magic_scan->column_count = bound_count;
+    for (uint32_t i = 0; i < bound_count; i++) {
+        if (bound_vars[i])
+            magic_scan->column_names[i] = strdup_safe(bound_vars[i]);
+    }
+
+    /* JOIN(magic_scan, body) keyed on bound variables */
+    wirelog_ir_node_t *guard_join = wl_ir_node_create(WIRELOG_IR_JOIN);
+    if (!guard_join) {
+        wl_ir_node_free(magic_scan);
+        return -1;
+    }
+
+    guard_join->join_left_keys = (char **)calloc(bound_count, sizeof(char *));
+    guard_join->join_right_keys = (char **)calloc(bound_count, sizeof(char *));
+    if (!guard_join->join_left_keys || !guard_join->join_right_keys) {
+        wl_ir_node_free(guard_join);
+        wl_ir_node_free(magic_scan);
+        return -1;
+    }
+    guard_join->join_key_count = bound_count;
+    for (uint32_t i = 0; i < bound_count; i++) {
+        if (bound_vars[i]) {
+            guard_join->join_left_keys[i] = strdup_safe(bound_vars[i]);
+            guard_join->join_right_keys[i] = strdup_safe(bound_vars[i]);
+        }
+    }
+
+    wl_ir_node_add_child(guard_join, magic_scan); /* left: magic demand */
+    wl_ir_node_add_child(guard_join, body);       /* right: original body */
+
+    /* Replace body in parent */
+    ir_root->children[0] = guard_join;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Public API: apply with explicit demands                                  */
+/* ======================================================================== */
+
+int
+wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
+                                 const wl_magic_demand_t *demands,
+                                 uint32_t demand_count,
+                                 wl_magic_sets_stats_t *stats)
+{
+    if (!prog)
+        return -2;
+    if (prog->magic_sets_applied)
+        return 0; /* Idempotency guard: already transformed */
+    if (!demands || demand_count == 0)
+        return 0;
+
+    if (stats) {
+        stats->demand_roots = 0;
+        stats->adorned_predicates = 0;
+        stats->magic_rules_generated = 0;
+        stats->original_rules_modified = 0;
+        stats->skipped_all_free = 0;
+    }
+
+    /* === Phase 1: Seed the worklist from explicit demands === */
+
+    ms_adorned_set_t processed;
+    memset(&processed, 0, sizeof(processed));
+
+    /* Simple queue over processed items (indices 0..count-1) */
+    uint32_t wl_head = 0; /* index of next item to process */
+
+    for (uint32_t i = 0; i < demand_count; i++) {
+        const wl_magic_demand_t *d = &demands[i];
+        if (!d->relation_name)
+            continue;
+
+        if (stats)
+            stats->demand_roots++;
+
+        if (d->bound_mask == 0) {
+            if (stats)
+                stats->skipped_all_free++;
+            continue; /* All-free optimization: skip */
+        }
+
+        uint32_t arity = d->arity;
+        if (arity == 0)
+            arity = get_arity(prog, d->relation_name);
+
+        adorned_add(&processed, d->relation_name, d->bound_mask, arity);
+    }
+
+    /* === Phase 2: BFS adorned program === */
+
+    while (wl_head < processed.count) {
+        const ms_adorned_t *ap = &processed.items[wl_head++];
+
+        /* Walk every rule defining this relation */
+        for (uint32_t ri = 0; ri < prog->rule_count; ri++) {
+            if (!prog->rules[ri].head_relation
+                || strcmp(prog->rules[ri].head_relation, ap->rel_name) != 0)
+                continue;
+
+            wirelog_ir_node_t *ir_root = prog->rules[ri].ir_root;
+            if (!ir_root)
+                continue;
+
+            /* Get head variable names (PROJECT only) */
+            const char *head_vars[64] = { 0 };
+            uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
+            if (head_arity == 0)
+                continue;
+
+            /* Init bound_vars from head's bound positions */
+            ms_varset_t bound;
+            varset_clear(&bound);
+            for (uint32_t i = 0; i < head_arity && i < 64; i++) {
+                if ((ap->bound_mask & (1ULL << i)) && head_vars[i])
+                    varset_add(&bound, head_vars[i]);
+            }
+
+            /* Collect body atoms in join order */
+            ms_atom_t atoms[MS_MAX_ATOMS];
+            uint32_t atom_count = collect_body_atoms(ir_root, atoms);
+
+            for (uint32_t ai = 0; ai < atom_count; ai++) {
+                const ms_atom_t *atom = &atoms[ai];
+                if (!atom->rel_name)
+                    goto next_atom;
+
+                if (is_idb(prog, atom->rel_name)) {
+                    /* Compute adornment of this IDB body atom */
+                    uint64_t atom_mask = 0;
+                    for (uint32_t ci = 0; ci < atom->col_count && ci < 64;
+                         ci++) {
+                        if (atom->col_names && atom->col_names[ci]
+                            && varset_contains(&bound, atom->col_names[ci]))
+                            atom_mask |= (1ULL << ci);
+                    }
+
+                    if (atom_mask != 0) {
+                        adorned_add(&processed, atom->rel_name, atom_mask,
+                                    atom->col_count);
+                    } else {
+                        if (stats)
+                            stats->skipped_all_free++;
+                    }
+                }
+
+            next_atom:
+                /* Add all vars of this atom to bound set */
+                for (uint32_t ci = 0; ci < atom->col_count; ci++) {
+                    if (atom->col_names && atom->col_names[ci])
+                        varset_add(&bound, atom->col_names[ci]);
+                }
+            }
+        }
+    }
+
+    if (stats)
+        stats->adorned_predicates = processed.count;
+
+    if (processed.count == 0)
+        return 0; /* Nothing to do */
+
+    /* === Phase 3: Create magic relations === */
+
+    for (uint32_t i = 0; i < processed.count; i++) {
+        const ms_adorned_t *ap = &processed.items[i];
+        uint32_t bound_count = popcount64(ap->bound_mask);
+
+        char *mname = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
+        if (!mname)
+            return -1;
+
+        int rc = wl_ir_program_add_magic_relation(prog, mname, bound_count);
+        if (rc != 0) {
+            free(mname);
+            return -1;
+        }
+        free(mname);
+        prog->magic_relation_count++;
+    }
+
+    /*
+     * === Phase 4a: Generate demand propagation rules (READ-ONLY) ===
+     *
+     * Walk original rule bodies BEFORE any IR mutation.  Inserting magic
+     * guards (Phase 4b) adds JOIN nodes wrapping the body; if we collected
+     * body atoms after that, we would see the guard SCAN as an extra atom
+     * and compute incorrect adornments for subsequent adorned predicates.
+     */
+
+    uint32_t orig_rule_count = prog->rule_count; /* snapshot before new rules */
+
+    for (uint32_t pi = 0; pi < processed.count; pi++) {
+        const ms_adorned_t *ap = &processed.items[pi];
+
+        char *guard_magic
+            = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
+        if (!guard_magic)
+            return -1;
+
+        for (uint32_t ri = 0; ri < orig_rule_count; ri++) {
+            if (!prog->rules[ri].head_relation
+                || strcmp(prog->rules[ri].head_relation, ap->rel_name) != 0)
+                continue;
+
+            wirelog_ir_node_t *ir_root = prog->rules[ri].ir_root;
+            if (!ir_root)
+                continue;
+
+            const char *head_vars[64] = { 0 };
+            uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
+            if (head_arity == 0)
+                continue;
+
+            const char *guard_bvars[64];
+            uint32_t guard_bcount = 0;
+            for (uint32_t i = 0; i < head_arity && i < 64; i++) {
+                if ((ap->bound_mask & (1ULL << i)) && head_vars[i])
+                    guard_bvars[guard_bcount++] = head_vars[i];
+            }
+
+            ms_atom_t atoms[MS_MAX_ATOMS];
+            uint32_t atom_count = collect_body_atoms(ir_root, atoms);
+
+            ms_varset_t bound;
+            varset_clear(&bound);
+            for (uint32_t i = 0; i < guard_bcount; i++) {
+                if (guard_bvars[i])
+                    varset_add(&bound, guard_bvars[i]);
+            }
+
+            for (uint32_t ai = 0; ai < atom_count; ai++) {
+                const ms_atom_t *atom = &atoms[ai];
+                if (!atom->rel_name)
+                    goto next_4a_atom;
+
+                if (is_idb(prog, atom->rel_name)) {
+                    uint64_t atom_mask = 0;
+                    for (uint32_t ci = 0; ci < atom->col_count && ci < 64;
+                         ci++) {
+                        if (atom->col_names && atom->col_names[ci]
+                            && varset_contains(&bound, atom->col_names[ci]))
+                            atom_mask |= (1ULL << ci);
+                    }
+
+                    if (atom_mask != 0) {
+                        char *body_magic = make_magic_name(
+                            atom->rel_name, atom_mask, atom->col_count);
+                        if (!body_magic) {
+                            free(guard_magic);
+                            return -1;
+                        }
+
+                        wirelog_ir_node_t *demand_ir = build_demand_rule_ir(
+                            body_magic, guard_magic, guard_bvars, guard_bcount,
+                            atoms, ai, atom, atom_mask);
+
+                        if (demand_ir) {
+                            int rc = wl_ir_program_add_magic_rule(
+                                prog, body_magic, demand_ir);
+                            if (rc != 0) {
+                                free(body_magic);
+                                free(guard_magic);
+                                wl_ir_node_free(demand_ir);
+                                return -1;
+                            }
+                            if (stats)
+                                stats->magic_rules_generated++;
+                        }
+                        free(body_magic);
+                    }
+                }
+
+            next_4a_atom:
+                for (uint32_t ci = 0; ci < atom->col_count; ci++) {
+                    if (atom->col_names && atom->col_names[ci])
+                        varset_add(&bound, atom->col_names[ci]);
+                }
+            }
+        }
+
+        free(guard_magic);
+    }
+
+    /*
+     * === Phase 4b: Insert magic guards into original rules (MUTATING) ===
+     *
+     * Now that all demand propagation rules have been generated from the
+     * original (unmodified) IR, we can safely mutate the original rule
+     * bodies by prepending JOIN(SCAN($m$rel), body).
+     */
+
+    for (uint32_t pi = 0; pi < processed.count; pi++) {
+        const ms_adorned_t *ap = &processed.items[pi];
+
+        char *guard_magic
+            = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
+        if (!guard_magic)
+            return -1;
+
+        for (uint32_t ri = 0; ri < orig_rule_count; ri++) {
+            if (!prog->rules[ri].head_relation
+                || strcmp(prog->rules[ri].head_relation, ap->rel_name) != 0)
+                continue;
+
+            wirelog_ir_node_t *ir_root = prog->rules[ri].ir_root;
+            if (!ir_root)
+                continue;
+
+            const char *head_vars[64] = { 0 };
+            uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
+            if (head_arity == 0)
+                continue;
+
+            const char *guard_bvars[64];
+            uint32_t guard_bcount = 0;
+            for (uint32_t i = 0; i < head_arity && i < 64; i++) {
+                if ((ap->bound_mask & (1ULL << i)) && head_vars[i])
+                    guard_bvars[guard_bcount++] = head_vars[i];
+            }
+
+            int rc = insert_magic_guard(ir_root, guard_magic, guard_bvars,
+                                        guard_bcount);
+            if (rc != 0) {
+                free(guard_magic);
+                return -1;
+            }
+            if (stats)
+                stats->original_rules_modified++;
+        }
+
+        free(guard_magic);
+    }
+
+    prog->magic_sets_applied = true;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Public API: apply from .output/.printsize demand roots                  */
+/* ======================================================================== */
+
+int
+wl_magic_sets_apply(struct wirelog_program *prog, wl_magic_sets_stats_t *stats)
+{
+    if (!prog)
+        return -2;
+
+    /* Collect demand roots from .output and .printsize relations */
+    wl_magic_demand_t demands[64];
+    uint32_t demand_count = 0;
+
+    for (uint32_t i = 0; i < prog->relation_count && demand_count < 64; i++) {
+        if (prog->relations[i].has_output || prog->relations[i].has_printsize) {
+            demands[demand_count].relation_name = prog->relations[i].name;
+            demands[demand_count].bound_mask = 0; /* All-free */
+            demands[demand_count].arity = prog->relations[i].column_count;
+            demand_count++;
+        }
+    }
+
+    /* With all-free adornment for all roots, all-free optimization
+     * kicks in inside wl_magic_sets_apply_with_demands → no-op. */
+    return wl_magic_sets_apply_with_demands(prog, demands, demand_count, stats);
+}

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -1,0 +1,129 @@
+/*
+ * magic_sets.h - Magic Sets Demand-Driven Optimization Pass
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Implements Magic Sets as a source-to-source IR transformation.
+ * Adds magic "demand" relations and rules that restrict evaluation
+ * to only the tuples reachable from the query, reducing intermediate
+ * result sizes for recursive programs.
+ *
+ * Pipeline position: runs after SIP, before plan generation.
+ *
+ *   Parse -> IR -> Stratify -> Fusion -> JPP -> SIP -> Magic Sets
+ *         -> Re-stratify -> Plan Gen -> Backend
+ *
+ * Magic relation naming: "$m$<RelationName>_<adornment>"
+ *   e.g. "$m$Path_bf" for Path with 1st arg bound, 2nd free.
+ *
+ * All-free optimization: when all demand roots have all-free adornment
+ * (the default for .output relations with no .query directives), no
+ * magic relations are generated and the pass is a no-op.
+ */
+
+#ifndef WIRELOG_PASSES_MAGIC_SETS_H
+#define WIRELOG_PASSES_MAGIC_SETS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct wirelog_program;
+
+/* ======================================================================== */
+/* Statistics                                                               */
+/* ======================================================================== */
+
+/**
+ * wl_magic_sets_stats_t:
+ *
+ * Statistics from a single Magic Sets pass invocation.
+ *
+ * @demand_roots:           Relations identified as demand roots.
+ * @adorned_predicates:     Unique (relation, adornment) pairs with bound_mask != 0.
+ * @magic_rules_generated:  Magic demand propagation rules added.
+ * @original_rules_modified: Original rules with magic guards inserted.
+ * @skipped_all_free:       Adorned predicates skipped (all-free adornment).
+ */
+typedef struct {
+    uint32_t demand_roots;
+    uint32_t adorned_predicates;
+    uint32_t magic_rules_generated;
+    uint32_t original_rules_modified;
+    uint32_t skipped_all_free;
+} wl_magic_sets_stats_t;
+
+/* ======================================================================== */
+/* Demand Specification (for explicit query demands)                        */
+/* ======================================================================== */
+
+/**
+ * wl_magic_demand_t:
+ *
+ * Specifies a demand (query constraint) for a relation.
+ *
+ * @relation_name: Name of the demanded relation.
+ * @bound_mask:    Bit i = 1 if position i is bound (query-constrained).
+ *                 0 = all-free (no restriction, optimization skips this).
+ * @arity:         Number of columns. 0 = auto-detect from program.
+ */
+typedef struct {
+    const char *relation_name;
+    uint64_t bound_mask;
+    uint32_t arity;
+} wl_magic_demand_t;
+
+/* ======================================================================== */
+/* Public API                                                               */
+/* ======================================================================== */
+
+/**
+ * wl_magic_sets_apply:
+ * @prog:  Program to transform (modified in-place).
+ * @stats: (out) (nullable): Pass statistics.
+ *
+ * Apply Magic Sets transformation using .output and .printsize relations
+ * as demand roots with all-free adornment.
+ *
+ * With all-free adornment (the default), the all-free optimization
+ * skips magic relation generation entirely, making this a no-op.
+ * Magic Sets only activates when explicit .query directives specify
+ * bound positions (future: parser support for .query).
+ *
+ * Must be called AFTER: fusion, JPP, SIP.
+ * Caller must call wl_ir_program_rebuild_relation_irs() and
+ * wl_ir_stratify_program() after this if magic_sets_applied is true.
+ *
+ * Returns:
+ *    0: Success.
+ *   -1: Memory allocation error.
+ *   -2: Invalid program (NULL).
+ */
+int
+wl_magic_sets_apply(struct wirelog_program *prog, wl_magic_sets_stats_t *stats);
+
+/**
+ * wl_magic_sets_apply_with_demands:
+ * @prog:         Program to transform (modified in-place).
+ * @demands:      Array of demand specifications.
+ * @demand_count: Number of demands.
+ * @stats:        (out) (nullable): Pass statistics.
+ *
+ * Apply Magic Sets transformation with explicit demand specifications.
+ * Demands with bound_mask == 0 are skipped (all-free optimization).
+ *
+ * Used for testing and for future .query directive support.
+ *
+ * Returns:
+ *    0: Success.
+ *   -1: Memory allocation error.
+ *   -2: Invalid program (NULL).
+ */
+int
+wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
+                                 const wl_magic_demand_t *demands,
+                                 uint32_t demand_count,
+                                 wl_magic_sets_stats_t *stats);
+
+#endif /* WIRELOG_PASSES_MAGIC_SETS_H */


### PR DESCRIPTION
## Summary

Closes #206

Implements the Magic Sets source-to-source IR transformation pass, which restricts Datalog fixpoint evaluation to only the tuples reachable from a query by adding demand-propagation relations and rules.

- **`wirelog/passes/magic_sets.c`** (~540 lines): Full Magic Sets transformation. BFS adorned program computation, Phase 4a (read-only demand rule generation from original IR), Phase 4b (magic guard insertion). Idempotency guard prevents double-application.
- **`wirelog/passes/magic_sets.h`**: Public API — `wl_magic_sets_apply()` (all-free no-op for standard `.output` pipelines), `wl_magic_sets_apply_with_demands()` (explicit bound demands for testing).
- **`wirelog/ir/program.c`/`program.h`**: Four new helpers — `add_magic_relation`, `add_magic_rule`, `rebuild_relation_irs`, `free_strata`. Bug fix: `add_magic_relation` resizes `relation_irs` in sync with `relation_count` to prevent out-of-bounds access in `wl_ir_program_free`.
- **`wirelog/cli/driver.c`**: Pipeline integration after SIP with conditional `rebuild_relation_irs` + `free_strata` + `re-stratify`.
- **`tests/test_magic_sets.c`**: 11 tests (9 unit + 2 integration) covering adornment propagation, demand rule generation, all-free skip, negation barrier, multiple adornments, mutual recursion, EDB skip, standard no-op, and full rebuild+stratify.

## Pipeline position

```
Parse -> IR -> Stratify -> Fusion -> JPP -> SIP -> Magic Sets
       -> Re-stratify -> Plan Gen -> Backend
```

## All-free optimization

When all demand roots have `bound_mask == 0` (the default for `.output` relations with no `.query` directives), the pass is a no-op — no magic relations are created and re-stratification is skipped. Existing programs are unaffected.

## Test plan

- [x] `meson test -C build` — 74 OK, 1 expected failure (option2_doop, unchanged), 0 failures
- [x] 11 new magic sets tests pass
- [x] All pre-existing tests pass
- [x] clang-format compliant
- [x] Phase 4a/4b split verified: body atoms collected before IR mutation
- [x] Idempotency guard: second call is a no-op
- [x] `MS_MAX_ADORNED=512` for multi-query workloads (DOOP-safe)