### PR TITLE
feat: Optimize col_rel_append_all with bulk memcpy and arena allocation

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -217,7 +217,8 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                         sess->delta_pool, rp->name, result.rel);
                     if (!copy)
                         return ENOMEM;
-                    if ((rc = col_rel_append_all(copy, result.rel)) != 0) {
+                    if ((rc = col_rel_append_all(copy, result.rel,
+                        sess->eval_arena)) != 0) {
                         col_rel_destroy(copy);
                         return rc;
                     }
@@ -229,7 +230,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                 }
             } else {
                 /* Append new results to existing relation */
-                rc = col_rel_append_all(target, result.rel);
+                rc = col_rel_append_all(target, result.rel, sess->eval_arena);
                 if (result.owned)
                     col_rel_destroy(result.rel);
                 if (rc != 0)
@@ -558,7 +559,8 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                             outer_rc = ENOMEM;
                             goto stride_error;
                         }
-                        if ((rc = col_rel_append_all(copy, result.rel)) != 0) {
+                        if ((rc = col_rel_append_all(copy, result.rel,
+                            sess->eval_arena)) != 0) {
                             col_rel_destroy(copy);
                             outer_rc = rc;
                             goto stride_error;
@@ -583,7 +585,8 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                             goto stride_error;
                         }
                     }
-                    rc = col_rel_append_all(target, result.rel);
+                    rc = col_rel_append_all(target, result.rel,
+                            sess->eval_arena);
                     if (result.owned)
                         col_rel_destroy(result.rel);
                     if (rc != 0) {

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -573,7 +573,7 @@ col_rel_alloc(col_rel_t **out, const char *name);
 int
 col_rel_append_row(col_rel_t *r, const int64_t *row);
 int
-col_rel_append_all(col_rel_t *dst, const col_rel_t *src);
+col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena);
 int
 col_rel_col_idx(const col_rel_t *r, const char *name);
 col_rel_t *

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2362,9 +2362,9 @@ col_op_concat(eval_stack_t *stack, wl_col_session_t *sess)
         return ENOMEM;
     }
 
-    int rc = col_rel_append_all(out, a);
+    int rc = col_rel_append_all(out, a, NULL);
     if (rc == 0)
-        rc = col_rel_append_all(out, b);
+        rc = col_rel_append_all(out, b, NULL);
 
     if (rc != 0) {
         if (a_e.seg_boundaries)
@@ -2922,7 +2922,7 @@ col_op_consolidate(eval_stack_t *stack, wl_col_session_t *sess)
                 free(e.seg_boundaries);
             return ENOMEM;
         }
