### PR TITLE
feat(#453): Implement wl_io_ctx_t accessors with intern wrapper and platform_ctx

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2404,8 +2404,10 @@ test('io_adapter', test_io_adapter_exe)
 
 test_io_ctx_exe = executable(
   'test_io_ctx',
-  files('test_io_ctx.c'),
+  files('test_io_ctx.c', '../wirelog/io/io_ctx.c'),
+  intern_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING'],
   install: false,
 )
 test('io_ctx', test_io_ctx_exe)

--- a/tests/test_io_ctx.c
+++ b/tests/test_io_ctx.c
@@ -12,14 +12,37 @@
  * Part of #446 (I/O adapter umbrella).
  */
 
+#define TEST_CTX_PRESENT
+
 #include <stdio.h>
 #include <string.h>
 
-/* The io_adapter.h header declares context accessor prototypes (#451)
- * but the actual functions are not yet implemented (#453). Guard all
- * test bodies behind TEST_CTX_PRESENT so they compile as SKIP until
- * the implementation lands. */
-#include "wirelog/io/io_adapter.h"
+#include "wirelog/io/io_ctx_internal.h"
+
+/* ======================================================================== */
+/* Mock Helpers                                                             */
+/* ======================================================================== */
+
+static wl_intern_t *g_intern = NULL;
+
+static wl_io_ctx_t *
+create_mock_ctx(const char *relation_name,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    const char **param_keys, const char **param_values,
+    uint32_t num_params)
+{
+    if (!g_intern)
+        g_intern = wl_intern_create();
+    return wl_io_ctx_create_test(relation_name, col_types, num_cols,
+               param_keys, param_values, num_params,
+               g_intern);
+}
+
+static void
+destroy_mock_ctx(wl_io_ctx_t *ctx)
+{
+    wl_io_ctx_destroy(ctx);
+}
 
 /* ======================================================================== */
 /* Test Harness                                                             */
@@ -199,5 +222,9 @@ int main(void) {
     test_platform_ctx();
     printf("=== Results: %d passed, %d failed, %d skipped ===\n",
         passed, failed, skipped);
+    if (g_intern) {
+        wl_intern_free(g_intern);
+        g_intern = NULL;
+    }
     return failed > 0 ? 1 : 0;
 }

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -1,0 +1,131 @@
+/*
+ * io_ctx.c - I/O Context Accessors
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * Implements the wl_io_ctx_t accessor functions declared in
+ * io_adapter.h (#451) and the test constructor/destructor from
+ * io_ctx_internal.h.
+ *
+ * Part of #446 (I/O adapter umbrella).
+ */
+
+#include "wirelog/io/io_ctx_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------------ */
+/* Test Constructor / Destructor                                            */
+/* ------------------------------------------------------------------------ */
+
+wl_io_ctx_t *
+wl_io_ctx_create_test(const char *relation_name,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    const char **param_keys, const char **param_values,
+    uint32_t num_params, wl_intern_t *intern)
+{
+    wl_io_ctx_t *ctx = (wl_io_ctx_t *)calloc(1, sizeof(*ctx));
+    if (!ctx)
+        return NULL;
+
+    ctx->relation_name = relation_name;
+    ctx->num_cols = num_cols;
+    ctx->num_params = num_params;
+    ctx->param_keys = param_keys;
+    ctx->param_values = param_values;
+    ctx->intern = intern;
+    ctx->platform_ctx = NULL;
+
+    if (num_cols > 0 && col_types) {
+        ctx->col_types = (wirelog_column_type_t *)malloc(
+            num_cols * sizeof(wirelog_column_type_t));
+        if (!ctx->col_types) {
+            free(ctx);
+            return NULL;
+        }
+        memcpy(ctx->col_types, col_types,
+            num_cols * sizeof(wirelog_column_type_t));
+    }
+
+    return ctx;
+}
+
+void
+wl_io_ctx_destroy(wl_io_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+    free(ctx->col_types);
+    free(ctx);
+}
+
+/* ------------------------------------------------------------------------ */
+/* Accessors                                                                */
+/* ------------------------------------------------------------------------ */
+
+const char *
+wl_io_ctx_relation_name(const wl_io_ctx_t *ctx)
+{
+    if (!ctx)
+        return NULL;
+    return ctx->relation_name;
+}
+
+uint32_t
+wl_io_ctx_num_cols(const wl_io_ctx_t *ctx)
+{
+    if (!ctx)
+        return 0;
+    return ctx->num_cols;
+}
+
+wirelog_column_type_t
+wl_io_ctx_col_type(const wl_io_ctx_t *ctx, uint32_t col)
+{
+    if (!ctx || col >= ctx->num_cols)
+        return (wirelog_column_type_t)-1;
+    return ctx->col_types[col];
+}
+
+const char *
+wl_io_ctx_param(const wl_io_ctx_t *ctx, const char *key)
+{
+    if (!ctx || !key)
+        return NULL;
+    for (uint32_t i = 0; i < ctx->num_params; i++) {
+        if (strcmp(ctx->param_keys[i], key) == 0)
+            return ctx->param_values[i];
+    }
+    return NULL;
+}
+
+int64_t
+wl_io_ctx_intern_string(wl_io_ctx_t *ctx, const char *utf8)
+{
+    if (!ctx || !ctx->intern)
+        return -1;
+    int64_t id = wl_intern_put(ctx->intern, utf8);
+    if (id < 0)
+        return -1;
+    /* Return 1-based IDs so callers can treat 0 as invalid/absent. */
+    return id + 1;
+}
+
+void *
+wl_io_ctx_platform(const wl_io_ctx_t *ctx)
+{
+    if (!ctx)
+        return NULL;
+    return ctx->platform_ctx;
+}
+
+int
+wl_io_ctx_set_platform(wl_io_ctx_t *ctx, void *ptr)
+{
+    if (!ctx)
+        return -1;
+    ctx->platform_ctx = ptr;
+    return 0;
+}

--- a/wirelog/io/io_ctx_internal.h
+++ b/wirelog/io/io_ctx_internal.h
@@ -1,0 +1,39 @@
+/*
+ * io_ctx_internal.h - I/O Context Internal Definition
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * INTERNAL HEADER - not installed, not part of public API.
+ * Defines the concrete wl_io_ctx struct so that the opaque typedef
+ * in io_adapter.h is preserved for library consumers.
+ *
+ * Part of #446 (I/O adapter umbrella).
+ */
+
+#ifndef WIRELOG_IO_IO_CTX_INTERNAL_H
+#define WIRELOG_IO_IO_CTX_INTERNAL_H
+
+#include "wirelog/io/io_adapter.h"
+#include "wirelog/intern.h"
+
+struct wl_io_ctx {
+    const char             *relation_name;
+    uint32_t num_cols;
+    wirelog_column_type_t  *col_types;       /* owned copy */
+    const char            **param_keys;      /* borrowed */
+    const char            **param_values;    /* borrowed */
+    uint32_t num_params;
+    wl_intern_t            *intern;          /* owned by context */
+    void                   *platform_ctx;
+};
+
+wl_io_ctx_t *wl_io_ctx_create_test(
+    const char *relation_name,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    const char **param_keys, const char **param_values, uint32_t num_params,
+    wl_intern_t *intern);
+
+void wl_io_ctx_destroy(wl_io_ctx_t *ctx);
+
+#endif /* WIRELOG_IO_IO_CTX_INTERNAL_H */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -77,7 +77,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
 #I / O Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_io_src = files('io/csv_reader.c', 'io/io_adapter.c', )
+wirelog_io_src = files('io/csv_reader.c', 'io/io_adapter.c', 'io/io_ctx.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #String Operations Module(Issue #143)


### PR DESCRIPTION
## Summary

Closes #453. Part of #446 (I/O adapter umbrella).

Implements the concrete wl_io_ctx_t struct and all 7 accessor functions, wrapping wl_intern_put for string interning without exposing wl_intern_t to adapters.

## Changes

- `wirelog/io/io_ctx_internal.h` — internal struct definition (not public)
- `wirelog/io/io_ctx.c` — all accessors + test constructor/destructor
- `tests/test_io_ctx.c` — lifted TEST_CTX_PRESENT guard, 7 tests now PASS
- `wirelog/meson.build` — added io_ctx.c to wirelog_io_src
- `tests/meson.build` — updated test linking

## Accessors

- `wl_io_ctx_relation_name` — returns relation name
- `wl_io_ctx_num_cols` — returns column count
- `wl_io_ctx_col_type` — returns column type by index
- `wl_io_ctx_param` — key=value parameter lookup
- `wl_io_ctx_intern_string` — wraps wl_intern_put (opaque)
- `wl_io_ctx_platform` / `wl_io_ctx_set_platform` — platform context slot

## Test results

- meson test: 131/131 green
- io_ctx: 7 PASS, 0 FAIL, 0 SKIP