### PR TITLE
perf(#285): Cache delta relation names in wl_plan_relation_t

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -592,8 +592,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
             for (uint32_t ri = 0; ri < nrels; ri++) {
                 if (!delta_rels[ri])
                     continue;
-                char dname[256];
-                snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+                const char *dname = sp->relations[ri].delta_name;
                 session_remove_rel(sess, dname);
                 int rc = session_add_rel(sess, delta_rels[ri]);
                 if (rc != 0)
@@ -616,9 +615,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                 > 0) { /* only skip from effective iteration 1 onward */
                 bool all_deltas_net_zero = true;
                 for (uint32_t ri = 0; ri < nrels; ri++) {
-                    char dname[256];
-                    snprintf(dname, sizeof(dname), "$d$%s",
-                        sp->relations[ri].name);
+                    const char *dname = sp->relations[ri].delta_name;
                     col_rel_t *delta = session_find_rel(sess, dname);
                     if (!delta || delta->nrows == 0) {
                         /* Empty delta: net multiplicity is zero */
@@ -766,8 +763,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
 
             /* Remove delta relations from session (evaluation is complete) */
             for (uint32_t ri = 0; ri < nrels; ri++) {
-                char dname[256];
-                snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+                const char *dname = sp->relations[ri].delta_name;
                 session_remove_rel(sess, dname);
             }
 
@@ -785,8 +781,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     continue; /* no new rows for this relation */
                 }
 
-                char dname[256];
-                snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+                const char *dname = sp->relations[ri].delta_name;
                 col_rel_t *delta = col_rel_pool_new_like(
                     sess->delta_pool, dname, r);
                 if (!delta) {
@@ -954,8 +949,7 @@ stride_error:
     for (uint32_t ri = 0; ri < nrels; ri++) {
         if (delta_rels[ri])
             col_rel_destroy(delta_rels[ri]);
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
         session_remove_rel(sess, dname);
     }
     free(delta_rels);
@@ -1428,8 +1422,7 @@ bool
 stratum_has_preseeded_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess)
 {
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
         col_rel_t *delta = session_find_rel(sess, dname);
         if (delta && delta->nrows > 0)
             return true;
@@ -1928,8 +1921,7 @@ tdd_worker_subpass_fn(void *arg)
      * Pre-installed $d$ persists across iterations; nrows=0 triggers
      * has_empty_forced_delta skip, same as absent $d$. */
     for (uint32_t ri = 0; ri < nrels; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
         col_rel_t *d = session_find_rel(sess, dname);
         if (d) {
             d->nrows = 0;
@@ -1946,8 +1938,7 @@ tdd_worker_subpass_fn(void *arg)
         if (!r || snap[ri] >= r->nrows)
             continue;
 
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
 
         /* Heap-allocate delta so it survives delta_pool_reset below. */
         col_rel_t *delta = col_rel_new_like(dname, r);
@@ -2442,8 +2433,7 @@ static int
 tdd_broadcast_relation_delta(const wl_plan_stratum_t *sp, uint32_t ri,
     wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W)
 {
-    char dname[256];
-    snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+    const char *dname = sp->relations[ri].delta_name;
 
     for (uint32_t w = 0; w < W; w++)
         session_remove_rel(&coord->tdd_workers[w], dname);
@@ -2698,8 +2688,7 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
     }
 
     for (uint32_t ri = 0; ri < nrels; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
 
         /* Locate EXCHANGE key columns for this relation (if any). */
         const uint32_t *key_cols = NULL;
@@ -3412,8 +3401,7 @@ tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
     uint32_t nrels = sp->relation_count;
 
     for (uint32_t ri = 0; ri < nrels; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
 
         /* Count total rows and find ncols */
         uint32_t total_rows = 0;
@@ -3693,8 +3681,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
     int rc = 0;
 
     for (uint32_t ri = 0; ri < nrels; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
         const char *rel_name = sp->relations[ri].name;
 
         /* Remove stale $d$ from workers */
@@ -3991,8 +3978,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
      * session_remove_rel, and broadcast refills instead of create+add.
      * Eliminates per-iteration alloc/free/session-ops (14k iters for CRDT). */
     for (uint32_t ri = 0; ri < nrels; ri++) {
-        char dname[256];
-        snprintf(dname, sizeof(dname), "$d$%s", sp->relations[ri].name);
+        const char *dname = sp->relations[ri].delta_name;
         col_rel_t *coord_rel = session_find_rel(coord,
                 sp->relations[ri].name);
         uint32_t ncols_ri = coord_rel ? coord_rel->ncols : 0;
@@ -4138,9 +4124,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                     sp->relations[ri].name);
             if (!cidb || cidb->nrows == 0)
                 continue;
-            char dname[256];
-            snprintf(dname, sizeof(dname), "$d$%s",
-                sp->relations[ri].name);
+            const char *dname = sp->relations[ri].delta_name;
             uint32_t ncols = cidb->ncols;
             /* Install full IDB as $d$ on worker 0 */
             col_rel_t *d0 = session_find_rel(&coord->tdd_workers[0], dname);

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -314,12 +314,16 @@ typedef struct {
  *
  * Operator sequence for a single IDB relation within a stratum.
  *
- * @name:      Null-terminated relation name (caller-owned).
- * @ops:       Array of operator descriptors (caller-owned).
- * @op_count:  Number of operators in the sequence.
+ * @name:       Null-terminated relation name (caller-owned).
+ * @delta_name: Pre-computed "$d$<name>" string (caller-owned).
+ *              Caches the delta relation name to avoid repeated snprintf
+ *              in eval hot paths (Issue #285).
+ * @ops:        Array of operator descriptors (caller-owned).
+ * @op_count:   Number of operators in the sequence.
  */
 typedef struct {
     const char *name;
+    char *delta_name;
     const wl_plan_op_t *ops;
     uint32_t op_count;
 } wl_plan_relation_t;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -58,6 +58,19 @@ dup_str(const char *s)
     return d;
 }
 
+/* Allocate "$d$<name>" for delta relation name caching (Issue #285). */
+static char *
+make_delta_name(const char *name)
+{
+    size_t len = strlen(name);
+    char *d = (char *)malloc(len + 4); /* "$d$" (3) + name + NUL */
+    if (!d)
+        return NULL;
+    memcpy(d, "$d$", 3);
+    memcpy(d + 3, name, len + 1);
+    return d;
+}
+
 /* ======================================================================== */
 /* Expression serialization (IR expr tree -> postfix byte buffer)           */
 /* ======================================================================== */
@@ -2263,6 +2276,7 @@ wl_plan_free(wl_plan_t *plan)
                     wl_plan_relation_t *rel
                         = (wl_plan_relation_t *)&st->relations[r];
                     free((void *)rel->name);
+                    free(rel->delta_name);
                     if (rel->ops) {
                         for (uint32_t o = 0; o < rel->op_count; o++)
                             free_op((wl_plan_op_t *)&rel->ops[o]);
@@ -2439,6 +2453,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
             }
 
             rels[u].name = dup_str(rel_name);
+            rels[u].delta_name = make_delta_name(rel_name);
 
             if (ir_root) {
                 op_list_t ol;
@@ -2447,6 +2462,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     /* Clean up already-built relations */
                     for (uint32_t v = 0; v < u; v++) {
                         free((void *)rels[v].name);
+                        free(rels[v].delta_name);
                         if (rels[v].ops) {
                             for (uint32_t o = 0; o < rels[v].op_count; o++)
                                 free_op((wl_plan_op_t *)&rels[v].ops[o]);
@@ -2454,6 +2470,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                         }
                     }
                     free((void *)rels[u].name);
+                    free(rels[u].delta_name);
                     free(rels);
                     free(strata);
                     wl_plan_free(plan);
@@ -2469,6 +2486,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)unique_names);
                     for (uint32_t v = 0; v < u; v++) {
                         free((void *)rels[v].name);
+                        free(rels[v].delta_name);
                         if (rels[v].ops) {
                             for (uint32_t o = 0; o < rels[v].op_count; o++)
                                 free_op((wl_plan_op_t *)&rels[v].ops[o]);
@@ -2476,6 +2494,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                         }
                     }
                     free((void *)rels[u].name);
+                    free(rels[u].delta_name);
                     free(rels);
                     free(strata);
                     wl_plan_free(plan);


### PR DESCRIPTION
## Summary

- Pre-compute `"$d$<name>"` delta names at plan creation time and cache in `wl_plan_relation_t.delta_name`
- Replace 14 of 16 `snprintf(dname, ..., "$d$%s", sp->relations[ri].name)` calls in eval.c hot paths with direct pointer use
- 2 remaining snprintf calls (lines 165, 315) use `op->relation_name`/local `rel_name` — cannot access cached field

## Changes

- **wirelog/exec_plan.h**: Added `char *delta_name` field to `wl_plan_relation_t`
- **wirelog/exec_plan_gen.c**: Added `make_delta_name()` helper, pre-compute in `wl_plan_from_program()`, free in `wl_plan_free()` + all error paths
- **wirelog/columnar/eval.c**: 14 snprintf calls replaced with `sp->relations[ri].delta_name`

## Test plan

- [x] 117/117 tests pass
- [x] No behavior change (cached name identical to snprintf result)
- [x] Memory management: freed in wl_plan_free + 4 error cleanup paths

Closes #285