### PR TITLE
feat(#326): Add col_rel_t accessor abstraction layer for column-major migration

### DIFF
--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -173,6 +173,69 @@ typedef struct {
     uint32_t retract_backup_sorted_nrows;
 } col_rel_t;
 
+/* ======================================================================== */
+/* col_rel_t Accessor Layer (Phase 0, Issue #326)                           */
+/*                                                                          */
+/* All row-major access to r->data SHOULD go through these accessors.       */
+/* Phase 5 (#332) will flip the internal layout to column-major; these      */
+/* functions are the ONLY place that needs to change.                       */
+/*                                                                          */
+/* Target layout: int64_t **columns; columns[col][row]                      */
+/* ======================================================================== */
+
+/** Read a single cell value at (row, col). */
+static inline int64_t
+col_rel_get(const col_rel_t *r, uint32_t row, uint32_t col)
+{
+    return r->data[(size_t)row * r->ncols + col];
+}
+
+/** Write a single cell value at (row, col). */
+static inline void
+col_rel_set(col_rel_t *r, uint32_t row, uint32_t col, int64_t val)
+{
+    r->data[(size_t)row * r->ncols + col] = val;
+}
+
+/** Const pointer to the start of a row (row-major: contiguous ncols elements).
+ *  NOTE: In column-major (Phase 5), this returns a gathered scratch buffer
+ *  or must be replaced with col_rel_get() per-cell access. */
+static inline const int64_t *
+col_rel_row(const col_rel_t *r, uint32_t row)
+{
+    return r->data + (size_t)row * r->ncols;
+}
+
+/** Mutable pointer to the start of a row. */
+static inline int64_t *
+col_rel_row_mut(col_rel_t *r, uint32_t row)
+{
+    return r->data + (size_t)row * r->ncols;
+}
+
+/** Copy one row out into a caller-provided buffer. */
+static inline void
+col_rel_row_copy_out(const col_rel_t *r, uint32_t row, int64_t *dst)
+{
+    memcpy(dst, r->data + (size_t)row * r->ncols,
+        (size_t)r->ncols * sizeof(int64_t));
+}
+
+/** Copy one row in from a caller-provided buffer. */
+static inline void
+col_rel_row_copy_in(col_rel_t *r, uint32_t row, const int64_t *src)
+{
+    memcpy(r->data + (size_t)row * r->ncols, src,
+        (size_t)r->ncols * sizeof(int64_t));
+}
+
+/** Compute buffer size in bytes for row_count rows. */
+static inline size_t
+col_rel_buf_bytes(const col_rel_t *r, uint32_t row_count)
+{
+    return (size_t)row_count * (size_t)r->ncols * sizeof(int64_t);
+}
+
 /**
  * col_materialized_join_t - Cached intermediate join result for CSE
  *


### PR DESCRIPTION
## Summary

- Add 7 `static inline` accessor functions to `col_rel_t` for row-major data access encapsulation
- Phase 0 of column-major migration (#325) — purely additive, zero behavior change
- No `.c` files modified, all existing tests pass unchanged

## Accessors

| Function | Pattern | Const |
|----------|---------|-------|
| `col_rel_get(r, row, col)` | Read single cell | `const col_rel_t *` |
| `col_rel_set(r, row, col, val)` | Write single cell | `col_rel_t *` |
| `col_rel_row(r, row)` | Const row pointer | `const col_rel_t *` → `const int64_t *` |
| `col_rel_row_mut(r, row)` | Mutable row pointer | `col_rel_t *` → `int64_t *` |
| `col_rel_row_copy_out(r, row, dst)` | Copy row to buffer | `const col_rel_t *` |
| `col_rel_row_copy_in(r, row, src)` | Copy row from buffer | `col_rel_t *` |
| `col_rel_buf_bytes(r, row_count)` | Compute buffer size | `const col_rel_t *` |

## Design decisions (Architect + Critic + Reviewer consensus)

| Decision | Rationale |
|----------|-----------|
| `col_rel_row` / `col_rel_row_mut` split | Reviewer: const-correctness — prevent silent mutation through const pointer |
| `(size_t)` cast on both operands in `buf_bytes` | Reviewer: prevent overflow on 32-bit |
| No `#define data` enforcement macro | Critic: name collision with `col_materialized_join_t.data` — use CI lint instead |
| No accessors for `merge_buf`/`retract_backup` | Architect: these swap with `data` via pointer swap, track layout automatically |
| No accessors for `col_materialized_join_t` | Only 2 access sites, already behind own API |

## Test plan

- [x] 100/100 tests pass (99 OK + 1 expected fail)
- [x] Zero behavior change (purely additive)
- [x] Compiles cleanly under `-Wall -Werror` with C11

Closes #326
