### PR TITLE
fix(#292): add missing -f flag to uncrustify pre-commit hook

### DIFF
--- a/scripts/setup_uncrustify_hook.py
+++ b/scripts/setup_uncrustify_hook.py
@@ -80,7 +80,7 @@ FORMATTED_FILES=0
 for file in $STAGED_FILES; do
     if [ -f "$file" ]; then
         # Create temp formatted version
-        uncrustify -c "$UNCRUSTIFY_CONFIG" "$file" > /tmp/uncrustify_formatted.tmp 2>/dev/null
+        uncrustify -c "$UNCRUSTIFY_CONFIG" -f "$file" > /tmp/uncrustify_formatted.tmp 2>/dev/null
 
         # Check if formatting changed
         if ! diff -q "$file" /tmp/uncrustify_formatted.tmp > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Fix `setup_uncrustify_hook.py` to use `uncrustify -f` flag for stdin-to-stdout mode
- Without `-f`, uncrustify writes to a `.uncrustify` suffix file instead of stdout, leaving the temp file empty
- The hook then `cp`s the empty file over the source, silently destroying file contents on commit

Closes #292

## Test plan

- [ ] Run `uncrustify -c uncrustify.cfg -f <file>` and verify stdout output matches file line count
- [ ] Stage a C file, commit, and verify file contents are preserved
- [ ] Re-run `scripts/setup_uncrustify_hook.py` and verify the regenerated hook contains `-f`