### PR TITLE
fix(#426): Scale join_output_limit by 1/W for TDD workers

### DIFF
--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -633,6 +633,122 @@ test_invalid_args(void)
 }
 
 static int
+test_join_output_limit_scaling(void)
+{
+    TEST("join_output_limit scaled 1/W per worker (Issue #426)");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+
+    /* --- W=1: worker gets full limit --- */
+    wl_col_session_t *coord1 = make_coordinator(&plan, &prog);
+    if (!coord1) {
+        FAIL("coordinator creation W=1");
+        return 1;
+    }
+    coord1->num_workers = 1;
+    coord1->join_output_limit = 4000;
+
+    int64_t rows1[] = { 1, 2 };
+    insert_edges(coord1, rows1, 1);
+
+    col_rel_t **parts1 = NULL;
+    partition_rel(coord1, "edge", 1, &parts1);
+
+    wl_col_session_t w1;
+    memset(&w1, 0, sizeof(w1));
+    col_worker_session_create(coord1, 0, parts1, 1, &w1);
+    free(parts1);
+
+    int ok = (w1.join_output_limit == 4000);
+    col_worker_session_destroy(&w1);
+    cleanup_coordinator(coord1, plan, prog);
+
+    if (!ok) {
+        FAIL("W=1: worker should get full limit");
+        return 1;
+    }
+
+    /* --- W=4: worker gets 1/4 of limit --- */
+    plan = NULL;
+    prog = NULL;
+    wl_col_session_t *coord4 = make_coordinator(&plan, &prog);
+    if (!coord4) {
+        FAIL("coordinator creation W=4");
+        return 1;
+    }
+    coord4->num_workers = 4;
+    coord4->join_output_limit = 8000;
+
+    int64_t rows4[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    insert_edges(coord4, rows4, 4);
+
+    col_rel_t **parts4 = NULL;
+    partition_rel(coord4, "edge", 4, &parts4);
+
+    /* Create 4 workers; each should get join_output_limit = 8000/4 = 2000 */
+    wl_col_session_t workers4[4];
+    memset(workers4, 0, sizeof(workers4));
+    for (uint32_t w = 0; w < 4; w++) {
+        col_rel_t *wp[1] = { parts4[w] };
+        parts4[w] = NULL;
+        col_worker_session_create(coord4, w, wp, 1, &workers4[w]);
+        if (workers4[w].join_output_limit != 2000)
+            ok = 0;
+    }
+    free(parts4);
+
+    for (uint32_t w = 0; w < 4; w++)
+        col_worker_session_destroy(&workers4[w]);
+    cleanup_coordinator(coord4, plan, prog);
+
+    if (!ok) {
+        FAIL("W=4: worker should get 1/4 of limit");
+        return 1;
+    }
+
+    /* --- W=2: zero limit stays zero (disabled) --- */
+    plan = NULL;
+    prog = NULL;
+    wl_col_session_t *coord2 = make_coordinator(&plan, &prog);
+    if (!coord2) {
+        FAIL("coordinator creation W=2 zero limit");
+        return 1;
+    }
+    coord2->num_workers = 2;
+    coord2->join_output_limit = 0; /* disabled */
+
+    int64_t rows2[] = { 1, 2, 3, 4 };
+    insert_edges(coord2, rows2, 2);
+
+    col_rel_t **parts2 = NULL;
+    partition_rel(coord2, "edge", 2, &parts2);
+
+    wl_col_session_t w2a, w2b;
+    memset(&w2a, 0, sizeof(w2a));
+    memset(&w2b, 0, sizeof(w2b));
+    col_rel_t *p2a[1] = { parts2[0] }; parts2[0] = NULL;
+    col_rel_t *p2b[1] = { parts2[1] }; parts2[1] = NULL;
+    col_worker_session_create(coord2, 0, p2a, 1, &w2a);
+    col_worker_session_create(coord2, 1, p2b, 1, &w2b);
+    free(parts2);
+
+    if (w2a.join_output_limit != 0 || w2b.join_output_limit != 0)
+        ok = 0;
+
+    col_worker_session_destroy(&w2a);
+    col_worker_session_destroy(&w2b);
+    cleanup_coordinator(coord2, plan, prog);
+
+    if (!ok) {
+        FAIL("zero limit should stay zero (disabled)");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
 test_hash_table_independent(void)
 {
     TEST("worker hash table is independent (lazy rebuild)");
@@ -699,6 +815,7 @@ main(void)
     test_find_rel_returns_partition();
     test_invalid_args();
     test_hash_table_independent();
+    test_join_output_limit_scaling();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -877,6 +877,17 @@ col_worker_session_create(wl_col_session_t *coordinator,
     }
     wl_mem_ledger_init(&out_worker->mem_ledger, worker_budget);
 
+    /* Issue #426: Scale join_output_limit per worker.
+     * The bitwise copy above gave the worker the coordinator's full limit;
+     * shrink to a fair per-worker share (0 = disabled, preserved as-is).
+     * Clamp to minimum 1 so that limit < W does not accidentally disable
+     * the cap (0 means unlimited). */
+    if (coordinator->num_workers > 0 && coordinator->join_output_limit > 0) {
+        uint64_t per_worker =
+            coordinator->join_output_limit / coordinator->num_workers;
+        out_worker->join_output_limit = per_worker > 0 ? per_worker : 1;
+    }
+
     /* Step 6: Populate rels[] with partition relations (ownership transfer) */
     if (num_partitions > 0) {
         out_worker->rels


### PR DESCRIPTION
## Summary

- Scale `join_output_limit` by `1/W` in `col_worker_session_create` so aggregate join output across all TDD workers stays within the coordinator's intended limit
- Clamp per-worker limit to minimum 1 to prevent `limit < W` integer division from yielding 0 (which means "disabled")
- Preserve limit=0 (disabled) semantics as-is

## Changes

- **wirelog/columnar/session.c**: Added join_output_limit scaling after mem_ledger init in `col_worker_session_create`
- **tests/test_worker_session.c**: Added `test_join_output_limit_scaling` covering W=1 (full limit), W=4 (quarter limit), and limit=0 (disabled stays disabled)

## Test plan

- [x] W=1: worker gets full coordinator limit
- [x] W=4: worker gets 1/4 of coordinator limit
- [x] limit=0 (disabled): stays 0 for workers
- [x] 117/117 tests pass
- [x] ASAN clean

Closes #426