### PR TITLE
fix(#352): Fix 3-body recursive join with multiworker evaluation

### DIFF
--- a/tests/test_tdd_integration.c
+++ b/tests/test_tdd_integration.c
@@ -129,6 +129,13 @@ static const char PROG_TC[] =
     "tc(x, y) :- edge(x, y).\n"
     "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
+/* Same-generation: 3-body recursive join (Issue #352) */
+static const char PROG_SAME_GEN[] =
+    ".decl parent(x: int32, y: int32)\n"
+    ".decl sg(x: int32, y: int32)\n"
+    "sg(x, y) :- parent(x, p), parent(y, p).\n"
+    "sg(x, y) :- parent(x, xp), sg(xp, yp), parent(y, yp).\n";
+
 /* Multi-stratum: non-recursive edge_sym feeds recursive reach */
 static const char PROG_MULTI_STRATUM[] =
     ".decl edge(x: int32, y: int32)\n"
@@ -302,6 +309,61 @@ test_multi_stratum_multiworker(void)
     }
     if (reach2 != reach1 || reach4 != reach1) {
         FAIL("W=2 or W=4 reach count differs from W=1 baseline");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+/*
+ * test_same_generation_multiworker:
+ * Issue #352: 3-body recursive join with self-join on non-col0 column.
+ * sg(x,y) :- parent(x,p), parent(y,p).
+ * sg(x,y) :- parent(x,xp), sg(xp,yp), parent(y,yp).
+ * Parent edges: (1,0),(2,0),(3,1),(4,1),(5,2).
+ * W=1 baseline: 13 sg rows. W=2 must match.
+ */
+static int
+test_same_generation_multiworker(void)
+{
+    TEST("Same-generation 3-body join: W=2 matches W=1 (Issue #352)");
+
+    wl_plan_t *p1 = NULL, *p2 = NULL;
+    wirelog_program_t *g1 = NULL, *g2 = NULL;
+
+    wl_col_session_t *s1 = make_session(PROG_SAME_GEN, 1, &p1, &g1);
+    wl_col_session_t *s2 = make_session(PROG_SAME_GEN, 2, &p2, &g2);
+
+    if (!s1 || !s2) {
+        if (s1) cleanup_session(s1, p1, g1);
+        if (s2) cleanup_session(s2, p2, g2);
+        FAIL("session create");
+        return 1;
+    }
+
+    int64_t parents[] = { 1, 0, 2, 0, 3, 1, 4, 1, 5, 2 };
+    insert_facts(s1, "parent", parents, 5);
+    insert_facts(s2, "parent", parents, 5);
+
+    int rc1 = wl_session_step(&s1->base);
+    int rc2 = wl_session_step(&s2->base);
+
+    uint32_t cnt1 = count_rows(s1, "sg");
+    uint32_t cnt2 = count_rows(s2, "sg");
+
+    cleanup_session(s1, p1, g1);
+    cleanup_session(s2, p2, g2);
+
+    if (rc1 != 0 || rc2 != 0) {
+        FAIL("session step failed");
+        return 1;
+    }
+    if (cnt1 != 13) {
+        FAIL("W=1 baseline: expected 13 sg rows");
+        return 1;
+    }
+    if (cnt2 != cnt1) {
+        FAIL("W=2 sg count differs from W=1 baseline");
         return 1;
     }
     PASS();
@@ -546,6 +608,7 @@ main(void)
     printf("\n-- Correctness --\n");
     test_reachability_w2();
     test_tc_diamond_multiworker();
+    test_same_generation_multiworker();
     test_multi_stratum_multiworker();
 
     printf("\n-- Determinism --\n");

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1461,6 +1461,117 @@ tdd_init_workers(wl_col_session_t *coord)
 }
 
 /*
+ * tdd_replicate_workers:
+ * Give every worker a FULL COPY of all coordinator relations.
+ *
+ * Unlike tdd_init_workers (which partitions by column 0), this function
+ * replicates each relation to every worker.  Required for recursive strata
+ * where multi-way joins may reference columns other than the partition key
+ * (e.g. the same-generation self-join on parent.col1).
+ *
+ * Issue #352: partitioning by col0 breaks self-joins on non-col0 columns
+ * and 3-body recursive rules where IDB appears in the middle of the join.
+ */
+static int
+tdd_replicate_workers(wl_col_session_t *coord)
+{
+    tdd_cleanup_workers(coord);
+
+    uint32_t W = coord->num_workers;
+    uint32_t nrels = coord->nrels;
+
+    /* No relations: create empty worker sessions */
+    if (nrels == 0) {
+        for (uint32_t w = 0; w < W; w++) {
+            int rc = col_worker_session_create(coord, w, NULL, 0,
+                    &coord->tdd_workers[w]);
+            if (rc != 0) {
+                tdd_cleanup_workers(coord);
+                return rc;
+            }
+            coord->tdd_workers_count = w + 1;
+        }
+        return 0;
+    }
+
+    /* Allocate W x nrels relation matrix */
+    col_rel_t ***worker_rels = (col_rel_t ***)calloc(W, sizeof(col_rel_t **));
+    if (!worker_rels)
+        return ENOMEM;
+
+    int rc = 0;
+    for (uint32_t w = 0; w < W; w++) {
+        worker_rels[w] = (col_rel_t **)calloc(nrels, sizeof(col_rel_t *));
+        if (!worker_rels[w]) {
+            for (uint32_t j = 0; j < w; j++)
+                free((void *)worker_rels[j]);
+            free((void *)worker_rels);
+            return ENOMEM;
+        }
+    }
+
+    /* Replicate each coordinator relation to every worker */
+    uint32_t rels_built = 0;
+
+    for (uint32_t r = 0; r < nrels && rc == 0; r++) {
+        col_rel_t *rel = coord->rels[r];
+        if (!rel)
+            continue;
+
+        const char *name = rel->name;
+
+        for (uint32_t w = 0; w < W && rc == 0; w++) {
+            col_rel_t *copy = col_rel_new_auto(name, rel->ncols);
+            if (!copy) {
+                rc = ENOMEM;
+                break;
+            }
+            if (rel->nrows > 0) {
+                rc = col_rel_append_all(copy, rel, NULL);
+                if (rc != 0) {
+                    col_rel_destroy(copy);
+                    break;
+                }
+            }
+            worker_rels[w][rels_built] = copy;
+        }
+
+        if (rc == 0)
+            rels_built++;
+    }
+
+    /* Create worker sessions */
+    uint32_t created = 0;
+    if (rc == 0) {
+        for (uint32_t w = 0; w < W; w++) {
+            rc = col_worker_session_create(coord, w,
+                    worker_rels[w], rels_built, &coord->tdd_workers[w]);
+            if (rc != 0)
+                break;
+            created++;
+        }
+    }
+
+    /* On failure: destroy successfully-created workers; free unclaimed rels */
+    if (rc != 0) {
+        for (uint32_t w = created; w < W; w++) {
+            for (uint32_t p = 0; p < rels_built; p++)
+                col_rel_destroy(worker_rels[w][p]);
+        }
+        coord->tdd_workers_count = created;
+        tdd_cleanup_workers(coord);
+    } else {
+        coord->tdd_workers_count = W;
+    }
+
+    for (uint32_t w = 0; w < W; w++)
+        free((void *)worker_rels[w]);
+    free((void *)worker_rels);
+
+    return rc;
+}
+
+/*
  * tdd_worker_subpass_fn:
  * Execute one sub-pass of the semi-naive iteration on a worker's partition.
  *
@@ -2343,8 +2454,14 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             coord->outer_epoch);
     }
 
-    /* Partition coordinator relations to workers */
-    rc = tdd_init_workers(coord);
+    /* Issue #352: Replicate (not partition) coordinator relations to workers.
+     * Recursive strata may contain multi-way joins on columns other than
+     * col0 (e.g. same-generation self-join on parent.col1).  Partitioning
+     * by col0 would split rows that share the same join key across workers,
+     * causing missed joins.  Replication ensures every worker can evaluate
+     * complete joins at the cost of redundant computation; the final
+     * merge+dedup step eliminates duplicates. */
+    rc = tdd_replicate_workers(coord);
     if (rc != 0)
         return rc;
 


### PR DESCRIPTION
## Summary

- **Root cause:** `col_eval_stratum_tdd_recursive` partitioned relations by column 0 via `tdd_init_workers()`. For 3-body recursive rules like `sg(x,y) :- parent(x,xp), sg(xp,yp), parent(y,yp)`, joins on non-col0 columns (e.g. `parent.col1`) caused rows sharing a join key to be split across workers, producing missed joins.
- **Fix:** New `tdd_replicate_workers()` gives every worker a full copy of all coordinator relations for recursive strata. Non-recursive strata continue using partition-by-col0.
- **Test:** Added `test_same_generation_multiworker` — same-generation program with 5 parent edges, verifies W=2 produces identical results to W=1 baseline (13 sg rows).

## Test plan

- [x] ASAN build passes (0 errors)
- [x] Full test suite: 108 OK, 1 Expected Fail, 0 Fail
- [x] New `test_same_generation_multiworker` validates W=1 vs W=2 correctness
- [x] Code review: no CRITICAL/HIGH issues

Closes #352