### PR TITLE
feat(#308): Replace all qsort_r with radix sort in consolidation

### DIFF
--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -590,6 +590,8 @@ void
 col_rel_compact(col_rel_t *r);
 void
 col_rel_radix_sort_int64(col_rel_t *r);
+int
+col_radix_sort_rows(int64_t *data, uint32_t nrows, uint32_t ncols);
 
 /* ======================================================================== */
 /* Cache & Materialized Join (columnar/cache.c)                             */

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2647,48 +2647,6 @@ kway_row_cmp(const int64_t *a, const int64_t *b, uint32_t ncols)
     return row_cmp_dispatch(a, b, ncols);
 }
 
-/* Issue #300: SIMD-accelerated qsort_r comparator for the kway_merge sort
- * phase.  row_cmp_fn in internal.h uses scalar-only comparison (it must work
- * across all translation units that do not include the SIMD helpers).  Here we
- * wrap row_cmp_optimized — the compile-time SIMD dispatcher — with the correct
- * platform-specific qsort_r signature so that the per-segment sort in
- * col_op_consolidate_kway_merge also benefits from SIMD acceleration.
- *
- * The sort phase accounts for ~40% of kway_merge time with a 12:1
- * sort-to-merge comparison ratio, making this the highest-ROI optimisation.
- */
-#ifdef __GLIBC__
-/* GNU glibc qsort_r: comparator(a, b, ctx) */
-static inline int
-row_cmp_fn_kway(const void *a, const void *b, void *ctx)
-{
-    const uint32_t ncols = *(const uint32_t *)ctx;
-    return row_cmp_optimized((const int64_t *)a, (const int64_t *)b, ncols);
-}
-#define QSORT_R_KWAY(base, nmemb, size, ctx) \
-        qsort_r(base, nmemb, size, row_cmp_fn_kway, ctx)
-#elif defined(_MSC_VER)
-/* MSVC qsort_s: comparator(ctx, a, b) */
-static int __cdecl
-row_cmp_fn_kway(void *ctx, const void *a, const void *b)
-{
-    const uint32_t ncols = *(const uint32_t *)ctx;
-    return row_cmp_optimized((const int64_t *)a, (const int64_t *)b, ncols);
-}
-#define QSORT_R_KWAY(base, nmemb, size, ctx) \
-        qsort_s(base, nmemb, size, row_cmp_fn_kway, ctx)
-#else
-/* BSD qsort_r: comparator(ctx, a, b) */
-static inline int
-row_cmp_fn_kway(void *ctx, const void *a, const void *b)
-{
-    const uint32_t ncols = *(const uint32_t *)ctx;
-    return row_cmp_optimized((const int64_t *)a, (const int64_t *)b, ncols);
-}
-#define QSORT_R_KWAY(base, nmemb, size, ctx) \
-        qsort_r(base, nmemb, size, ctx, row_cmp_fn_kway)
-#endif
-
 /*
  * col_op_consolidate_kway_merge - K-way merge with per-segment sort and dedup.
  *
@@ -2715,13 +2673,13 @@ col_op_consolidate_kway_merge(col_rel_t *rel, const uint32_t *seg_boundaries,
     if (nr <= 1)
         return 0;
 
-    /* Sort each segment in-place using SIMD-accelerated comparator (#300) */
+    /* Sort each segment in-place using radix sort */
     for (uint32_t s = 0; s < seg_count; s++) {
         uint32_t start = seg_boundaries[s];
         uint32_t end = seg_boundaries[s + 1];
         if (end > start + 1) {
-            QSORT_R_KWAY(rel->data + (size_t)start * nc, end - start,
-                row_bytes, &nc);
+            col_radix_sort_rows(rel->data + (size_t)start * nc,
+                end - start, nc);
         }
     }
 
@@ -2958,8 +2916,8 @@ col_op_consolidate(eval_stack_t *stack, wl_col_session_t *sess)
         uint32_t delta_count = nr - sn;
         int64_t *delta_start = work->data + (size_t)sn * nc;
 
-        /* Phase 1: sort only the unsorted suffix */
-        QSORT_R_CALL(delta_start, delta_count, row_bytes, &nc, row_cmp_fn);
+        /* Phase 1: sort only the unsorted suffix using radix sort */
+        col_radix_sort_rows(delta_start, delta_count, nc);
 
         /* Phase 1b: dedup within suffix */
         uint32_t d_unique = 1;
@@ -3110,8 +3068,8 @@ col_op_consolidate_incremental(col_rel_t *rel, uint32_t old_nrows)
     int64_t *delta_start = rel->data + (size_t)old_nrows * nc;
     size_t row_bytes = (size_t)nc * sizeof(int64_t);
 
-    /* Phase 1: sort only the new delta rows */
-    QSORT_R_CALL(delta_start, delta_count, row_bytes, &nc, row_cmp_fn);
+    /* Phase 1: sort only the new delta rows using radix sort */
+    col_radix_sort_rows(delta_start, delta_count, nc);
 
     /* Phase 1b: dedup within delta */
     uint32_t d_unique = 1;
@@ -3230,8 +3188,8 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
     int64_t *delta_start = rel->data + (size_t)old_nrows * nc;
     size_t row_bytes = (size_t)nc * sizeof(int64_t);
 
-    /* Phase 1: sort only the new delta rows */
-    QSORT_R_CALL(delta_start, delta_count, row_bytes, &nc, row_cmp_fn);
+    /* Phase 1: sort only the new delta rows using radix sort */
+    col_radix_sort_rows(delta_start, delta_count, nc);
 
     /* Phase 1b: dedup within delta */
     uint32_t d_unique = 1;
@@ -4854,8 +4812,8 @@ col_op_consolidate_diff(eval_stack_t *stack, wl_col_session_t *sess)
         uint32_t delta_count = nr - sn;
         int64_t *delta_start = work->data + (size_t)sn * nc;
 