-        if (col_rel_append_all(work, in) != 0) {
+        if (col_rel_append_all(work, in, NULL) != 0) {
             col_rel_destroy(work);
             if (e.seg_boundaries)
                 free(e.seg_boundaries);
@@ -4818,7 +4818,7 @@ col_op_consolidate_diff(eval_stack_t *stack, wl_col_session_t *sess)
                 free(e.seg_boundaries);
             return ENOMEM;
         }
-        if (col_rel_append_all(work, in) != 0) {
+        if (col_rel_append_all(work, in, NULL) != 0) {
             col_rel_destroy(work);
             if (e.seg_boundaries)
                 free(e.seg_boundaries);

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -197,21 +197,82 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
 }
 
 /* Copy all rows from src into dst (must have same ncols).
-* If src has timestamps and dst has timestamp tracking enabled, the source
-* timestamps are propagated to the newly appended rows. */
+ * If src has timestamps and dst has timestamp tracking enabled, the source
+ * timestamps are propagated to the newly appended rows.
+ * Optimized (Issue #300): bulk memcpy instead of per-row append. */
 int
-col_rel_append_all(col_rel_t *dst, const col_rel_t *src)
+col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
 {
+    if (src->nrows == 0)
+        return 0;
+
     uint32_t dst_base = dst->nrows;
-    for (uint32_t i = 0; i < src->nrows; i++) {
-        int rc = col_rel_append_row(dst, src->data + (size_t)i * src->ncols);
-        if (rc != 0)
-            return rc;
+    uint32_t new_nrows = dst->nrows + src->nrows;
+
+    /* Ensure dst has sufficient capacity */
+    if (new_nrows > dst->capacity) {
+        uint32_t new_cap = dst->capacity ? dst->capacity * 2 : COL_REL_INIT_CAP;
+        while (new_cap < new_nrows) {
+            uint32_t next_cap = new_cap * 2;
+            if (next_cap <= new_cap) /* overflow guard */
+                return ENOMEM;
+            new_cap = next_cap;
+        }
+
+        /* Grow timestamps first (if tracking) */
+        if (dst->timestamps) {
+            col_delta_timestamp_t *new_ts = (col_delta_timestamp_t *)realloc(
+                dst->timestamps, new_cap * sizeof(col_delta_timestamp_t));
+            if (!new_ts)
+                return ENOMEM;
+            dst->timestamps = new_ts;
+        }
+
+        int64_t *nd;
+        if (dst->arena_owned) {
+            /* Arena data: allocate from same arena, preserve arena_owned flag */
+            size_t data_bytes = (size_t)new_cap * dst->ncols * sizeof(int64_t);
+            if (arena) {
+                nd = (int64_t *)wl_arena_alloc(arena, data_bytes);
+                if (!nd)
+                    return ENOMEM;
+            } else {
+                /* Fallback to heap if arena unavailable */
+                nd = (int64_t *)malloc(data_bytes);
+                if (!nd)
+                    return ENOMEM;
+                dst->arena_owned = false;
+            }
+            memcpy(nd, dst->data,
+                sizeof(int64_t) * (size_t)dst->nrows * dst->ncols);
+        } else {
+            nd = (int64_t *)realloc(
+                dst->data, sizeof(int64_t) * (size_t)new_cap * dst->ncols);
+            if (!nd)
+                return ENOMEM;
+        }
+        dst->data = nd;
+
+        /* Track capacity growth in ledger */
+        if (dst->mem_ledger && dst->ncols > 0) {
+            uint64_t delta = (uint64_t)(new_cap - dst->capacity) * dst->ncols
+                * sizeof(int64_t);
+            wl_mem_ledger_alloc(dst->mem_ledger, WL_MEM_SUBSYS_RELATION, delta);
+        }
+        dst->capacity = new_cap;
     }
-    /* Overwrite the zero-initialized timestamps with src provenance. */
+
+    /* Bulk copy all rows in one memcpy (O(1) syscall vs O(src->nrows)) */
+    memcpy(dst->data + (size_t)dst_base * dst->ncols,
+        src->data,
+        (size_t)src->nrows * dst->ncols * sizeof(int64_t));
+    dst->nrows = new_nrows;
+
+    /* Copy timestamps if both have tracking enabled */
     if (src->timestamps && dst->timestamps)
         memcpy(&dst->timestamps[dst_base], src->timestamps,
             src->nrows * sizeof(col_delta_timestamp_t));
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Two-stage optimization of col_rel_append_all to eliminate malloc_large_huge overhead:

1. **Bulk memcpy**: Replace per-row col_rel_append_row with single bulk memcpy
   - Eliminates O(src->nrows) function calls
   - Reduces from 50.16s (10.2%) to negligible overhead

2. **Arena allocation**: Use wl_arena_alloc for arena_owned buffers
   - Avoids malloc_large_huge overhead (59.17s, 12.4%)
   - Preserves arena_owned flag instead of migrating to heap

## Test Plan

- [x] Build: gcc, clang, macos-clang, msvc all pass
- [x] Tests: 96/97 pass, 1 expected fail
- [x] ASAN: Clean
- [x] Time profiler: CRDT benchmark traces generated
  - crdt_final.trace: Final optimized version (30M)
  - crdt_benchmark_optimized.trace: Intermediate (bulk memcpy only, 29M)

## Performance Impact

- Total execution time: 8:16 → 7:56 (**4% improvement**)
- malloc_large_huge: Eliminated
- col_rel_append_row: 50.16s removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)