### PR TITLE
feat(#449): Add WL_PUBLIC visibility macro and io_adapter.h install path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -221,6 +221,7 @@ wirelog_public_headers = [
   'wirelog/wirelog-parser.h',
   'wirelog/wirelog-ir.h',
   'wirelog/wirelog-optimizer.h',
+  'wirelog/wirelog-export.h',
   'wirelog/wl_easy.h',
 ]
 
@@ -234,6 +235,7 @@ wirelog_lib = library(
   wirelog_sources,
   config_h_file,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING'],
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: true,
   version: project_version,
@@ -245,6 +247,7 @@ wirelog_static_lib = static_library(
   wirelog_sources,
   config_h_file,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING'],
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: false,  # Not installed by default
 )
@@ -253,6 +256,11 @@ wirelog_static_lib = static_library(
 install_headers(
   wirelog_public_headers,
   subdir: 'wirelog'
+)
+
+install_headers(
+  'wirelog/io/io_adapter.h',
+  subdir: 'wirelog/io'
 )
 
 #pkg - config file

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -1,0 +1,15 @@
+/*
+ * io_adapter.h - wirelog I/O Adapter Interface
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * Placeholder for Issue #451. Actual adapter API will be added there.
+ */
+
+#ifndef WIRELOG_IO_IO_ADAPTER_H
+#define WIRELOG_IO_IO_ADAPTER_H
+
+#include "wirelog/wirelog-export.h"
+
+#endif /* WIRELOG_IO_IO_ADAPTER_H */

--- a/wirelog/wirelog-export.h
+++ b/wirelog/wirelog-export.h
@@ -1,0 +1,23 @@
+/*
+ * wirelog-export.h - Symbol visibility macros
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#ifndef WIRELOG_EXPORT_H
+#define WIRELOG_EXPORT_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef WIRELOG_BUILDING
+    #define WL_PUBLIC __declspec(dllexport)
+  #else
+    #define WL_PUBLIC __declspec(dllimport)
+  #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
+  #define WL_PUBLIC __attribute__((visibility("default")))
+#else
+  #define WL_PUBLIC
+#endif
+
+#endif /* WIRELOG_EXPORT_H */


### PR DESCRIPTION
## Summary

Closes #449. Part of #446 (I/O adapter umbrella).

Introduces the `WL_PUBLIC` symbol visibility macro and wires the `wirelog/io/` install path for the upcoming adapter interface.

## Changes

- `wirelog/wirelog-export.h` — new public header with `WL_PUBLIC` macro (GCC visibility, MSVC dllexport/dllimport, fallback)
- `wirelog/io/io_adapter.h` — placeholder for #451, includes wirelog-export.h
- `meson.build` — add wirelog-export.h to public headers, add WIRELOG_BUILDING c_args to both shared and static lib targets, add install_headers for wirelog/io/

## Test results

- meson test -C build: 129/129 green
- meson install --destdir verified: wirelog-export.h and io/io_adapter.h install to correct paths
- Standalone compile of io_adapter.h from install path: OK

## Review

- Code-reviewer: APPROVE (0 issues)