-        /* Phase 1: sort only the unsorted suffix */
-        QSORT_R_CALL(delta_start, delta_count, row_bytes, &nc, row_cmp_fn);
+        /* Phase 1: sort only the unsorted suffix using radix sort */
+        col_radix_sort_rows(delta_start, delta_count, nc);
 
         /* Phase 1b: dedup within suffix */
         uint32_t d_unique = 1;

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -518,42 +518,30 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
 /* ---- radix sort ---------------------------------------------------------- */
 
 /*
- * col_rel_radix_sort_int64: sort all rows of r in-place using LSD radix sort.
+ * col_radix_sort_rows: sort nrows rows of ncols int64_t columns in-place
+ * using LSD radix sort.  Works on a raw pointer (no col_rel_t needed).
  *
- * Sorts lexicographically by all ncols columns (column 0 is most significant).
- * Handles signed int64_t by flipping the sign bit on the MSB of each column
- * so that unsigned byte comparison yields the correct signed ordering.
- *
- * Complexity: O(ncols * 8 * nrows) time, O(nrows * ncols) extra space.
- * Sets r->sorted_nrows = r->nrows on completion.
- * Falls back to qsort on allocation failure.
+ * Falls back to qsort_r on allocation failure.
+ * Returns 0 on success, -1 on fallback (still sorted, just via qsort).
  */
-void
-col_rel_radix_sort_int64(col_rel_t *r)
+int
+col_radix_sort_rows(int64_t *data, uint32_t nrows, uint32_t ncols)
 {
-    if (!r || r->ncols == 0) {
-        if (r)
-            r->sorted_nrows = r->nrows;
-        return;
-    }
-    if (r->nrows <= 1) {
-        r->sorted_nrows = r->nrows;
-        return;
-    }
+    if (!data || ncols == 0 || nrows <= 1)
+        return 0;
 
-    uint32_t nr = r->nrows;
-    uint32_t nc = r->ncols;
+    uint32_t nr = nrows;
+    uint32_t nc = ncols;
     size_t row_bytes = (size_t)nc * sizeof(int64_t);
 
     int64_t *tmp = (int64_t *)malloc((size_t)nr * row_bytes);
     if (!tmp) {
         /* Fallback to comparison sort on allocation failure */
-        QSORT_R_CALL(r->data, nr, row_bytes, &nc, row_cmp_fn);
-        r->sorted_nrows = nr;
-        return;
+        QSORT_R_CALL(data, nr, row_bytes, &nc, row_cmp_fn);
+        return -1;
     }
 
-    int64_t *src = r->data;
+    int64_t *src = data;
     int64_t *dst = tmp;
 
     /* count[b] = frequency of byte value b in current pass.
@@ -605,9 +593,37 @@ col_rel_radix_sort_int64(col_rel_t *r)
     }
 
     /* After nc*8 passes the result is in src.  Copy back if needed. */
-    if (src != r->data)
-        memcpy(r->data, src, (size_t)nr * row_bytes);
+    if (src != data)
+        memcpy(data, src, (size_t)nr * row_bytes);
 
     free(tmp);
-    r->sorted_nrows = nr;
+    return 0;
+}
+
+/*
+ * col_rel_radix_sort_int64: sort all rows of r in-place using LSD radix sort.
+ *
+ * Sorts lexicographically by all ncols columns (column 0 is most significant).
+ * Handles signed int64_t by flipping the sign bit on the MSB of each column
+ * so that unsigned byte comparison yields the correct signed ordering.
+ *
+ * Complexity: O(ncols * 8 * nrows) time, O(nrows * ncols) extra space.
+ * Sets r->sorted_nrows = r->nrows on completion.
+ * Falls back to qsort on allocation failure.
+ */
+void
+col_rel_radix_sort_int64(col_rel_t *r)
+{
+    if (!r || r->ncols == 0) {
+        if (r)
+            r->sorted_nrows = r->nrows;
+        return;
+    }
+    if (r->nrows <= 1) {
+        r->sorted_nrows = r->nrows;
+        return;
+    }
+
+    col_radix_sort_rows(r->data, r->nrows, r->ncols);
+    r->sorted_nrows = r->nrows;
 }


### PR DESCRIPTION
## Summary

- Add `col_radix_sort_rows()` segment-level radix sort API for raw pointer + nrows/ncols
- Replace all 5 `qsort_r` call sites in `ops.c` with O(n) LSD radix sort
- Remove unused `row_cmp_fn_kway` / `QSORT_R_KWAY` macro (net -24 lines)
- Refactor `col_rel_radix_sort_int64()` to delegate to shared implementation

## Motivation

CRDT workload profiling (perf record, 224K samples) showed **sorting consumes ~70% of wall time** (157s/225s):
- `row_cmp_fn_kway`: 14.7% (33s)
- `row_cmp_fn`: 9.3% (21s)  
- `qsort_r` internals (libc): 43.8% (98s)

Root cause: per-segment `qsort_r` O(n log n) called every iteration across 14,148 iterations.

## Changes

| File | Change |
|------|--------|
| `relation.c` | Add `col_radix_sort_rows()`, refactor `col_rel_radix_sort_int64` to delegate |
| `ops.c` | Replace 5x `QSORT_R_CALL`/`QSORT_R_KWAY` with `col_radix_sort_rows()`, remove unused kway comparator |
| `internal.h` | Add `col_radix_sort_rows` declaration |

## Test plan

- [x] Full test suite: 97 passed, 1 expected fail, 0 failures
- [x] Build clean (no warnings from our changes)
- [ ] CRDT benchmark regression: verify wall time improvement
- [ ] CSPA/DOOP workload regression check