### PR TITLE
feat(#455): Add wl_csv_read_file_via_ctx with intern callback

### DIFF
--- a/tests/test_csv.c
+++ b/tests/test_csv.c
@@ -26,22 +26,22 @@ static int tests_passed = 0;
 static int tests_failed = 0;
 
 #define TEST(name)                            \
-    do {                                      \
-        tests_run++;                          \
-        printf("  [%d] %s", tests_run, name); \
-    } while (0)
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
 
 #define PASS()                 \
-    do {                       \
-        tests_passed++;        \
-        printf(" ... PASS\n"); \
-    } while (0)
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                         \
-    do {                                  \
-        tests_failed++;                   \
-        printf(" ... FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
 
 /* ======================================================================== */
 /* Test: wl_csv_parse_line                                                  */
@@ -422,7 +422,7 @@ test_parse_line_ex_mixed(void)
     int64_t values[3];
     uint32_t count = 0;
     int rc = wl_csv_parse_line_ex("\"Alice\",42,\"Bob\"", ',', types, 3, values,
-                                  &count, intern);
+            &count, intern);
 
     if (rc != 0) {
         FAIL("returned non-zero");
@@ -476,7 +476,7 @@ test_parse_line_ex_unquoted_strings(void)
     int64_t values[2];
     uint32_t count = 0;
     int rc = wl_csv_parse_line_ex("hello,world", ',', types, 2, values, &count,
-                                  intern);
+            intern);
 
     if (rc != 0) {
         FAIL("returned non-zero");
@@ -539,6 +539,82 @@ test_parse_line_ex_all_int(void)
 }
 
 /* ======================================================================== */
+/* Test: wl_csv_read_file_via_ctx (callback-based, #455)                    */
+/* ======================================================================== */
+
+static int64_t fake_intern_counter;
+
+static int64_t
+fake_intern_cb(void *opaque, const char *str)
+{
+    (void)opaque;
+    (void)str;
+    return fake_intern_counter++;
+}
+
+static void
+test_csv_via_ctx_callback(void)
+{
+    TEST("read_file_via_ctx: callback invoked for STRING columns");
+
+    char path[512];
+    test_tmppath(path, sizeof(path), "wirelog_test_csv_via_ctx.csv");
+    FILE *f = fopen(path, "w");
+    if (!f) {
+        FAIL("cannot create temp file");
+        return;
+    }
+    fprintf(f, "\"Alice\",10\n\"Bob\",20\n\"Carol\",30\n");
+    fclose(f);
+
+    wirelog_column_type_t types[]
+        = { WIRELOG_TYPE_STRING, WIRELOG_TYPE_INT32 };
+
+    fake_intern_counter = 0;
+
+    int64_t *data = NULL;
+    uint32_t nrows = 0, ncols = 0;
+    int rc = wl_csv_read_file_via_ctx(path, ',', types, 2,
+            &data, &nrows, &ncols,
+            fake_intern_cb, NULL);
+    remove(path);
+
+    if (rc != 0) {
+        FAIL("returned non-zero");
+        return;
+    }
+    if (nrows != 3 || ncols != 2) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected 3x2, got %ux%u", nrows, ncols);
+        free(data);
+        FAIL(msg);
+        return;
+    }
+
+    /* Callback should have been called 3 times (once per STRING cell) */
+    if (fake_intern_counter != 3) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected 3 intern calls, got %d",
+            (int)fake_intern_counter);
+        free(data);
+        FAIL(msg);
+        return;
+    }
+
+    /* String column IDs: 0, 1, 2 (from counter); int column values: 10, 20, 30 */
+    if (data[0] != 0 || data[1] != 10
+        || data[2] != 1 || data[3] != 20
+        || data[4] != 2 || data[5] != 30) {
+        free(data);
+        FAIL("wrong data values");
+        return;
+    }
+
+    free(data);
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -570,8 +646,11 @@ main(void)
     test_read_file_null_args();
     test_read_file_inconsistent_cols();
 
