### PR TITLE
fix(#350): Fix incremental multiworker tuple loss across step rounds

### DIFF
--- a/tests/test_td_multiworker.c
+++ b/tests/test_td_multiworker.c
@@ -640,30 +640,30 @@ test_tc_determinism_w2(void)
 /* ======================================================================== */
 
 /*
- * test_td_incremental_w1:
- * Incremental TDD: insert edges, step, insert more edges, step again.
- * Chain built in two batches: 1->2->3 then 3->4->5.
- * Final TC must equal full chain result: C(5,2) = 10 tuples.
+ * test_td_incremental_w4:
+ * Incremental TDD: insert 3 edges, step, insert 2 more, step.
+ * Batch 1: 1->2, 2->3, 3->4. Batch 2: 4->5, 5->6.
+ * Full chain 1->6: TC = C(6,2) = 15 tuples.
  *
- * Note: multiworker incremental (W>1) is a known evaluator limitation;
- * this test verifies the incremental pipeline at W=1.
+ * Issue #350: W=4 validates that multiworker incremental correctly
+ * recomputes IDB across step boundaries.
  */
 static int
-test_td_incremental_w1(void)
+test_td_incremental_w4(void)
 {
-    TEST("W=1 incremental: two insert+step rounds yield 10 tuples");
+    TEST("W=4 incremental: 3+2 edge batches yield 15 tuples");
 
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
-    wl_col_session_t *sess = make_tc_session(1, &plan, &prog);
+    wl_col_session_t *sess = make_tc_session(4, &plan, &prog);
     if (!sess) {
         FAIL("session create");
         return 1;
     }
 
-    /* Round 1: edges 1->2, 2->3 */
-    int64_t batch1[] = { 1, 2, 2, 3 };
-    if (insert_edges(sess, batch1, 2) != 0) {
+    /* Batch 1: 3 edges */
+    int64_t batch1[] = { 1, 2, 2, 3, 3, 4 };
+    if (insert_edges(sess, batch1, 3) != 0) {
         cleanup_session(sess, plan, prog);
         FAIL("insert batch 1");
         return 1;
@@ -676,8 +676,8 @@ test_td_incremental_w1(void)
         return 1;
     }
 
-    /* Round 2: edges 3->4, 4->5 */
-    int64_t batch2[] = { 3, 4, 4, 5 };
+    /* Batch 2: 2 edges */
+    int64_t batch2[] = { 4, 5, 5, 6 };
     if (insert_edges(sess, batch2, 2) != 0) {
         cleanup_session(sess, plan, prog);
         FAIL("insert batch 2");
@@ -694,8 +694,8 @@ test_td_incremental_w1(void)
     uint32_t nrows = count_rows(sess, "tc");
     cleanup_session(sess, plan, prog);
 
-    if (nrows != 10) {
-        FAIL("expected 10 tc tuples after incremental build of 5-node chain");
+    if (nrows != 15) {
+        FAIL("expected 15 tc tuples after incremental build of 6-node chain");
         return 1;
     }
     PASS();
@@ -827,7 +827,7 @@ main(void)
     test_tc_determinism_w2();
 
     printf("\n-- Incremental / Multi-Stratum --\n");
-    test_td_incremental_w1();
+    test_td_incremental_w4();
     test_td_multi_stratum_w2();
 
     printf("\n%d/%d tests passed", tests_passed, tests_run);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2323,6 +2323,26 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         }
     }
 
+    /* Issue #350: On incremental steps (new EDB inserted), clear pre-existing
+     * IDB rows so workers recompute from scratch.  Without this, stale IDB
+     * partitioned by col0 prevents cross-partition recursive joins
+     * (e.g. tc(1,3) on worker 1 cannot join edge(3,4) on worker 3).
+     * Also reset stratum frontier so should_skip_iteration does not skip
+     * iterations beyond the previous step's convergence point.
+     * When no new EDB was inserted, skip clearing to preserve frontier skip. */
+    if (coord->last_inserted_relation != NULL) {
+        for (uint32_t ri = 0; ri < nrels; ri++) {
+            col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
+            if (r && r->nrows > 0) {
+                r->nrows = 0;
+                col_session_invalidate_arrangements(&coord->base,
+                    sp->relations[ri].name);
+            }
+        }
+        coord->frontier_ops->reset_stratum_frontier(coord, stratum_idx,
+            coord->outer_epoch);
+    }
+
     /* Partition coordinator relations to workers */
     rc = tdd_init_workers(coord);
     if (rc != 0)


### PR DESCRIPTION
## Summary

- **Root cause**: In `col_eval_stratum_tdd_recursive`, stale IDB rows from step 1 were partitioned by col0 to workers, preventing cross-partition recursive joins on step 2 (e.g. `tc(1,3)` on worker 1 cannot join `edge(3,4)` on worker 3). Additionally, the stratum frontier was not reset, causing `should_skip_iteration` to skip iterations beyond step 1's convergence point.
- **Fix**: Before partitioning coordinator relations to workers, clear pre-existing IDB rows and reset the stratum frontier when `last_inserted_relation != NULL` (incremental path only). Non-incremental evaluation is unaffected.
- **Test**: Updated `test_td_incremental` to use W=4 (was W=1 workaround), validating multiworker incremental correctness with a 6-node chain (3+2 edge batches, 15 expected TC tuples).

## Verification

- Normal build: 107 OK, 1 expected fail, 0 failures
- ASAN build: 107 OK, 1 expected fail, 0 failures, no memory errors

Closes #350