### PR TITLE
fix(#352,#353): Fix multiworker recursive replication and empty stratum handling

### DIFF
--- a/tests/test_tdd_integration.c
+++ b/tests/test_tdd_integration.c
@@ -518,19 +518,19 @@ test_single_tuple_w2(void)
 }
 
 /*
- * test_empty_multi_stratum_w1:
- * Multi-stratum program with empty EDB and W=1.
+ * test_empty_multi_stratum_w2:
+ * Multi-stratum program with empty EDB and W=2.
  * All relations must be empty, no error.
- * Verifies multi-stratum empty path through the integration pipeline.
+ * Verifies multi-stratum empty path through the TDD integration pipeline.
  */
 static int
-test_empty_multi_stratum_w1(void)
+test_empty_multi_stratum_w2(void)
 {
-    TEST("Empty multi-stratum W=1: all relations empty");
+    TEST("Empty multi-stratum W=2: all relations empty");
 
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
-    wl_col_session_t *sess = make_session(PROG_MULTI_STRATUM, 1, &plan, &prog);
+    wl_col_session_t *sess = make_session(PROG_MULTI_STRATUM, 2, &plan, &prog);
     if (!sess) {
         FAIL("session create");
         return 1;
@@ -617,7 +617,7 @@ main(void)
 
     printf("\n-- Edge Cases --\n");
     test_single_tuple_w2();
-    test_empty_multi_stratum_w1();
+    test_empty_multi_stratum_w2();
     test_w1_fallback_api();
 
     printf("\n%d/%d tests passed", tests_passed, tests_run);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1911,6 +1911,24 @@ tdd_merge_worker_results(const wl_plan_stratum_t *sp,
 
             rc = col_rel_append_all(target, wrel, NULL);
         }
+
+        /* Issue #353: When all workers produced empty results, the relation
+         * was never registered on the coordinator.  Subsequent strata that
+         * reference it (e.g. recursive stratum reading non-recursive output)
+         * would fail with ENOENT.  Register an empty relation so downstream
+         * strata can find it. */
+        if (!target && rc == 0) {
+            target = col_rel_new_auto(rel_name, 0);
+            if (!target) {
+                rc = ENOMEM;
+            } else {
+                rc = session_add_rel(coord, target);
+                if (rc != 0) {
+                    col_rel_destroy(target);
+                    target = NULL;
+                }
+            }
+        }
     }
 
     return rc;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -645,7 +645,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     uint32_t worker_id, col_rel_t **partitions,
     uint32_t num_partitions, wl_col_session_t *out_worker)
 {
-    if (!coordinator || !out_worker || !partitions)
+    if (!coordinator || !out_worker || (!partitions && num_partitions > 0))
         return EINVAL;
 
     /* Step 1: Bitwise copy — copies all value fields (frontiers,
@@ -707,13 +707,15 @@ col_worker_session_create(wl_col_session_t *coordinator,
         coordinator->mem_ledger.total_budget);
 
     /* Step 6: Populate rels[] with partition relations (ownership transfer) */
-    out_worker->rels
-        = (col_rel_t **)calloc(num_partitions, sizeof(col_rel_t *));
-    if (!out_worker->rels)
-        goto cleanup;
-    for (uint32_t i = 0; i < num_partitions; i++) {
-        out_worker->rels[i] = partitions[i];
-        partitions[i] = NULL; /* Mark as transferred */
+    if (num_partitions > 0) {
+        out_worker->rels
+            = (col_rel_t **)calloc(num_partitions, sizeof(col_rel_t *));
+        if (!out_worker->rels)
+            goto cleanup;
+        for (uint32_t i = 0; i < num_partitions; i++) {
+            out_worker->rels[i] = partitions[i];
+            partitions[i] = NULL; /* Mark as transferred */
+        }
     }
     out_worker->nrels = num_partitions;
     out_worker->rel_cap = num_partitions;


### PR DESCRIPTION
## Summary
- Fix 3-body recursive join producing incorrect results with multiworker (W>1)
- Fix empty multi-stratum program returning error with W=2

## Root Causes

### #352: 3-body recursive join
`tdd_init_workers` partitions all relations by col0. For 3-body joins like `sg(x,y) :- parent(x,xp), sg(xp,yp), parent(y,yp)`, joins on col1 fail cross-partition. Fix: new `tdd_replicate_workers()` gives every worker a full copy of all relations for recursive strata.

### #353: Empty multi-stratum W=2
`tdd_merge_worker_results` skips registering relations when all workers produce zero rows. Downstream strata can't find the relation (ENOENT). Fix: register empty relation on coordinator even when all workers are empty.

Closes #352, Closes #353

## Test plan
- [x] test_same_generation_multiworker: W=2 produces 13 sg rows (was 5)
- [x] test_empty_multi_stratum_w2: W=2 returns rc=0 (was rc=2)
- [x] All 109 tests pass (108 OK + 1 expected fail)
- [x] ASAN/UBSAN clean