+    printf("\n--- Callback-based Reading (#455) ---\n");
+    test_csv_via_ctx_callback();
+
     printf("\n=== Results: %d passed, %d failed, %d total ===\n\n",
-           tests_passed, tests_failed, tests_run);
+        tests_passed, tests_failed, tests_run);
 
     return tests_failed > 0 ? 1 : 0;
 }

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -17,7 +17,7 @@
 
 int
 wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
-                  uint32_t max_cols, uint32_t *count)
+    uint32_t max_cols, uint32_t *count)
 {
     if (!line || !values || !count)
         return -1;
@@ -76,7 +76,7 @@ wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
 
 int
 wl_csv_read_file(const char *path, char delimiter, int64_t **data,
-                 uint32_t *nrows, uint32_t *ncols)
+    uint32_t *nrows, uint32_t *ncols)
 {
     if (!path || !data || !nrows || !ncols)
         return -1;
@@ -107,7 +107,7 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
         int64_t row_values[CSV_MAX_COLS];
         uint32_t col_count = 0;
         int rc = wl_csv_parse_line(line, delimiter, row_values, CSV_MAX_COLS,
-                                   &col_count);
+                &col_count);
         if (rc != 0 || col_count == 0) {
             free(buf);
             fclose(f);
@@ -118,7 +118,7 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
         if (*nrows == 0) {
             cols_expected = col_count;
             buf = (int64_t *)malloc((size_t)capacity * cols_expected
-                                    * sizeof(int64_t));
+                    * sizeof(int64_t));
             if (!buf) {
                 fclose(f);
                 return -3;
@@ -144,7 +144,7 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
 
         /* Copy row into flat array */
         memcpy(&buf[(size_t)*nrows * cols_expected], row_values,
-               (size_t)cols_expected * sizeof(int64_t));
+            (size_t)cols_expected * sizeof(int64_t));
         (*nrows)++;
     }
 
