### PR TITLE
feat(#445): Add snapshot-vs-delta comparison example

### DIFF
--- a/examples/12-snapshot-vs-delta/README.md
+++ b/examples/12-snapshot-vs-delta/README.md
@@ -1,0 +1,84 @@
+# Example 12: Snapshot vs Delta
+
+## Overview
+
+Wirelog exposes two ways to read derived facts: **delta mode**
+(`wl_easy_set_delta_cb` + `wl_easy_step`) streams sign-tagged changes
+as they happen, while **snapshot mode** (`wl_easy_snapshot`) returns the
+full IDB in one shot.  Two APIs, same answer, different costs.
+
+This example runs the same access-control Datalog program through both
+APIs and verifies that the results are identical.
+
+## Datalog Program
+
+```datalog
+.decl can(user: symbol, perm: symbol)
+.decl granted(user: symbol, perm: symbol)
+granted(U, P) :- can(U, P).
+```
+
+Five `can` facts are inserted (alice/read, alice/write, bob/read,
+bob/admin, carol/read).  The single rule derives a corresponding
+`granted` tuple for each.
+
+## Build & Run
+
+```sh
+meson compile -C build snapshot_demo
+./build/examples/12-snapshot-vs-delta/snapshot_demo
+```
+
+## Expected Output
+
+```
+Example 12: Snapshot vs Delta
+=============================
+
+=== delta mode: wl_easy_step ===
+=== snapshot mode: wl_easy_snapshot ===
+
+delta: granted("alice", "read")        snapshot: granted("alice", "read")        MATCH
+delta: granted("alice", "write")       snapshot: granted("alice", "write")       MATCH
+delta: granted("bob", "admin")         snapshot: granted("bob", "admin")         MATCH
+delta: granted("bob", "read")          snapshot: granted("bob", "read")          MATCH
+delta: granted("carol", "read")        snapshot: granted("carol", "read")        MATCH
+
+PASS
+```
+
+## When To Use Which
+
+| API | Use when | Cost shape |
+|---|---|---|
+| `wl_easy_set_delta_cb` + `wl_easy_step` | Facts trickle in over time and you want to react to *changes* | Proportional to delta size |
+| `wl_easy_snapshot` | One-shot batch query where you want the full IDB | Proportional to total IDB size |
+
+Delta mode is ideal for long-running sessions where only incremental
+updates matter (monitoring, streaming pipelines).  Snapshot mode is
+simpler when you just need the current answer without tracking history.
+
+## What This Demonstrates
+
+- **Semantic equivalence** -- the incremental delta path produces the
+  same derived facts as full re-evaluation via snapshot.
+- **Two independent sessions** -- because `wl_easy_snapshot` is an
+  evaluating call, the driver uses separate sessions to avoid
+  double-counting.  See `wl_easy.h` for the full contract.
+- **Deterministic comparison** -- both result sets are sorted before
+  comparison so the test is stable regardless of backend evaluation
+  order.
+
+## What You Will NOT See Here
+
+- **Retraction** (`-1` deltas) -- see Example 09 (#442).
+- **Recursive relations under update** -- see Example 10 (#443).
+- **Multi-step time evolution** -- see Example 11 (#444).
+
+## See Also
+
+- `examples/08-delta-queries/` -- single-step delta introduction
+- `examples/09-retraction-basics/` -- retraction deltas
+- `examples/10-recursive-under-update/` -- recursive transitive closure
+- `examples/11-time-evolution/` -- per-epoch delta isolation
+- `wirelog/wl_easy.h` -- convenience facade API

--- a/examples/12-snapshot-vs-delta/access_control.dl
+++ b/examples/12-snapshot-vs-delta/access_control.dl
@@ -1,0 +1,3 @@
+.decl can(user: symbol, perm: symbol)
+.decl granted(user: symbol, perm: symbol)
+granted(U, P) :- can(U, P).

--- a/examples/12-snapshot-vs-delta/expected.txt
+++ b/examples/12-snapshot-vs-delta/expected.txt
@@ -1,0 +1,13 @@
+Example 12: Snapshot vs Delta
+=============================
+
+=== delta mode: wl_easy_step ===
+=== snapshot mode: wl_easy_snapshot ===
+
+delta: granted("alice", "read")        snapshot: granted("alice", "read")        MATCH
+delta: granted("alice", "write")       snapshot: granted("alice", "write")       MATCH
+delta: granted("bob", "admin")         snapshot: granted("bob", "admin")         MATCH
+delta: granted("bob", "read")          snapshot: granted("bob", "read")          MATCH
+delta: granted("carol", "read")        snapshot: granted("carol", "read")        MATCH
+
+PASS

--- a/examples/12-snapshot-vs-delta/golden_diff.py
+++ b/examples/12-snapshot-vs-delta/golden_diff.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# golden_diff.py - Portable golden-output comparator for example 12.
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+#
+# Usage: golden_diff.py <executable> <expected.txt>
+#
+# Runs the executable, captures stdout, and compares it line-by-line
+# against the expected file.  On mismatch, prints a unified diff and
+# exits non-zero.  Trailing whitespace on each line is preserved; line
+# endings are normalized to LF so Windows builds are not spuriously
+# flagged.
+
+import difflib
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: golden_diff.py <executable> <expected.txt>",
+              file=sys.stderr)
+        return 2
+
+    exe, expected_path = sys.argv[1], sys.argv[2]
+
+    result = subprocess.run(
+        [exe],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            "executable exited with code %d\n" % result.returncode)
+        sys.stderr.write(result.stderr)
+        return result.returncode
+
+    actual = result.stdout.replace("\r\n", "\n").splitlines(keepends=True)
+    with open(expected_path, "r", encoding="utf-8", newline="") as fh:
+        expected = fh.read().replace("\r\n", "\n").splitlines(keepends=True)
+
+    if actual == expected:
+        return 0
+
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            expected, actual,
+            fromfile="expected.txt",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+    sys.stdout.write("\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/12-snapshot-vs-delta/meson.build
+++ b/examples/12-snapshot-vs-delta/meson.build
@@ -1,0 +1,32 @@
+# examples/12-snapshot-vs-delta/meson.build
+# Snapshot vs Delta comparison demo using the wl_easy facade (#445)
+#
+# Include all wirelog sources directly (same pattern as example 08 and
+# wirelog_cli) to ensure proper linking under LTO.
+
+snapshot_demo = executable(
+  'snapshot_demo',
+  files('snapshot_demo.c'),
+  wirelog_sources,
+  config_h_file,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+
+# Golden-output regression test: run snapshot_demo and diff stdout against
+# expected.txt.  Python3 is used instead of bash for portability across the
+# Linux / macOS / Windows-MSVC CI matrix (wirelog already has a python3
+# dependency for the uncrustify hook setup).
+py3 = find_program('python3', 'python', required: true)
+test(
+  'example_12_snapshot_demo_golden',
+  py3,
+  args: [
+    files('golden_diff.py')[0],
+    snapshot_demo.full_path(),
+    meson.current_source_dir() / 'expected.txt',
+  ],
+  depends: snapshot_demo,
+  suite: 'examples',
+)

--- a/examples/12-snapshot-vs-delta/snapshot_demo.c
+++ b/examples/12-snapshot-vs-delta/snapshot_demo.c
@@ -1,0 +1,253 @@
+/*
+ * snapshot_demo.c - Example 12: Snapshot vs Delta
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ *
+ * Runs the same access-control Datalog program through both
+ * wl_easy_step (delta callback, streaming) and wl_easy_snapshot
+ * (one-shot batch) and verifies that they produce identical results.
+ *
+ * IMPORTANT: wl_easy_snapshot() is an evaluating call -- calling
+ * wl_easy_step() followed by wl_easy_snapshot() on the same insert
+ * batch would double-count derived tuples.  This driver therefore
+ * uses two independent sessions: one for the delta path and one for
+ * the snapshot path.
+ *
+ * Build: meson compile -C build snapshot_demo
+ * Run:   ./build/examples/12-snapshot-vs-delta/snapshot_demo
+ */
+
+#include "wirelog/wl_easy.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *ACCESS_CONTROL_SRC =
+    ".decl can(user: symbol, perm: symbol)\n"
+    ".decl granted(user: symbol, perm: symbol)\n"
+    "granted(U, P) :- can(U, P).\n";
+
+/* ---- Symbol lookup table ---- */
+
+typedef struct {
+    int64_t id;
+    const char *str;
+} sym_entry_t;
+
+#define MAX_SYMS 16
+
+typedef struct {
+    sym_entry_t entries[MAX_SYMS];
+    int n;
+} sym_table_t;
+
+static void
+sym_table_add(sym_table_t *t, int64_t id, const char *str)
+{
+    if (t->n >= MAX_SYMS) {
+        fprintf(stderr, "sym_table overflow\n");
+        abort();
+    }
+    t->entries[t->n].id = id;
+    t->entries[t->n].str = str;
+    t->n++;
+}
+
+static const char *
+sym_table_lookup(const sym_table_t *t, int64_t id)
+{
+    for (int i = 0; i < t->n; i++) {
+        if (t->entries[i].id == id)
+            return t->entries[i].str;
+    }
+    return NULL;
+}
+
+/* ---- Result collector ---- */
+
+#define MAX_RESULTS 16
+#define RESULT_LEN 128
+
+typedef struct {
+    char rows[MAX_RESULTS][RESULT_LEN];
+    int n;
+    sym_table_t *syms;
+} result_set_t;
+
+static void
+format_tuple(result_set_t *rs, const char *relation, const int64_t *row,
+    uint32_t ncols)
+{
+    if (rs->n >= MAX_RESULTS) {
+        fprintf(stderr, "result_set overflow\n");
+        abort();
+    }
+    char *buf = rs->rows[rs->n];
+    int off = snprintf(buf, RESULT_LEN, "%s(", relation);
+    for (uint32_t i = 0; i < ncols; i++) {
+        if (i > 0)
+            off += snprintf(buf + off, RESULT_LEN - off, ", ");
+        const char *str = sym_table_lookup(rs->syms, row[i]);
+        if (!str) {
+            fprintf(stderr,
+                "reverse-intern miss for relation '%s' column %u "
+                "id %" PRId64 "\n",
+                relation, i, row[i]);
+            abort();
+        }
+        off += snprintf(buf + off, RESULT_LEN - off, "\"%s\"", str);
+    }
+    snprintf(buf + off, RESULT_LEN - off, ")");
+    rs->n++;
+}
+
+/* ---- Callbacks ---- */
+
+static void
+on_delta(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    if (diff <= 0)
+        return; /* only collect insertions */
+    result_set_t *rs = (result_set_t *)user_data;
+    format_tuple(rs, relation, row, ncols);
+}
+
+static void
+on_snapshot(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    result_set_t *rs = (result_set_t *)user_data;
+    format_tuple(rs, relation, row, ncols);
+}
+
+/* ---- Sorting ---- */
+
+static int
+row_compare(const void *a, const void *b)
+{
+    return strcmp((const char *)a, (const char *)b);
+}
+
+/* ---- Helpers ---- */
+
+#define CHECK(expr, msg, sess) do { \
+            if ((expr) != WIRELOG_OK) { \
+                fprintf(stderr, "%s\n", msg); \
+                wl_easy_close(sess); \
+                return 1; \
+            } \
+} while (0)
+
+static void
+insert_facts(wl_easy_session_t *s, sym_table_t *syms)
+{
+    int64_t alice = wl_easy_intern(s, "alice");
+    int64_t bob = wl_easy_intern(s, "bob");
+    int64_t carol = wl_easy_intern(s, "carol");
+    int64_t rd = wl_easy_intern(s, "read");
+    int64_t wr = wl_easy_intern(s, "write");
+    int64_t adm = wl_easy_intern(s, "admin");
+
+    sym_table_add(syms, alice, "alice");
+    sym_table_add(syms, bob,   "bob");
+    sym_table_add(syms, carol, "carol");
+    sym_table_add(syms, rd,    "read");
+    sym_table_add(syms, wr,    "write");
+    sym_table_add(syms, adm,   "admin");
+
+    int64_t r1[] = { alice, rd  };
+    int64_t r2[] = { alice, wr  };
+    int64_t r3[] = { bob,   rd  };
+    int64_t r4[] = { bob,   adm };
+    int64_t r5[] = { carol, rd  };
+    wl_easy_insert(s, "can", r1, 2);
+    wl_easy_insert(s, "can", r2, 2);
+    wl_easy_insert(s, "can", r3, 2);
+    wl_easy_insert(s, "can", r4, 2);
+    wl_easy_insert(s, "can", r5, 2);
+}
+
+int
+main(void)
+{
+    printf("Example 12: Snapshot vs Delta\n");
+    printf("=============================\n\n");
+
+    /* ---- Path A: delta mode ---- */
+    wl_easy_session_t *sd = NULL;
+    if (wl_easy_open(ACCESS_CONTROL_SRC, &sd) != WIRELOG_OK) {
+        fprintf(stderr, "wl_easy_open (delta) failed\n");
+        return 1;
+    }
+
+    sym_table_t delta_syms = { .n = 0 };
+    result_set_t delta_rs = { .n = 0, .syms = &delta_syms };
+
+    CHECK(wl_easy_set_delta_cb(sd, on_delta, &delta_rs),
+        "wl_easy_set_delta_cb failed", sd);
+
+    insert_facts(sd, &delta_syms);
+
+    printf("=== delta mode: wl_easy_step ===\n");
+    CHECK(wl_easy_step(sd), "wl_easy_step failed", sd);
+    wl_easy_close(sd);
+
+    /* ---- Path B: snapshot mode ---- */
+    wl_easy_session_t *ss = NULL;
+    if (wl_easy_open(ACCESS_CONTROL_SRC, &ss) != WIRELOG_OK) {
+        fprintf(stderr, "wl_easy_open (snapshot) failed\n");
+        return 1;
+    }
+
+    sym_table_t snap_syms = { .n = 0 };
+    result_set_t snap_rs = { .n = 0, .syms = &snap_syms };
+
+    insert_facts(ss, &snap_syms);
+
+    printf("=== snapshot mode: wl_easy_snapshot ===\n");
+    CHECK(wl_easy_snapshot(ss, "granted", on_snapshot, &snap_rs),
+        "wl_easy_snapshot failed", ss);
+    wl_easy_close(ss);
+
+    /* ---- Sort both result sets ---- */
+    qsort(delta_rs.rows, (size_t)delta_rs.n, RESULT_LEN, row_compare);
+    qsort(snap_rs.rows, (size_t)snap_rs.n, RESULT_LEN, row_compare);
+
+    /* ---- Side-by-side comparison ---- */
+    printf("\n");
+    int max = delta_rs.n > snap_rs.n ? delta_rs.n : snap_rs.n;
+    int pass = 1;
+    for (int i = 0; i < max; i++) {
+        const char *d = (i < delta_rs.n) ? delta_rs.rows[i] : "(none)";
+        const char *s = (i < snap_rs.n) ? snap_rs.rows[i] : "(none)";
+        int match = (strcmp(d, s) == 0);
+        if (!match)
+            pass = 0;
+        printf("delta: %-30s  snapshot: %-30s  %s\n",
+            d, s, match ? "MATCH" : "MISMATCH");
+    }
+
+    printf("\n%s\n", pass ? "PASS" : "FAIL");
+
+    return pass ? 0 : 1;
+}

--- a/meson.build
+++ b/meson.build
@@ -303,6 +303,7 @@ subdir('examples/08-delta-queries')
 subdir('examples/09-retraction-basics')
 subdir('examples/10-recursive-under-update')
 subdir('examples/11-time-evolution')
+subdir('examples/12-snapshot-vs-delta')
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Documentation


### PR DESCRIPTION
## Summary

Closes #445. Adds `examples/12-snapshot-vs-delta`, the final incremental-reasoning example. Runs the same access-control Datalog program through both `wl_easy_step` (delta callback, streaming) and `wl_easy_snapshot` (one-shot batch) and verifies they produce identical results.

## Design

Uses **two independent sessions** to avoid the step+snapshot double-counting pitfall documented in `wl_easy.h`. Each session gets its own `sym_table_t` (id-to-string mapping via `wl_easy_intern`) so no internal APIs are needed.

## Files

- `examples/12-snapshot-vs-delta/snapshot_demo.c` (~250 LOC) — side-by-side delta vs snapshot comparison
- `examples/12-snapshot-vs-delta/access_control.dl`, `expected.txt`, `golden_diff.py`, `meson.build`, `README.md`
- Root `meson.build` subdir registration

## Test results

- `meson test -C build`: 126/126 green
- ASan: clean
- Golden output matches, PASS printed
- No emojis, no Co-Authored-By

## Review

- Code-reviewer: APPROVE (1 MEDIUM nit: add comment about per-session sym_table)
- Critic: ACCEPT

## Test plan

- [x] 126/126 tests pass
- [x] Golden test passes
- [x] PASS printed (delta == snapshot)
- [x] ASan clean
- [x] README "When To Use Which" decision table present
- [x] README "What You Will NOT See Here" with forward references