### PR TITLE
fix(ci): lint-pr uncrustify job fails to detect changed files

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install uncrustify
         run: |


### PR DESCRIPTION
## Summary
- The uncrustify-check job in lint-pr.yml used a shallow clone (`fetch-depth: 1` default), so `origin/main` was not available
- `git diff origin/main...HEAD` failed silently (swallowed by `|| true`), resulting in `CHANGED_FILES` always being empty
- Added `fetch-depth: 0` to the checkout step so the full history is available for the diff

## Test plan
- [ ] Verify the lint-pr workflow correctly detects changed C/H files on a PR with formatting changes
- [ ] Confirm uncrustify check runs against the detected files instead of skipping