### PR TITLE
feat(#444): Add time-evolution example with per-epoch delta isolation

### DIFF
--- a/examples/11-time-evolution/README.md
+++ b/examples/11-time-evolution/README.md
@@ -1,0 +1,68 @@
+# Example 11: Time Evolution
+
+## Overview
+
+Each `wl_easy_step()` call is one tick of logical time.  Only deltas
+produced *during that step* are reported to the delta callback -- tuples
+derived in earlier steps are never re-emitted.
+
+## Datalog Program
+
+```datalog
+.decl event(id: symbol, kind: symbol)
+.decl alert(id: symbol)
+
+alert(ID) :- event(ID, "error").
+```
+
+A trivially non-recursive rule: any event whose kind is `"error"` produces
+an alert.  The lesson here is purely about *time* (epochs), not about
+complex derivation.
+
+## Build & Run
+
+```sh
+meson compile -C build time_evolution_demo
+./build/examples/11-time-evolution/time_evolution_demo
+```
+
+## Expected Output
+
+```
+Example 11: Time Evolution (Per-Epoch Delta Isolation)
+=====================================================
+
+=== epoch 1: insert e1(error), e2(info), e3(error) ===
++ alert("e1")
++ alert("e3")
+
+=== epoch 2: insert e4(info) ===
+
+=== epoch 3: insert e5(error) ===
++ alert("e5")
+
+Done.
+```
+
+## What This Demonstrates
+
+- **Per-epoch delta isolation** -- epoch 3 reports only `+ alert("e5")`,
+  not the epoch-1 alerts `alert("e1")` and `alert("e3")`.
+- **Insert-only monotone growth** -- no retraction is used; the fact set
+  grows monotonically across steps.
+- **Discrete time model** -- each `wl_easy_step()` advances logical time
+  by one tick.  Facts inserted between steps are batched into the next
+  step.
+
+## What You Will NOT See Here
+
+- **Retraction** (`-1` deltas) -- see Example 09 (#442).
+- **Recursive relations under update** -- see Example 10 (#443).
+- **Snapshot vs delta mode comparison** -- see Example 12 (#445).
+
+## See Also
+
+- `examples/08-delta-queries/` -- single-step delta introduction
+- `examples/09-retraction-basics/` -- retraction deltas
+- `examples/10-recursive-under-update/` -- recursive transitive closure
+- `wirelog/wl_easy.h` -- convenience facade API

--- a/examples/11-time-evolution/events.dl
+++ b/examples/11-time-evolution/events.dl
@@ -1,0 +1,4 @@
+.decl event(id: symbol, kind: symbol)
+.decl alert(id: symbol)
+
+alert(ID) :- event(ID, "error").

--- a/examples/11-time-evolution/expected.txt
+++ b/examples/11-time-evolution/expected.txt
@@ -1,0 +1,13 @@
+Example 11: Time Evolution (Per-Epoch Delta Isolation)
+=====================================================
+
+=== epoch 1: insert e1(error), e2(info), e3(error) ===
++ alert("e1")
++ alert("e3")
+
+=== epoch 2: insert e4(info) ===
+
+=== epoch 3: insert e5(error) ===
++ alert("e5")
+
+Done.

--- a/examples/11-time-evolution/golden_diff.py
+++ b/examples/11-time-evolution/golden_diff.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# golden_diff.py - Portable golden-output comparator for example 11.
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+#
+# Usage: golden_diff.py <executable> <expected.txt>
+#
+# Runs the executable, captures stdout, and compares it line-by-line
+# against the expected file.  On mismatch, prints a unified diff and
+# exits non-zero.  Trailing whitespace on each line is preserved; line
+# endings are normalized to LF so Windows builds are not spuriously
+# flagged.
+
+import difflib
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: golden_diff.py <executable> <expected.txt>",
+              file=sys.stderr)
+        return 2
+
+    exe, expected_path = sys.argv[1], sys.argv[2]
+
+    result = subprocess.run(
+        [exe],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            "executable exited with code %d\n" % result.returncode)
+        sys.stderr.write(result.stderr)
+        return result.returncode
+
+    actual = result.stdout.replace("\r\n", "\n").splitlines(keepends=True)
+    with open(expected_path, "r", encoding="utf-8", newline="") as fh:
+        expected = fh.read().replace("\r\n", "\n").splitlines(keepends=True)
+
+    if actual == expected:
+        return 0
+
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            expected, actual,
+            fromfile="expected.txt",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+    sys.stdout.write("\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/11-time-evolution/meson.build
+++ b/examples/11-time-evolution/meson.build
@@ -1,0 +1,32 @@
+# examples/11-time-evolution/meson.build
+# Time Evolution demo using the wl_easy facade (#444)
+#
+# Include all wirelog sources directly (same pattern as example 08 and
+# wirelog_cli) to ensure proper linking under LTO.
+
+time_evolution_demo = executable(
+  'time_evolution_demo',
+  files('time_evolution_demo.c'),
+  wirelog_sources,
+  config_h_file,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+
+# Golden-output regression test: run time_evolution_demo and diff stdout
+# against expected.txt.  Python3 is used instead of bash for portability
+# across the Linux / macOS / Windows-MSVC CI matrix (wirelog already has
+# a python3 dependency for the uncrustify hook setup).
+py3 = find_program('python3', 'python', required: true)
+test(
+  'example_11_time_evolution_golden',
+  py3,
+  args: [
+    files('golden_diff.py')[0],
+    time_evolution_demo.full_path(),
+    meson.current_source_dir() / 'expected.txt',
+  ],
+  depends: time_evolution_demo,
+  suite: 'examples',
+)

--- a/examples/11-time-evolution/time_evolution_demo.c
+++ b/examples/11-time-evolution/time_evolution_demo.c
@@ -1,0 +1,202 @@
+/*
+ * time_evolution_demo.c - Example 11: Time Evolution (Per-Epoch Delta Isolation)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ *
+ * Demonstrates per-epoch delta isolation (Issue #444).  Each call to
+ * wl_easy_step() is a discrete time epoch; the delta callback fires only
+ * for tuples derived during that epoch, not since the beginning.
+ *
+ * Build: meson compile -C build time_evolution_demo
+ * Run:   ./build/examples/11-time-evolution/time_evolution_demo
+ */
+
+#include "wirelog/wl_easy.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *EVENTS_SRC =
+    ".decl event(id: symbol, kind: symbol)\n"
+    ".decl alert(id: symbol)\n"
+    "alert(ID) :- event(ID, \"error\").\n";
+
+/* Per-step buffered delta for deterministic output ordering.
+ * Deltas within a single step are not contractually ordered by the
+ * columnar backend; buffer-and-sort makes the golden file stable. */
+typedef struct {
+    char relation[64];
+    int64_t row[2];
+    uint32_t ncols;
+    int32_t diff;
+} buffered_delta_t;
+
+#define MAX_BUFFER 16
+
+typedef struct {
+    wl_easy_session_t *sess;
+    buffered_delta_t buf[MAX_BUFFER];
+    int n;
+    int plus_alert_count;
+} demo_ctx_t;
+
+static int
+delta_compare(const void *a, const void *b)
+{
+    const buffered_delta_t *da = a;
+    const buffered_delta_t *db = b;
+    /* Sort by sign (positive before negative), then relation, then row IDs. */
+    if (da->diff != db->diff)
+        return (da->diff < db->diff) - (da->diff > db->diff);
+    int c = strcmp(da->relation, db->relation);
+    if (c != 0)
+        return c;
+    if (da->row[0] != db->row[0])
+        return (da->row[0] > db->row[0]) - (da->row[0] < db->row[0]);
+    return (da->row[1] > db->row[1]) - (da->row[1] < db->row[1]);
+}
+
+static void
+on_delta_wrapper(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    demo_ctx_t *ctx = (demo_ctx_t *)user_data;
+
+    /* Count +alert deltas for per-epoch assertion. */
+    if (diff > 0 && strcmp(relation, "alert") == 0)
+        ctx->plus_alert_count++;
+
+    if (ctx->n >= MAX_BUFFER) {
+        fprintf(stderr, "delta buffer overflow\n");
+        abort();
+    }
+    buffered_delta_t *b = &ctx->buf[ctx->n++];
+    strncpy(b->relation, relation, sizeof(b->relation) - 1);
+    b->relation[sizeof(b->relation) - 1] = '\0';
+    b->ncols = ncols;
+    b->row[0] = (ncols > 0) ? row[0] : 0;
+    b->row[1] = (ncols > 1) ? row[1] : 0;
+    b->diff = diff;
+}
+
+static void
+flush_sorted(demo_ctx_t *ctx)
+{
+    if (ctx->n == 0)
+        return;
+    qsort(ctx->buf, (size_t)ctx->n, sizeof(ctx->buf[0]), delta_compare);
+    for (int i = 0; i < ctx->n; i++) {
+        buffered_delta_t *b = &ctx->buf[i];
+        wl_easy_print_delta(b->relation, b->row, b->ncols, b->diff, ctx->sess);
+    }
+    ctx->n = 0;
+}
+
+#define CHECK(expr, msg) do { \
+            if ((expr) != WIRELOG_OK) { \
+                fprintf(stderr, "%s\n", msg); \
+                wl_easy_close(s); \
+                return 1; \
+            } \
+} while (0)
+
+int
+main(void)
+{
+    printf("Example 11: Time Evolution (Per-Epoch Delta Isolation)\n");
+    printf("=====================================================\n");
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(EVENTS_SRC, &s) != WIRELOG_OK) {
+        fprintf(stderr, "wl_easy_open failed\n");
+        return 1;
+    }
+
+    demo_ctx_t ctx = { .sess = s, .n = 0, .plus_alert_count = 0 };
+    CHECK(wl_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
+        "wl_easy_set_delta_cb failed");
+
+    /* Pre-intern all symbols used in the demo. */
+    (void)wl_easy_intern(s, "e1");
+    (void)wl_easy_intern(s, "e2");
+    (void)wl_easy_intern(s, "e3");
+    (void)wl_easy_intern(s, "e4");
+    (void)wl_easy_intern(s, "e5");
+    (void)wl_easy_intern(s, "error");
+    (void)wl_easy_intern(s, "info");
+
+    /* ---- Epoch 1 ---- */
+    wl_easy_banner("epoch 1: insert e1(error), e2(info), e3(error)");
+    CHECK(wl_easy_insert_sym(s, "event", "e1", "error", NULL),
+        "insert event(e1,error) failed");
+    CHECK(wl_easy_insert_sym(s, "event", "e2", "info", NULL),
+        "insert event(e2,info) failed");
+    CHECK(wl_easy_insert_sym(s, "event", "e3", "error", NULL),
+        "insert event(e3,error) failed");
+    ctx.plus_alert_count = 0;
+    CHECK(wl_easy_step(s), "step 1 failed");
+    flush_sorted(&ctx);
+
+    if (ctx.plus_alert_count != 2) {
+        fprintf(stderr,
+            "ASSERTION FAILED: expected 2 '+' alert deltas in epoch 1, "
+            "got %d\n", ctx.plus_alert_count);
+        wl_easy_close(s);
+        return 2;
+    }
+
+    /* ---- Epoch 2 ---- */
+    wl_easy_banner("epoch 2: insert e4(info)");
+    CHECK(wl_easy_insert_sym(s, "event", "e4", "info", NULL),
+        "insert event(e4,info) failed");
+    ctx.plus_alert_count = 0;
+    CHECK(wl_easy_step(s), "step 2 failed");
+    flush_sorted(&ctx);
+
+    if (ctx.plus_alert_count != 0) {
+        fprintf(stderr,
+            "ASSERTION FAILED: expected 0 '+' alert deltas in epoch 2, "
+            "got %d\n", ctx.plus_alert_count);
+        wl_easy_close(s);
+        return 2;
+    }
+
+    /* ---- Epoch 3 ---- */
+    wl_easy_banner("epoch 3: insert e5(error)");
+    CHECK(wl_easy_insert_sym(s, "event", "e5", "error", NULL),
+        "insert event(e5,error) failed");
+    ctx.plus_alert_count = 0;
+    CHECK(wl_easy_step(s), "step 3 failed");
+    flush_sorted(&ctx);
+
+    if (ctx.plus_alert_count != 1) {
+        fprintf(stderr,
+            "ASSERTION FAILED: expected 1 '+' alert delta in epoch 3, "
+            "got %d\n", ctx.plus_alert_count);
+        wl_easy_close(s);
+        return 2;
+    }
+
+    printf("\nDone.\n");
+
+    wl_easy_close(s);
+    return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -302,6 +302,7 @@ endif
 subdir('examples/08-delta-queries')
 subdir('examples/09-retraction-basics')
 subdir('examples/10-recursive-under-update')
+subdir('examples/11-time-evolution')
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Documentation


### PR DESCRIPTION
## Summary

Closes #444. Adds `examples/11-time-evolution`, demonstrating that each `wl_easy_step()` call is a discrete time epoch whose delta callback reports only newly derived tuples from that step.

Three epochs: two error events trigger alerts (epoch 1), one info event triggers nothing (epoch 2), one more error triggers exactly one new alert (epoch 3) without re-emitting the epoch-1 alerts.

## Files

- `examples/11-time-evolution/time_evolution_demo.c` (~120 LOC)
- `examples/11-time-evolution/events.dl`, `expected.txt`, `golden_diff.py`, `meson.build`, `README.md`
- Root `meson.build` subdir registration

## Test results

- `meson test -C build`: 125/125 green
- ASan: clean
- Golden output matches byte-for-byte
- In-driver assertions: epoch 1 = 2, epoch 2 = 0, epoch 3 = 1

## Review

- Code-reviewer: APPROVE-WITH-NITS (ncols hardcoding fixed before push)
- Critic: ACCEPT

## Test plan

- [x] 125/125 tests pass
- [x] Golden test passes
- [x] In-driver assertions verify exact delta counts per epoch
- [x] ASan clean
- [x] README 8 sections with forward/back references
- [x] No emojis, no Co-Authored-By