@@ -161,8 +161,8 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
 
 int
 wl_csv_parse_line_ex(const char *line, char delimiter,
-                     const wirelog_column_type_t *col_types, uint32_t num_cols,
-                     int64_t *values, uint32_t *count, wl_intern_t *intern)
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t *values, uint32_t *count, wl_intern_t *intern)
 {
     if (!line || !col_types || !values || !count || num_cols == 0)
         return -1;
@@ -237,26 +237,113 @@ wl_csv_parse_line_ex(const char *line, char delimiter,
 }
 
 /* ======================================================================== */
-/* Extended File Reader (mixed int/string)                                  */
+/* Callback-based line parser (internal)                                    */
+/* ======================================================================== */
+
+static int
+csv_parse_line_via_ctx(const char *line, char delimiter,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t *values, uint32_t *count,
+    int64_t (*intern_cb)(void *opaque, const char *str),
+    void *opaque)
+{
+    if (!line || !col_types || !values || !count || num_cols == 0 || !intern_cb)
+        return -1;
+
+    *count = 0;
+    const char *p = line;
+
+    for (uint32_t col = 0; col < num_cols; col++) {
+        /* Skip leading whitespace */
+        while (*p && *p != delimiter && *p != '"' && isspace((unsigned char)*p))
+            p++;
+
+        if (*p == '\0' && col < num_cols - 1)
+            return -2; /* too few columns */
+
+        if (col_types[col] == WIRELOG_TYPE_STRING) {
+            /* Parse string field: quoted or unquoted */
+            char strbuf[4096];
+            size_t slen = 0;
+
+            if (*p == '"') {
+                /* Quoted field: read until closing quote */
+                p++; /* skip opening quote */
+                while (*p && *p != '"') {
+                    if (slen < sizeof(strbuf) - 1)
+                        strbuf[slen++] = *p;
+                    p++;
+                }
+                if (*p == '"')
+                    p++; /* skip closing quote */
+            } else {
+                /* Unquoted field: read until delimiter or end */
+                while (*p && *p != delimiter && *p != '\n' && *p != '\r') {
+                    if (slen < sizeof(strbuf) - 1)
+                        strbuf[slen++] = *p;
+                    p++;
+                }
+                /* Trim trailing whitespace */
+                while (slen > 0 && isspace((unsigned char)strbuf[slen - 1]))
+                    slen--;
+            }
+            strbuf[slen] = '\0';
+
+            values[col] = intern_cb(opaque, strbuf);
+            if (values[col] < 0)
+                return -1;
+        } else {
+            /* Parse integer field */
+            char *end;
+            values[col] = strtoll(p, &end, 10);
+            if (end == p)
+                return -1; /* not a valid integer */
+            p = end;
+
+            /* Skip trailing whitespace */
+            while (*p && *p != delimiter && isspace((unsigned char)*p))
+                p++;
+        }
+
+        (*count)++;
+
+        /* Skip delimiter between fields */
+        if (col < num_cols - 1) {
+            if (*p == delimiter)
+                p++;
+        }
+    }
+
+    return 0;
+}
+
+/* ======================================================================== */
+/* Callback-based File Reader (#455)                                        */
 /* ======================================================================== */
 
 int
-wl_csv_read_file_ex(const char *path, char delimiter,
-                    const wirelog_column_type_t *col_types, uint32_t num_cols,
-                    int64_t **data, uint32_t *nrows, uint32_t *ncols,
-                    wl_intern_t *intern)
+wl_csv_read_file_via_ctx(
+    const char *filepath,
+    char delimiter,
+    const wirelog_column_type_t *col_types,
+    uint32_t num_cols,
+    int64_t **out_data,
+    uint32_t *out_nrows,
+    uint32_t *out_ncols,
+    int64_t (*intern_cb)(void *opaque, const char *str),
+    void *opaque)
 {
-    if (!path || !col_types || !data || !nrows || !ncols || num_cols == 0
-        || !intern)
+    if (!filepath || !col_types || !out_data || !out_nrows || !out_ncols
+        || num_cols == 0 || !intern_cb)
         return -1;
 
-    FILE *f = fopen(path, "r");
+    FILE *f = fopen(filepath, "r");
     if (!f)
         return -1;
 
-    *data = NULL;
-    *nrows = 0;
-    *ncols = num_cols;
+    *out_data = NULL;
+    *out_nrows = 0;
+    *out_ncols = num_cols;
 
     uint32_t capacity = CSV_INITIAL_CAPACITY;
     int64_t *buf
@@ -279,8 +366,9 @@ wl_csv_read_file_ex(const char *path, char delimiter,
 
         int64_t row_values[CSV_MAX_COLS];
         uint32_t col_count = 0;
-        int rc = wl_csv_parse_line_ex(line, delimiter, col_types, num_cols,
-                                      row_values, &col_count, intern);
+        int rc = csv_parse_line_via_ctx(line, delimiter, col_types, num_cols,
+                row_values, &col_count,
+                intern_cb, opaque);
         if (rc != 0 || col_count != num_cols) {
             free(buf);
             fclose(f);
@@ -288,10 +376,10 @@ wl_csv_read_file_ex(const char *path, char delimiter,
         }
 
         /* Grow buffer if needed */
-        if (*nrows >= capacity) {
+        if (*out_nrows >= capacity) {
             capacity *= 2;
             int64_t *tmp = (int64_t *)realloc(buf, (size_t)capacity * num_cols
-                                                       * sizeof(int64_t));
+                    * sizeof(int64_t));
             if (!tmp) {
                 free(buf);
                 fclose(f);
@@ -301,13 +389,37 @@ wl_csv_read_file_ex(const char *path, char delimiter,
         }
 
         /* Copy row into flat array */
-        memcpy(&buf[(size_t)*nrows * num_cols], row_values,
-               (size_t)num_cols * sizeof(int64_t));
-        (*nrows)++;
+        memcpy(&buf[(size_t)*out_nrows * num_cols], row_values,
+            (size_t)num_cols * sizeof(int64_t));
+        (*out_nrows)++;
     }
 
     fclose(f);
 
-    *data = buf;
+    *out_data = buf;
     return 0;
+}
+
+/* ======================================================================== */
+/* Extended File Reader -- thin wrapper over via_ctx                         */
+/* ======================================================================== */
+
+/* Trampoline for backward compatibility */
+static int64_t
+intern_trampoline(void *opaque, const char *str)
+{
+    return wl_intern_put((wl_intern_t *)opaque, str);
+}
+
+int
+wl_csv_read_file_ex(const char *path, char delimiter,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t **data, uint32_t *nrows, uint32_t *ncols,
+    wl_intern_t *intern)
+{
+    if (!intern)
+        return -1;
+    return wl_csv_read_file_via_ctx(path, delimiter, col_types, num_cols,
+               data, nrows, ncols,
+               intern_trampoline, intern);
 }

--- a/wirelog/io/csv_reader.h
+++ b/wirelog/io/csv_reader.h
@@ -35,7 +35,7 @@
  */
 int
 wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
-                  uint32_t max_cols, uint32_t *count);
+    uint32_t max_cols, uint32_t *count);
 
 /**
  * wl_csv_read_file:
@@ -56,7 +56,7 @@ wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
  */
 int
 wl_csv_read_file(const char *path, char delimiter, int64_t **data,
-                 uint32_t *nrows, uint32_t *ncols);
+    uint32_t *nrows, uint32_t *ncols);
 
 /**
  * wl_csv_parse_line_ex:
@@ -81,8 +81,8 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
  */
 int
 wl_csv_parse_line_ex(const char *line, char delimiter,
-                     const wirelog_column_type_t *col_types, uint32_t num_cols,
-                     int64_t *values, uint32_t *count, wl_intern_t *intern);
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t *values, uint32_t *count, wl_intern_t *intern);
 
 /**
  * wl_csv_read_file_ex:
@@ -107,8 +107,29 @@ wl_csv_parse_line_ex(const char *line, char delimiter,
  */
 int
 wl_csv_read_file_ex(const char *path, char delimiter,
-                    const wirelog_column_type_t *col_types, uint32_t num_cols,
-                    int64_t **data, uint32_t *nrows, uint32_t *ncols,
-                    wl_intern_t *intern);
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t **data, uint32_t *nrows, uint32_t *ncols,
+    wl_intern_t *intern);
+
+/**
+ * wl_csv_read_file_via_ctx:
+ * Callback-based variant for I/O adapter integration (#455).
+ * @intern_cb: called for each STRING cell, must return an int64_t id.
+ * @opaque:    passed verbatim to intern_cb.
+ *
+ * Otherwise identical to wl_csv_read_file_ex.
+ * DO NOT DELETE -- Path A rollback target
+ */
+int
+wl_csv_read_file_via_ctx(
+    const char *filepath,
+    char delimiter,
+    const wirelog_column_type_t *col_types,
+    uint32_t num_cols,
+    int64_t **out_data,
+    uint32_t *out_nrows,
+    uint32_t *out_ncols,
+    int64_t (*intern_cb)(void *opaque, const char *str),
+    void *opaque);
 
 #endif /* WIRELOG_IO_CSV_READER_H */


### PR DESCRIPTION
## Summary

Closes #455. Part of #446 (I/O adapter umbrella).

Adds a callback-based CSV reader variant that accepts an (intern_cb, opaque) pair instead of wl_intern_t*, decoupling the CSV reader from the intern table type. Existing wl_csv_read_file_ex becomes a thin trampoline wrapper.

## Changes

- `wirelog/io/csv_reader.h` — new function declaration
- `wirelog/io/csv_reader.c` — callback-based parser + file reader, existing function converted to wrapper
- `tests/test_csv.c` — new test with fake intern callback

## Test results

- meson test: 131/131 green
- csv tests: 18 passed (all existing + 1 new)
- Backward compat: all existing callers unchanged