### PR TITLE
feat(#315): Implement per-worker session state isolation

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1869,3 +1869,24 @@ test_partition_exe = executable(
 )
 
 test('partition', test_partition_exe)
+
+# ============================================================================
+# Per-Worker Session State (Issue #315)
+# ============================================================================
+
+test_worker_session_exe = executable(
+  'test_worker_session',
+  files('test_worker_session.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep],
+)
+
+test('worker_session', test_worker_session_exe)

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -1,0 +1,695 @@
+/*
+ * test_worker_session.c - Unit tests for per-worker session state
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Tests: worker session create/destroy lifecycle, relation isolation,
+ * frontier independence, arena/pool independence, coordinator read-only.
+ *
+ * Issue #315: Per-Worker Session State
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test Harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+/* ======================================================================== */
+/* Helpers                                                                  */
+/* ======================================================================== */
+
+/* Create a coordinator session with "edge(x,y)" EDB and "path(x,y)" IDB. */
+static wl_col_session_t *
+make_coordinator(wl_plan_t **plan_out, wirelog_program_t **prog_out)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n",
+        &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return NULL;
+    }
+
+    wl_session_t *session = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 2, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return NULL;
+    }
+
+    *plan_out = plan;
+    *prog_out = prog;
+    return COL_SESSION(session);
+}
+
+/* Insert edge rows into coordinator session. */
+static int
+insert_edges(wl_col_session_t *sess, const int64_t *rows, uint32_t nrows)
+{
+    return wl_session_insert(&sess->base, "edge", rows, nrows, 2);
+}
+
+/* Build partition array for a named relation in the coordinator. */
+static int
+partition_rel(wl_col_session_t *coordinator, const char *name,
+    uint32_t num_workers, col_rel_t ***out_partitions)
+{
+    col_rel_t *rel = session_find_rel(coordinator, name);
+    if (!rel || rel->ncols == 0)
+        return ENOENT;
+
+    col_rel_t **parts
+        = (col_rel_t **)calloc(num_workers, sizeof(col_rel_t *));
+    if (!parts)
+        return ENOMEM;
+
+    /* Partition on first column */
+    uint32_t key_cols[] = { 0 };
+    int rc = col_rel_partition_by_key(rel, key_cols, 1, num_workers, parts);
+    if (rc != 0) {
+        free(parts);
+        return rc;
+    }
+
+    /* Rename partitions to original name for session_find_rel */
+    for (uint32_t w = 0; w < num_workers; w++) {
+        free(parts[w]->name);
+        {
+            size_t len = strlen(name) + 1;
+            char *dup = (char *)malloc(len);
+            if (!dup) {
+                for (uint32_t j = 0; j < num_workers; j++)
+                    col_rel_destroy(parts[j]);
+                free(parts);
+                return ENOMEM;
+            }
+            memcpy(dup, name, len);
+            parts[w]->name = dup;
+        }
+        if (!parts[w]->name) {
+            for (uint32_t j = 0; j < num_workers; j++)
+                col_rel_destroy(parts[j]);
+            free(parts);
+            return ENOMEM;
+        }
+    }
+
+    *out_partitions = parts;
+    return 0;
+}
+
+static void
+cleanup_coordinator(wl_col_session_t *sess, wl_plan_t *plan,
+    wirelog_program_t *prog)
+{
+    wl_session_destroy(&sess->base);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static int
+test_create_destroy(void)
+{
+    TEST("worker session create and destroy (lifecycle, no leaks)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    if (insert_edges(coord, rows, 4) != 0) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("insert");
+        return 1;
+    }
+
+    col_rel_t **parts = NULL;
+    int rc = partition_rel(coord, "edge", 2, &parts);
+    if (rc != 0) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("partition");
+        return 1;
+    }
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    rc = col_worker_session_create(coord, 0, parts, 2, &worker);
+    if (rc != 0) {
+        for (uint32_t i = 0; i < 2; i++) {
+            if (parts[i])
+                col_rel_destroy(parts[i]);
+        }
+        free(parts);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("worker create");
+        return 1;
+    }
+    free(parts);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+    PASS();
+    return 0;
+}
+
+static int
+test_identity_fields(void)
+{
+    TEST("worker identity fields (worker_id, coordinator pointer)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2, 3, 4 };
+    insert_edges(coord, rows, 2);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 7, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.worker_id == 7)
+        && (worker.coordinator == coord)
+        && (coord->coordinator == NULL);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("identity mismatch");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_borrowed_fields(void)
+{
+    TEST("borrowed fields shared (plan, frontier_ops)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.plan == coord->plan)
+        && (worker.frontier_ops == coord->frontier_ops);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("borrowed fields differ");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_rels_independent(void)
+{
+    TEST("worker rels[] independent from coordinator");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 10, 2, 20, 3, 30, 4, 40 };
+    insert_edges(coord, rows, 4);
+
+    col_rel_t *coord_edge = session_find_rel(coord, "edge");
+    uint32_t coord_nrows = coord_edge ? coord_edge->nrows : 0;
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 2, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 2, &worker);
+    free(parts);
+
+    int ok = (worker.rels != coord->rels);
+
+    col_rel_t *coord_edge2 = session_find_rel(coord, "edge");
+    if (!coord_edge2 || coord_edge2->nrows != coord_nrows)
+        ok = 0;
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("rels not independent");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_wq_null(void)
+{
+    TEST("worker wq is NULL (prevents nested K-fusion)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.wq == NULL);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("wq not NULL");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_arena_pool_allocated(void)
+{
+    TEST("worker has independent eval_arena and delta_pool");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.eval_arena != NULL)
+        && (worker.delta_pool != NULL)
+        && (worker.eval_arena != coord->eval_arena)
+        && (worker.delta_pool != coord->delta_pool);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("arena/pool not independent");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_mat_cache_empty(void)
+{
+    TEST("worker mat_cache starts empty");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.mat_cache.count == 0);
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("mat_cache not empty");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_frontier_independence(void)
+{
+    TEST("worker frontiers independent from coordinator");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    coord->frontiers[0].outer_epoch = 1;
+    coord->frontiers[0].iteration = 5;
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.frontiers[0].outer_epoch == 1)
+        && (worker.frontiers[0].iteration == 5);
+
+    worker.frontiers[0].outer_epoch = 99;
+    worker.frontiers[0].iteration = 42;
+
+    if (coord->frontiers[0].outer_epoch != 1
+        || coord->frontiers[0].iteration != 5)
+        ok = 0;
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("frontiers not independent");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_coordinator_readonly(void)
+{
+    TEST("coordinator rels unchanged after worker lifecycle");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 10, 2, 20, 3, 30, 4, 40,
+                       5, 50, 6, 60, 7, 70, 8, 80 };
+    insert_edges(coord, rows, 8);
+
+    col_rel_t *coord_edge = session_find_rel(coord, "edge");
+    uint32_t orig_nrows = coord_edge->nrows;
+
+    int64_t *orig_data = (int64_t *)malloc(
+        (size_t)orig_nrows * 2 * sizeof(int64_t));
+    memcpy(orig_data, coord_edge->data,
+        (size_t)orig_nrows * 2 * sizeof(int64_t));
+
+    for (uint32_t w = 0; w < 2; w++) {
+        col_rel_t **parts = NULL;
+        partition_rel(coord, "edge", 2, &parts);
+
+        wl_col_session_t worker;
+        memset(&worker, 0, sizeof(worker));
+        col_worker_session_create(coord, w, parts, 2, &worker);
+        free(parts);
+
+        col_worker_session_destroy(&worker);
+    }
+
+    coord_edge = session_find_rel(coord, "edge");
+    int ok = (coord_edge != NULL)
+        && (coord_edge->nrows == orig_nrows)
+        && (memcmp(coord_edge->data, orig_data,
+        (size_t)orig_nrows * 2 * sizeof(int64_t))
+        == 0);
+
+    free(orig_data);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("coordinator modified");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_find_rel_returns_partition(void)
+{
+    TEST("session_find_rel on worker returns partition data");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 10, 2, 20, 3, 30, 4, 40 };
+    insert_edges(coord, rows, 4);
+
+    col_rel_t *coord_edge = session_find_rel(coord, "edge");
+    uint32_t total = coord_edge->nrows;
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 2, &parts);
+
+    wl_col_session_t workers[2];
+    memset(workers, 0, sizeof(workers));
+
+    col_rel_t *w0_parts[1] = { parts[0] };
+    parts[0] = NULL;
+    col_worker_session_create(coord, 0, w0_parts, 1, &workers[0]);
+
+    col_rel_t *w1_parts[1] = { parts[1] };
+    parts[1] = NULL;
+    col_worker_session_create(coord, 1, w1_parts, 1, &workers[1]);
+    free(parts);
+
+    col_rel_t *w0_edge = session_find_rel(&workers[0], "edge");
+    col_rel_t *w1_edge = session_find_rel(&workers[1], "edge");
+
+    int ok = (w0_edge != NULL) && (w1_edge != NULL);
+    if (ok)
+        ok = (w0_edge->nrows + w1_edge->nrows == total);
+
+    col_worker_session_destroy(&workers[0]);
+    col_worker_session_destroy(&workers[1]);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("partition lookup failed");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_invalid_args(void)
+{
+    TEST("invalid args: NULL coordinator/out_worker returns EINVAL");
+
+    wl_col_session_t dummy;
+    memset(&dummy, 0, sizeof(dummy));
+    col_rel_t *parts[1] = { NULL };
+
+    int rc1 = col_worker_session_create(NULL, 0, parts, 1, &dummy);
+    int rc2 = col_worker_session_create(&dummy, 0, parts, 1, NULL);
+    int rc3 = col_worker_session_create(&dummy, 0, NULL, 1, &dummy);
+
+    if (rc1 != EINVAL || rc2 != EINVAL || rc3 != EINVAL) {
+        FAIL("expected EINVAL");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_hash_table_independent(void)
+{
+    TEST("worker hash table is independent (lazy rebuild)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2 };
+    insert_edges(coord, rows, 1);
+
+    col_rel_t **parts = NULL;
+    partition_rel(coord, "edge", 1, &parts);
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    col_worker_session_create(coord, 0, parts, 1, &worker);
+    free(parts);
+
+    int ok = (worker.rel_hash_nbuckets == 0);
+
+    col_rel_t *found = session_find_rel(&worker, "edge");
+    if (!found)
+        ok = 0;
+
+    /* After lazy build, hash should be worker-owned (not coordinator's) */
+    if (worker.rel_hash_nbuckets > 0
+        && worker.rel_hash_head == coord->rel_hash_head)
+        ok = 0;
+
+    col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("hash table not independent");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("Per-Worker Session State Tests (Issue #315)\n");
+
+    test_create_destroy();
+    test_identity_fields();
+    test_borrowed_fields();
+    test_rels_independent();
+    test_wq_null();
+    test_arena_pool_allocated();
+    test_mat_cache_empty();
+    test_frontier_independence();
+    test_coordinator_readonly();
+    test_find_rel_returns_partition();
+    test_invalid_args();
+    test_hash_table_independent();
+
+    printf("\nPassed: %d/%d\n", tests_passed, tests_run);
+    printf("Failed: %d/%d\n", tests_failed, tests_run);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -355,7 +355,7 @@ extern const col_frontier_ops_t col_frontier_diff_ops;
  * wl_session_t* to wl_col_session_t* is valid per C11 pointer
  * compatibility (address of struct == address of first member).
  */
-typedef struct {
+typedef struct wl_col_session_t {
     wl_session_t base;         /* MUST be first field (vtable dispatch)  */
     const col_frontier_ops_t *frontier_ops; /* frontier vtable (#261)   */
     const wl_plan_t *plan;     /* borrowed, lifetime: caller             */
@@ -524,6 +524,16 @@ typedef struct {
      * getenv() calls in hot paths. */
     bool debug_join;         /* WL_DEBUG_JOIN=1 enables DEBUG[JOIN] output  */
     bool consolidation_log;  /* WL_CONSOLIDATION_LOG=1 enables CONS output  */
+    /* Per-worker session state (Issue #315): data-partitioned worker isolation.
+     * worker_id:    0-based worker index.  Only meaningful when coordinator
+     *               is non-NULL (i.e., this session is a worker, not the
+     *               coordinator).
+     * coordinator:  borrowed pointer to parent session.  NULL means this
+     *               IS the coordinator session.  Non-NULL is the canonical
+     *               "is this a worker?" test and prevents freeing borrowed
+     *               resources (plan, frontier_ops) in worker destroy. */
+    uint32_t worker_id;
+    struct wl_col_session_t *coordinator;
 } wl_col_session_t;
 
 /*
@@ -783,6 +793,10 @@ col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count);
 void
 col_session_free_diff_arrangements(wl_col_session_t *cs);
+/* Issue #260: Deep-copy arrangement entries for K-fusion worker isolation. */
+int
+col_arr_entries_clone(const col_arr_entry_t *src, uint32_t count,
+    col_arr_entry_t **out_entries, uint32_t *out_cap);
 /* Issue #274: Deep-copy differential arrangement entries for K-fusion worker isolation. */
 int
 col_diff_arr_entries_clone(const col_diff_arr_entry_t *src, uint32_t count,
@@ -934,5 +948,37 @@ col_rel_partition_by_key(const col_rel_t *src,
 int
 col_rel_merge_partitions(col_rel_t **parts, uint32_t num_workers,
     col_rel_t **out);
+
+/* ======================================================================== */
+/* Per-Worker Session State (columnar/session.c, Issue #315)                */
+/* ======================================================================== */
+
+/*
+ * col_worker_session_create:
+ * Create an isolated worker session from a coordinator session.
+ * The worker owns independent rels[] (populated with partitions),
+ * eval_arena, delta_pool, arrangement clones, and mat_cache.
+ * Borrowed fields (plan, frontier_ops) are shared read-only.
+ *
+ * out_worker must be caller-allocated (e.g., from calloc'd array).
+ * partitions[] ownership transfers to the worker on success;
+ * on failure, partitions[] are NOT consumed (caller must free).
+ *
+ * Returns 0 on success, EINVAL for bad arguments, ENOMEM on failure.
+ */
+int
+col_worker_session_create(wl_col_session_t *coordinator,
+    uint32_t worker_id, col_rel_t **partitions,
+    uint32_t num_partitions, wl_col_session_t *out_worker);
+
+/*
+ * col_worker_session_destroy:
+ * Free all resources owned by a worker session.  Does NOT free borrowed
+ * resources (plan, frontier_ops) or the out_worker struct itself.
+ * Safe to call on a partially-initialized worker (all owned pointers
+ * are pre-NULLed during create).  Zeroes the struct on completion.
+ */
+void
+col_worker_session_destroy(wl_col_session_t *worker);
 
 #endif /* WL_COLUMNAR_INTERNAL_H */

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -3595,7 +3595,7 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
  * On success, *out_entries owns all allocations and *out_cap equals count.
  * On failure, *out_entries is NULL.
  */
-static int
+int
 col_arr_entries_clone(const col_arr_entry_t *src, uint32_t count,
     col_arr_entry_t **out_entries, uint32_t *out_cap)
 {

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -581,6 +581,182 @@ col_session_destroy(wl_session_t *session)
     free(sess);
 }
 
+/* ======================================================================== */
+/* Per-Worker Session State (Issue #315)                                    */
+/* ======================================================================== */
+
+/*
+ * col_worker_session_create:
+ * Create an isolated worker session from a coordinator session.
+ * See internal.h for full documentation.
+ */
+int
+col_worker_session_create(wl_col_session_t *coordinator,
+    uint32_t worker_id, col_rel_t **partitions,
+    uint32_t num_partitions, wl_col_session_t *out_worker)
+{
+    if (!coordinator || !out_worker || !partitions)
+        return EINVAL;
+
+    /* Step 1: Bitwise copy — copies all value fields (frontiers,
+     * counters, booleans, plan pointer, frontier_ops). */
+    *out_worker = *coordinator;
+
+    /* Step 2: Set identity fields */
+    out_worker->worker_id = worker_id;
+    out_worker->coordinator = coordinator;
+
+    /* Prevent accidental wl_session_destroy on stack-allocated worker */
+    out_worker->base.backend = NULL;
+
+    /* Step 3: NULL all owned pointers (safe for cleanup on early abort) */
+    out_worker->wq = NULL;
+    out_worker->eval_arena = NULL;
+    out_worker->delta_pool = NULL;
+    out_worker->rels = NULL;
+    out_worker->nrels = 0;
+    out_worker->rel_cap = 0;
+    out_worker->rel_hash_head = NULL;
+    out_worker->rel_hash_next = NULL;
+    out_worker->rel_hash_nbuckets = 0;
+    out_worker->rel_hash_chain_cap = 0;
+    out_worker->arr_entries = NULL;
+    out_worker->arr_count = 0;
+    out_worker->arr_cap = 0;
+    out_worker->diff_arr_entries = NULL;
+    out_worker->diff_arr_count = 0;
+    out_worker->diff_arr_cap = 0;
+    out_worker->darr_entries = NULL;
+    out_worker->darr_count = 0;
+    out_worker->darr_cap = 0;
+    out_worker->sarr_entries = NULL;
+    out_worker->sarr_count = 0;
+    out_worker->sarr_cap = 0;
+    memset(&out_worker->mat_cache, 0, sizeof(col_mat_cache_t));
+
+    /* Step 4: NULL borrowed fields that workers must not use */
+    out_worker->delta_cb = NULL;
+    out_worker->delta_data = NULL;
+    out_worker->last_inserted_relation = NULL;
+    out_worker->last_removed_relation = NULL;
+
+    /* Step 5: Initialize independent mem_ledger (avoid copying atomics) */
+    wl_mem_ledger_init(&out_worker->mem_ledger,
+        coordinator->mem_ledger.total_budget);
+
+    /* Step 6: Populate rels[] with partition relations (ownership transfer) */
+    out_worker->rels
+        = (col_rel_t **)calloc(num_partitions, sizeof(col_rel_t *));
+    if (!out_worker->rels)
+        goto cleanup;
+    for (uint32_t i = 0; i < num_partitions; i++) {
+        out_worker->rels[i] = partitions[i];
+        partitions[i] = NULL; /* Mark as transferred */
+    }
+    out_worker->nrels = num_partitions;
+    out_worker->rel_cap = num_partitions;
+
+    /* Step 7: Allocate per-worker arena (scaled by num_workers) */
+    {
+        uint32_t k = coordinator->num_workers > 0
+            ? coordinator->num_workers
+            : 1;
+        size_t arena_cap = coordinator->eval_arena
+            ? coordinator->eval_arena->capacity / k
+            : 8UL * 1024 * 1024;
+        if (arena_cap < 8UL * 1024 * 1024)
+            arena_cap = 8UL * 1024 * 1024;
+        out_worker->eval_arena = wl_arena_create(arena_cap);
+        /* Non-fatal if NULL: operators fall back to malloc */
+    }
+
+    /* Step 8: Allocate per-worker delta_pool (scaled by num_workers) */
+    {
+        uint32_t k = coordinator->num_workers > 0
+            ? coordinator->num_workers
+            : 1;
+        size_t pool_arena = 32UL * 1024 * 1024 / k;
+        if (pool_arena < 4UL * 1024 * 1024)
+            pool_arena = 4UL * 1024 * 1024;
+        uint32_t pool_slots = 128 / k;
+        if (pool_slots < 16)
+            pool_slots = 16;
+        out_worker->delta_pool
+            = delta_pool_create(pool_slots, sizeof(col_rel_t), pool_arena);
+        /* Non-fatal if NULL: operators fall back to malloc */
+    }
+
+    /* Step 9: Deep-clone arrangement registries */
+    if (coordinator->arr_count > 0) {
+        int rc = col_arr_entries_clone(coordinator->arr_entries,
+                coordinator->arr_count, &out_worker->arr_entries,
+                &out_worker->arr_cap);
+        if (rc != 0)
+            goto cleanup;
+        out_worker->arr_count = coordinator->arr_count;
+    }
+    if (coordinator->diff_arr_count > 0) {
+        int rc = col_diff_arr_entries_clone(coordinator->diff_arr_entries,
+                coordinator->diff_arr_count, &out_worker->diff_arr_entries,
+                &out_worker->diff_arr_cap);
+        if (rc != 0)
+            goto cleanup;
+        out_worker->diff_arr_count = coordinator->diff_arr_count;
+    }
+
+    return 0;
+
+cleanup:
+    col_worker_session_destroy(out_worker);
+    return ENOMEM;
+}
+
+/*
+ * col_worker_session_destroy:
+ * Free all resources owned by a worker session.
+ * See internal.h for full documentation.
+ */
+void
+col_worker_session_destroy(wl_col_session_t *worker)
+{
+    if (!worker)
+        return;
+
+    /* Free mat_cache entries (all worker-owned since zeroed at create) */
+    col_mat_cache_clear(&worker->mat_cache);
+
+    /* Free arrangement registries */
+    for (uint32_t i = 0; i < worker->arr_count; i++) {
+        free(worker->arr_entries[i].rel_name);
+        free(worker->arr_entries[i].key_cols);
+        arr_free_contents(&worker->arr_entries[i].arr);
+    }
+    free(worker->arr_entries);
+    col_session_free_delta_arrangements(worker);
+    col_session_free_sorted_arrangements(worker);
+    col_session_free_diff_arrangements(worker);
+
+    /* Free owned relations (partition data) */
+    for (uint32_t i = 0; i < worker->nrels; i++) {
+        if (worker->rels[i]) {
+            col_rel_free_contents(worker->rels[i]);
+            free(worker->rels[i]);
+        }
+    }
+    free(worker->rels);
+
+    /* Free hash table (may have been lazily built) */
+    session_rel_free_hash(worker);
+
+    /* Free allocators (all NULL-safe) */
+    wl_workqueue_destroy(worker->wq);
+    delta_pool_destroy(worker->delta_pool);
+    wl_arena_free(worker->eval_arena);
+
+    /* Zero the struct to prevent dangling pointer use */
+    memset(worker, 0, sizeof(*worker));
+}
+
 int
 col_session_insert(wl_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols)


### PR DESCRIPTION
## Summary

- Implement `col_worker_session_create` / `col_worker_session_destroy` for independent worker sessions with partitioned relation data
- Each worker owns: `rels[]` (partitions), `eval_arena`, `delta_pool`, arrangement clones, `mat_cache`, `mem_ledger`
- Shared read-only: `plan`, `frontier_ops`, value-copied frontiers/counters/booleans
- Add `worker_id` and `coordinator` pointer to `wl_col_session_t` (named struct tag added for self-reference)
- Promote `col_arr_entries_clone` from `static` to `extern` for cross-module reuse

## Design (Architect + Critic + Reviewer consensus)

| Decision | Rationale |
|----------|-----------|
| `base.backend = NULL` on worker | Prevents accidental `wl_session_destroy` on stack-allocated worker (reviewer CRITICAL) |
| Hash table 4 fields zeroed | Worker's `rels[]` differs from coordinator; stale hash would return wrong relations (critic MAJOR) |
| `wl_mem_ledger_init()` explicit | Avoids C11 UB from bitwise-copying embedded atomics (critic MAJOR) |
| `wl_workqueue_destroy` in destroy | Defensive cleanup even though `wq=NULL` at create (reviewer HIGH) |
| `sarr_entries` zeroed, not cloned | Coordinator's sorted arrangement indices invalid for partition data |
| `partitions[i] = NULL` after transfer | Prevents double-free in caller on partial failure |

## Test plan

- [x] 12/12 unit tests passing (`test_worker_session.c`)
  - Lifecycle create/destroy (no leaks)
  - Identity fields (worker_id, coordinator pointer)
  - Borrowed fields shared (plan, frontier_ops)
  - Worker rels[] independent from coordinator
  - wq is NULL (prevents nested K-fusion)
  - Independent eval_arena and delta_pool
  - mat_cache starts empty
  - Frontier independence (mutation isolation)
  - Coordinator rels unchanged after worker lifecycle
  - session_find_rel returns partition data
  - Invalid argument validation (EINVAL)
  - Hash table independent (lazy rebuild)
- [x] Full test suite: 100/100 pass (99 OK + 1 expected fail)
- [x] No regressions

## Dependencies

- #314 (Hash-Partitioned Relation Storage) -- merged

Closes #315