### PR TITLE
feat(#456): Implement built-in CSV adapter with auto-registration

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -207,6 +207,8 @@ backend_src = files(
 io_src = files(
   '../wirelog/io/csv_reader.c',
   '../wirelog/io/io_adapter.c',
+  '../wirelog/io/csv_adapter.c',
+  '../wirelog/io/io_ctx.c',
 )
 
 arena_src = files(
@@ -2389,7 +2391,7 @@ test('baseline_tab_nodes',
 
 test_io_adapter_exe = executable(
   'test_io_adapter',
-  files('test_io_adapter.c', '../wirelog/io/io_adapter.c'),
+  files('test_io_adapter.c', '../wirelog/io/io_adapter.c', '../wirelog/io/csv_adapter.c', '../wirelog/io/csv_reader.c', '../wirelog/io/io_ctx.c', '../wirelog/intern.c'),
   thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -1,0 +1,140 @@
+/*
+ * csv_adapter.c - Built-in CSV/TSV I/O Adapter
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ *
+ * Wraps wl_csv_read_file / wl_csv_read_file_via_ctx behind the
+ * wl_io_adapter_t vtable for auto-registration in the I/O registry.
+ *
+ * Part of #446 (I/O adapter umbrella).
+ */
+
+#include "wirelog/io/io_adapter.h"
+#include "wirelog/io/io_ctx_internal.h"
+#include "wirelog/io/csv_reader.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#if !defined(_WIN32) && !defined(_WIN64)
+#include <unistd.h>
+#else
+#include <direct.h>
+#define getcwd _getcwd
+#endif
+
+/* ======================================================================== */
+/* Intern Trampoline                                                        */
+/* ======================================================================== */
+
+static int64_t
+csv_intern_trampoline(void *opaque, const char *str)
+{
+    return wl_io_ctx_intern_string((wl_io_ctx_t *)opaque, str);
+}
+
+/* ======================================================================== */
+/* csv_read callback                                                        */
+/* ======================================================================== */
+
+static int
+csv_read(wl_io_ctx_t *ctx, int64_t **out_data,
+    uint32_t *out_nrows, void *user_data)
+{
+    (void)user_data;
+
+    /* ---- filename (required) ---- */
+    const char *filename = wl_io_ctx_param(ctx, "filename");
+    if (!filename)
+        return -1;
+
+    /* ---- delimiter (default: tab) ---- */
+    char delimiter = '\t';
+    const char *delim_str = wl_io_ctx_param(ctx, "delimiter");
+    if (delim_str) {
+        if (strcmp(delim_str, "\\t") == 0)
+            delimiter = '\t';
+        else
+            delimiter = delim_str[0];
+    }
+
+    /* ---- path resolution (absolute, then cwd-fallback) ---- */
+    const char *resolved_path = filename;
+    char resolved_buf[4096];
+
+    FILE *test_f = fopen(filename, "r");
+    if (!test_f && filename[0] != '/') {
+        char cwd[4096];
+        if (getcwd(cwd, sizeof(cwd)) != NULL) {
+            snprintf(resolved_buf, sizeof(resolved_buf), "%s/%s", cwd,
+                filename);
+            test_f = fopen(resolved_buf, "r");
+            if (test_f) {
+                resolved_path = resolved_buf;
+                fclose(test_f);
+            }
+        }
+    } else if (test_f) {
+        fclose(test_f);
+    }
+
+    /* ---- check for STRING columns ---- */
+    uint32_t num_cols = wl_io_ctx_num_cols(ctx);
+    int has_string = 0;
+    for (uint32_t i = 0; i < num_cols; i++) {
+        if (wl_io_ctx_col_type(ctx, i) == WIRELOG_TYPE_STRING) {
+            has_string = 1;
+            break;
+        }
+    }
+
+    if (has_string) {
+        /* Build col_types array from context */
+        wirelog_column_type_t *types = malloc(num_cols * sizeof(*types));
+        if (!types)
+            return -1;
+        for (uint32_t i = 0; i < num_cols; i++)
+            types[i] = wl_io_ctx_col_type(ctx, i);
+
+        uint32_t out_ncols = 0;
+        int rc = wl_csv_read_file_via_ctx(resolved_path, delimiter,
+                types, num_cols,
+                out_data, out_nrows, &out_ncols,
+                csv_intern_trampoline, ctx);
+        free(types);
+        return rc;
+    }
+
+    /* Integer-only path */
+    uint32_t out_ncols = 0;
+    return wl_csv_read_file(resolved_path, delimiter,
+               out_data, out_nrows, &out_ncols);
+}
+
+/* ======================================================================== */
+/* Adapter Definition                                                       */
+/* ======================================================================== */
+
+const wl_io_adapter_t wl_csv_adapter = {
+    .abi_version = WL_IO_ABI_VERSION,
+    .scheme = "csv",
+    .description = "Built-in CSV/TSV file reader",
+    .read = csv_read,
+    .validate = NULL,
+    .user_data = NULL,
+};

--- a/wirelog/io/io_adapter.c
+++ b/wirelog/io/io_adapter.c
@@ -80,15 +80,8 @@ static mutex_t s_mutex = { PTHREAD_MUTEX_INITIALIZER };
 #endif
 static bool s_initialized;
 
-/* Built-in CSV stub adapter */
-static const wl_io_adapter_t s_csv_builtin = {
-    .abi_version = WL_IO_ABI_VERSION,
-    .scheme = "csv",
-    .description = "Built-in CSV adapter (stub)",
-    .read = NULL,
-    .validate = NULL,
-    .user_data = NULL,
-};
+/* Built-in CSV adapter (implemented in csv_adapter.c) */
+extern const wl_io_adapter_t wl_csv_adapter;
 
 /* ======================================================================== */
 /* One-Shot Initialization                                                  */
@@ -111,7 +104,7 @@ ensure_builtins(void)
      * Windows) to guard the one-shot builtin registration. */
     mutex_lock(&s_mutex);
     if (!s_initialized) {
-        s_registry[0].adapter = &s_csv_builtin;
+        s_registry[0].adapter = &wl_csv_adapter;
         strncpy(s_registry[0].scheme, "csv", SCHEME_MAX_LEN - 1);
         s_registry[0].scheme[SCHEME_MAX_LEN - 1] = '\0';
         s_count = 1;

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -77,7 +77,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
 #I / O Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_io_src = files('io/csv_reader.c', 'io/io_adapter.c', 'io/io_ctx.c', )
+wirelog_io_src = files('io/csv_reader.c', 'io/io_adapter.c', 'io/io_ctx.c', 'io/csv_adapter.c')
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #String Operations Module(Issue #143)


### PR DESCRIPTION
## Summary

Closes #456. Part of #446 (I/O adapter umbrella).

Replaces the stub CSV adapter from #451 with a real implementation that wraps wl_csv_read_file_via_ctx (#455). Reads filename/delimiter params from wl_io_ctx_t, replicates cwd-fallback path resolution, uses wl_io_ctx_intern_string for STRING columns.

## Changes

- `wirelog/io/csv_adapter.c` — real CSV adapter implementing wl_io_adapter_t.read
- `wirelog/io/io_adapter.c` — replaced stub with extern reference to real adapter
- `wirelog/meson.build` — added csv_adapter.c to wirelog_io_src
- `tests/meson.build` — updated test linking

## Test results

- meson test: 131/131 green
- test_builtin_csv_autoload: passes with real adapter