### PR TITLE
refactor(#458): Dispatch .input loading through I/O adapter registry

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -51,6 +51,9 @@ bench_backend_src = files(
 
 bench_io_src = files(
   subdir_wirelog / 'io/csv_reader.c',
+  subdir_wirelog / 'io/io_adapter.c',
+  subdir_wirelog / 'io/io_ctx.c',
+  subdir_wirelog / 'io/csv_adapter.c',
 )
 
 bench_arena_src = files(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,6 +42,20 @@ csv_src = files(
   '../wirelog/io/csv_reader.c',
 )
 
+io_src = files(
+  '../wirelog/io/csv_reader.c',
+  '../wirelog/io/io_adapter.c',
+  '../wirelog/io/csv_adapter.c',
+  '../wirelog/io/io_ctx.c',
+)
+
+# Select threading backend based on platform
+if host_machine.system() == 'windows'
+  thread_src = files('../wirelog/thread_msvc.c',)
+else
+  thread_src = files('../wirelog/thread_posix.c',)
+endif
+
 # ============================================================================
 # Test Executables
 # ============================================================================
@@ -65,8 +79,10 @@ test_ir_exe = executable(
   files('test_ir.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test_program_exe = executable(
@@ -74,8 +90,10 @@ test_program_exe = executable(
   files('test_program.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test_stratify_exe = executable(
@@ -83,8 +101,10 @@ test_stratify_exe = executable(
   files('test_stratify.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 # ============================================================================
@@ -103,8 +123,10 @@ test_fusion_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('fusion', test_fusion_exe)
@@ -115,8 +137,10 @@ test_jpp_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('jpp', test_jpp_exe)
@@ -127,8 +151,10 @@ test_sip_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('sip', test_sip_exe)
@@ -204,13 +230,6 @@ backend_src = files(
   '../wirelog/string_ops.c',
 )
 
-io_src = files(
-  '../wirelog/io/csv_reader.c',
-  '../wirelog/io/io_adapter.c',
-  '../wirelog/io/csv_adapter.c',
-  '../wirelog/io/io_ctx.c',
-)
-
 arena_src = files(
   '../wirelog/arena/arena.c',
 )
@@ -218,13 +237,6 @@ arena_src = files(
 workqueue_src = files(
   '../wirelog/workqueue.c',
 )
-
-# Select threading backend based on platform
-if host_machine.system() == 'windows'
-  thread_src = files('../wirelog/thread_msvc.c',)
-else
-  thread_src = files('../wirelog/thread_posix.c',)
-endif
 
 test_plan_gen_exe = executable(
   'test_plan_gen',
@@ -1338,9 +1350,10 @@ test_bitwise_types_exe = executable(
   files('test_bitwise_types.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
-  dependencies: [nanoarrow_dep],
+  dependencies: [nanoarrow_dep, threads_dep],
 )
 
 test('bitwise_types', test_bitwise_types_exe)
@@ -1350,9 +1363,10 @@ test_bitwise_parser_exe = executable(
   files('test_bitwise_parser.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
-  dependencies: [nanoarrow_dep],
+  dependencies: [nanoarrow_dep, threads_dep],
 )
 
 test('bitwise_parser', test_bitwise_parser_exe)
@@ -1400,9 +1414,10 @@ test_hash_types_exe = executable(
   files('test_hash_types.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
-  dependencies: [nanoarrow_dep],
+  dependencies: [nanoarrow_dep, threads_dep],
 )
 
 test('hash_types', test_hash_types_exe)
@@ -1412,9 +1427,10 @@ test_hash_parser_exe = executable(
   files('test_hash_parser.c'),
   parser_src,
   ir_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
-  dependencies: [nanoarrow_dep],
+  dependencies: [nanoarrow_dep, threads_dep],
 )
 
 test('hash_parser', test_hash_parser_exe)
@@ -1619,8 +1635,10 @@ test_magic_sets_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('magic_sets', test_magic_sets_exe)
@@ -2296,8 +2314,10 @@ test_string_parser_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
-  csv_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('string_parser', test_string_parser_exe)
@@ -2421,7 +2441,13 @@ test('io_ctx', test_io_ctx_exe)
 test_io_dispatch_exe = executable(
   'test_io_dispatch',
   files('test_io_dispatch.c'),
+  parser_src,
+  ir_src,
+  io_src,
+  thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING', '-DTEST_DISPATCH_PRESENT'],
+  dependencies: [threads_dep],
   install: false,
 )
 test('io_dispatch', test_io_dispatch_exe)

--- a/tests/test_io_dispatch.c
+++ b/tests/test_io_dispatch.c
@@ -6,14 +6,17 @@
  *
  * Three test scenarios for adapter-based .input dispatch:
  * dispatch_mock_adapter, dispatch_csv_default, dispatch_unknown_scheme.
- * All guarded behind TEST_DISPATCH_PRESENT and currently SKIP until
- * #458 implements the session_facts.c dispatch rewrite.
  *
  * Part of #446 (I/O adapter umbrella).
  */
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+
+#ifndef TEST_DISPATCH_PRESENT
+#define TEST_DISPATCH_PRESENT
+#endif
 
 /* ======================================================================== */
 /* Test Harness                                                             */
@@ -27,42 +30,183 @@
 static int passed = 0, failed = 0, skipped = 0;
 
 /* ======================================================================== */
+/* Includes for dispatch testing                                            */
+/* ======================================================================== */
+
+#ifdef TEST_DISPATCH_PRESENT
+
+#include "wirelog/io/io_adapter.h"
+#include "wirelog/io/io_ctx_internal.h"
+#include "wirelog/ir/program.h"
+#include "wirelog/ir/ir.h"       /* strdup_safe */
+#include "wirelog/session_facts.h"
+#include "wirelog/session.h"
+#include "wirelog/backend.h"
+
+/* ---- Mock backend (accepts any insert) ---- */
+
+static int s_insert_called;
+
+static int
+mock_insert(wl_session_t *session, const char *relation,
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols)
+{
+    (void)session; (void)relation; (void)data;
+    (void)num_rows; (void)num_cols;
+    s_insert_called = 1;
+    return 0;
+}
+
+static const wl_compute_backend_t s_mock_backend = {
+    .name = "mock",
+    .session_create = NULL,
+    .session_destroy = NULL,
+    .session_insert = mock_insert,
+    .session_remove = NULL,
+    .session_step = NULL,
+    .session_set_delta_cb = NULL,
+    .session_snapshot = NULL,
+};
+
+/* ---- Mock I/O adapter ---- */
+
+static int s_mock_read_called;
+static const char *s_mock_received_key;
+
+static int
+mock_read_cb(wl_io_ctx_t *ctx, int64_t **out_data,
+    uint32_t *out_nrows, void *user_data)
+{
+    (void)user_data;
+    s_mock_read_called = 1;
+    s_mock_received_key = wl_io_ctx_param(ctx, "key");
+
+    /* Return a single row with one column */
+    *out_data = (int64_t *)malloc(sizeof(int64_t));
+    if (!*out_data)
+        return -1;
+    (*out_data)[0] = 42;
+    *out_nrows = 1;
+    return 0;
+}
+
+/* ---- Helper: build a minimal program with one .input relation ---- */
+
+static struct wirelog_program *
+make_program(const char *scheme, const char **pnames,
+    const char **pvalues, uint32_t nparam)
+{
+    struct wirelog_program *prog =
+        (struct wirelog_program *)calloc(1, sizeof(*prog));
+    if (!prog)
+        return NULL;
+
+    prog->relation_count = 1;
+    prog->relations = (wl_ir_relation_info_t *)calloc(1,
+            sizeof(wl_ir_relation_info_t));
+    if (!prog->relations) {
+        free(prog);
+        return NULL;
+    }
+
+    wl_ir_relation_info_t *rel = &prog->relations[0];
+    rel->name = "events";
+    rel->has_input = true;
+    rel->column_count = 1;
+    rel->columns = (wirelog_column_t *)calloc(1, sizeof(wirelog_column_t));
+    if (!rel->columns) {
+        free(prog->relations);
+        free(prog);
+        return NULL;
+    }
+    rel->columns[0].type = WIRELOG_TYPE_INT64;
+
+    if (scheme)
+        rel->input_io_scheme = strdup_safe(scheme);
+    else
+        rel->input_io_scheme = NULL;
+    rel->input_param_names = (char **)pnames;
+    rel->input_param_values = (char **)pvalues;
+    rel->input_param_count = nparam;
+
+    prog->intern = NULL;
+    return prog;
+}
+
+static void
+free_program(struct wirelog_program *prog)
+{
+    if (!prog)
+        return;
+    free(prog->relations[0].columns);
+    free(prog->relations[0].input_io_scheme);
+    free(prog->relations);
+    free(prog);
+}
+
+#endif /* TEST_DISPATCH_PRESENT */
+
+/* ======================================================================== */
 /* Tests                                                                    */
 /* ======================================================================== */
 
 /*
  * test_dispatch_mock_adapter
  *
- * Register a mock adapter with scheme="mock". Parse+compile a program
- * with `.input events(io="mock", key="val")`. Call
- * wl_session_load_input_files. Assert the mock adapter's `read`
- * callback was invoked (use a global flag/counter). Assert the mock
- * received the correct params (key="val").
+ * Register a mock adapter with scheme="mock". Build a minimal program
+ * with has_input=true and input_io_scheme="mock". Call
+ * wl_session_load_input_files. Assert the mock adapter's read callback
+ * was invoked and received the correct params.
  */
 static void
 test_dispatch_mock_adapter(void)
 {
     TEST("dispatch_mock_adapter");
 #ifdef TEST_DISPATCH_PRESENT
-    /* Register a mock adapter with scheme="mock" */
-    static int mock_called = 0;
-    mock_called = 0;
+    s_mock_read_called = 0;
+    s_mock_received_key = NULL;
+    s_insert_called = 0;
 
-    /* TODO(#458): Full implementation when dispatch rewrite lands.
-     *
-     * wl_io_adapter_t mock = {0};
-     * mock.scheme = "mock";
-     * mock.abi_version = WL_IO_ABI_VERSION;
-     * mock.read = mock_read_cb;  // sets mock_called=1, checks params
-     * wl_io_register_adapter(&mock);
-     *
-     * Parse+compile: .input events(io="mock", key="val")
-     * Call wl_session_load_input_files(session)
-     * Assert mock_called == 1
-     * Assert mock received key="val"
-     */
-    (void)mock_called;
-    FAIL("dispatch rewrite not yet implemented (#458)");
+    /* Register mock adapter */
+    wl_io_adapter_t mock = {0};
+    mock.abi_version = WL_IO_ABI_VERSION;
+    mock.scheme = "mock";
+    mock.description = "test mock adapter";
+    mock.read = mock_read_cb;
+    mock.validate = NULL;
+    mock.user_data = NULL;
+
+    int reg_rc = wl_io_register_adapter(&mock);
+    if (reg_rc != 0) {
+        FAIL("failed to register mock adapter");
+        return;
+    }
+
+    /* Build program with io="mock" and key="val" */
+    const char *pnames[] = { "key" };
+    const char *pvalues[] = { "val" };
+    struct wirelog_program *prog = make_program("mock", pnames, pvalues, 1);
+    if (!prog) {
+        FAIL("failed to create program");
+        wl_io_unregister_adapter("mock");
+        return;
+    }
+
+    /* Create a mock session backed by our mock backend */
+    wl_session_t sess;
+    sess.backend = &s_mock_backend;
+
+    int rc = wl_session_load_input_files(&sess, prog);
+
+    int ok = (rc == 0 && s_mock_read_called == 1 && s_insert_called == 1);
+    if (ok && s_mock_received_key && strcmp(s_mock_received_key, "val") == 0) {
+        PASS();
+    } else {
+        FAIL("mock adapter not called correctly or param mismatch");
+    }
+
+    free_program(prog);
+    wl_io_unregister_adapter("mock");
 #else
     SKIP("dispatch rewrite not yet implemented (#458)");
 #endif
@@ -71,24 +215,56 @@ test_dispatch_mock_adapter(void)
 /*
  * test_dispatch_csv_default
  *
- * Parse a program with `.input events(filename="test.csv")` (no io=).
- * Call wl_session_load_input_files. Assert it routes to the built-in
- * CSV adapter (no crash, produces expected results -- or at minimum,
- * does not call the mock adapter).
+ * Build a program with no io= (NULL => defaults to "csv"). Create a
+ * temp CSV file and verify it routes to the built-in CSV adapter.
  */
 static void
 test_dispatch_csv_default(void)
 {
     TEST("dispatch_csv_default");
 #ifdef TEST_DISPATCH_PRESENT
-    /* TODO(#458): Full implementation when dispatch rewrite lands.
-     *
-     * Parse+compile: .input events(filename="test.csv")
-     * Call wl_session_load_input_files(session)
-     * Assert no crash, routes to built-in CSV adapter
-     * Assert mock adapter was NOT called
-     */
-    FAIL("dispatch rewrite not yet implemented (#458)");
+    s_insert_called = 0;
+
+    /* Create a temp CSV file (use platform-safe temp path) */
+    const char *tmpdir = getenv("TMPDIR");
+    if (!tmpdir) tmpdir = getenv("TMP");
+    if (!tmpdir) tmpdir = getenv("TEMP");
+    if (!tmpdir) tmpdir = "/tmp";
+    char csv_path[512];
+    snprintf(csv_path, sizeof(csv_path), "%s/wirelog_test_dispatch_default.csv",
+        tmpdir);
+    FILE *f = fopen(csv_path, "w");
+    if (!f) {
+        FAIL("could not create temp CSV file");
+        return;
+    }
+    fprintf(f, "10\n20\n");
+    fclose(f);
+
+    /* Build program with no io= (defaults to "csv") */
+    const char *pnames[] = { "filename" };
+    const char *pvalues[] = { csv_path };
+    struct wirelog_program *prog = make_program(NULL, pnames, pvalues, 1);
+    if (!prog) {
+        FAIL("failed to create program");
+        remove(csv_path);
+        return;
+    }
+
+    /* Mock session */
+    wl_session_t sess;
+    sess.backend = &s_mock_backend;
+
+    int rc = wl_session_load_input_files(&sess, prog);
+
+    if (rc == 0 && s_insert_called == 1) {
+        PASS();
+    } else {
+        FAIL("csv default dispatch failed");
+    }
+
+    free_program(prog);
+    remove(csv_path);
 #else
     SKIP("dispatch rewrite not yet implemented (#458)");
 #endif
@@ -97,22 +273,36 @@ test_dispatch_csv_default(void)
 /*
  * test_dispatch_unknown_scheme_error
  *
- * Parse a program with `.input events(io="nonexistent", filename="x")`.
- * Call wl_session_load_input_files. Assert it returns an error
- * (non-zero rc).
+ * Build a program with io="nonexistent". Assert
+ * wl_session_load_input_files returns an error (non-zero rc).
  */
 static void
 test_dispatch_unknown_scheme_error(void)
 {
     TEST("dispatch_unknown_scheme_error");
 #ifdef TEST_DISPATCH_PRESENT
-    /* TODO(#458): Full implementation when dispatch rewrite lands.
-     *
-     * Parse+compile: .input events(io="nonexistent", filename="x")
-     * int rc = wl_session_load_input_files(session)
-     * Assert rc != 0
-     */
-    FAIL("dispatch rewrite not yet implemented (#458)");
+    const char *pnames[] = { "filename" };
+    const char *pvalues[] = { "x" };
+    struct wirelog_program *prog = make_program("nonexistent",
+            pnames, pvalues, 1);
+    if (!prog) {
+        FAIL("failed to create program");
+        return;
+    }
+
+    /* Mock session */
+    wl_session_t sess;
+    sess.backend = &s_mock_backend;
+
+    int rc = wl_session_load_input_files(&sess, prog);
+
+    if (rc != 0) {
+        PASS();
+    } else {
+        FAIL("expected non-zero rc for unknown scheme");
+    }
+
+    free_program(prog);
 #else
     SKIP("dispatch rewrite not yet implemented (#458)");
 #endif

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -42,10 +42,18 @@
 /* Intern Trampoline                                                        */
 /* ======================================================================== */
 
+/*
+ * The built-in CSV adapter calls wl_intern_put directly (0-based IDs)
+ * to stay consistent with the legacy wl_csv_read_file_ex path.
+ * External adapters should use wl_io_ctx_intern_string (1-based) instead.
+ */
 static int64_t
 csv_intern_trampoline(void *opaque, const char *str)
 {
-    return wl_io_ctx_intern_string((wl_io_ctx_t *)opaque, str);
+    wl_io_ctx_t *ctx = (wl_io_ctx_t *)opaque;
+    if (!ctx || !ctx->intern)
+        return -1;
+    return wl_intern_put(ctx->intern, str);
 }
 
 /* ======================================================================== */

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -17,6 +17,43 @@
 #include <string.h>
 
 /* ------------------------------------------------------------------------ */
+/* Production Constructor (from relation metadata)                          */
+/* ------------------------------------------------------------------------ */
+
+wl_io_ctx_t *
+wl_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
+    wl_intern_t *intern)
+{
+    if (!rel)
+        return NULL;
+
+    wl_io_ctx_t *ctx = (wl_io_ctx_t *)calloc(1, sizeof(*ctx));
+    if (!ctx)
+        return NULL;
+
+    ctx->relation_name = rel->name;                          /* borrowed */
+    ctx->num_cols = rel->column_count;
+    ctx->param_keys = (const char **)rel->input_param_names;      /* borrowed */
+    ctx->param_values = (const char **)rel->input_param_values;   /* borrowed */
+    ctx->num_params = rel->input_param_count;
+    ctx->intern = intern;                                    /* borrowed */
+    ctx->platform_ctx = NULL;
+
+    if (rel->column_count > 0 && rel->columns) {
+        ctx->col_types = (wirelog_column_type_t *)malloc(
+            rel->column_count * sizeof(wirelog_column_type_t));
+        if (!ctx->col_types) {
+            free(ctx);
+            return NULL;
+        }
+        for (uint32_t i = 0; i < rel->column_count; i++)
+            ctx->col_types[i] = rel->columns[i].type;
+    }
+
+    return ctx;
+}
+
+/* ------------------------------------------------------------------------ */
 /* Test Constructor / Destructor                                            */
 /* ------------------------------------------------------------------------ */
 

--- a/wirelog/io/io_ctx_internal.h
+++ b/wirelog/io/io_ctx_internal.h
@@ -16,6 +16,7 @@
 
 #include "wirelog/io/io_adapter.h"
 #include "wirelog/intern.h"
+#include "wirelog/ir/program.h"  /* for wl_ir_relation_info_t */
 
 struct wl_io_ctx {
     const char             *relation_name;
@@ -24,7 +25,7 @@ struct wl_io_ctx {
     const char            **param_keys;      /* borrowed */
     const char            **param_values;    /* borrowed */
     uint32_t num_params;
-    wl_intern_t            *intern;          /* owned by context */
+    wl_intern_t            *intern;          /* borrowed, not owned */
     void                   *platform_ctx;
 };
 
@@ -35,5 +36,9 @@ wl_io_ctx_t *wl_io_ctx_create_test(
     wl_intern_t *intern);
 
 void wl_io_ctx_destroy(wl_io_ctx_t *ctx);
+
+wl_io_ctx_t *wl_io_ctx_create_for_relation(
+    const wl_ir_relation_info_t *rel,
+    wl_intern_t *intern);
 
 #endif /* WIRELOG_IO_IO_CTX_INTERNAL_H */

--- a/wirelog/session_facts.c
+++ b/wirelog/session_facts.c
@@ -7,23 +7,21 @@
  *
  * Backend-agnostic fact-loading helpers that replace the deleted
  * DD-specific wirelog_load_all_facts() and wirelog_load_input_files().
+ *
+ * As of #458 the .input path delegates to the I/O adapter registry
+ * instead of hard-coding CSV logic.  session_facts.c is now
+ * scheme-agnostic; CSV-specific concerns live in csv_adapter.c.
  */
 
 #include "session_facts.h"
 
-#include "io/csv_reader.h"
+#include "io/io_adapter.h"
+#include "io/io_ctx_internal.h"
 #include "ir/program.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef _MSC_VER
-#include <direct.h>
-#define getcwd _getcwd
-#else
-#include <unistd.h>
-#endif
 
 int
 wl_session_load_facts(wl_session_t *sess, const struct wirelog_program *prog)
@@ -37,10 +35,10 @@ wl_session_load_facts(wl_session_t *sess, const struct wirelog_program *prog)
             continue;
 
         int rc = wl_session_insert(sess, rel->name, rel->fact_data,
-                                   rel->fact_count, rel->column_count);
+                rel->fact_count, rel->column_count);
         if (rc != 0) {
             fprintf(stderr, "error: failed to load facts for '%s'\n",
-                    rel->name);
+                rel->name);
             return -1;
         }
     }
@@ -50,7 +48,7 @@ wl_session_load_facts(wl_session_t *sess, const struct wirelog_program *prog)
 
 int
 wl_session_load_input_files(wl_session_t *sess,
-                            const struct wirelog_program *prog)
+    const struct wirelog_program *prog)
 {
     if (!sess || !prog)
         return -1;
@@ -60,116 +58,66 @@ wl_session_load_input_files(wl_session_t *sess,
         if (!rel->name || !rel->has_input)
             continue;
 
-        /* Extract filename parameter */
-        const char *filename = NULL;
-        char delimiter = '\t'; /* default delimiter */
+        /* Determine I/O scheme: explicit io="..." or default "csv" */
+        const char *scheme = rel->input_io_scheme ? rel->input_io_scheme
+                                                  : "csv";
 
-        for (uint32_t p = 0; p < rel->input_param_count; p++) {
-            if (rel->input_param_names[p]
-                && strcmp(rel->input_param_names[p], "filename") == 0) {
-                filename = rel->input_param_values[p];
-            } else if (rel->input_param_names[p]
-                       && strcmp(rel->input_param_names[p], "delimiter") == 0
-                       && rel->input_param_values[p]) {
-                /* Handle escaped delimiter strings */
-                const char *dv = rel->input_param_values[p];
-                if (strcmp(dv, "\\t") == 0)
-                    delimiter = '\t';
-                else if (strlen(dv) > 0)
-                    delimiter = dv[0];
-            }
-        }
-
-        if (!filename) {
-            fprintf(stderr, "error: .input for '%s' missing filename\n",
-                    rel->name);
+        const wl_io_adapter_t *adapter = wl_io_find_adapter(scheme);
+        if (!adapter) {
+            fprintf(stderr,
+                "error: no I/O adapter registered for scheme '%s' "
+                "(relation '%s')\n",
+                scheme, rel->name);
             return -1;
         }
 
-        /* Try to resolve file path:
-         * 1. If absolute path, use as-is
-         * 2. If relative path, try from current working directory
-         * 3. Try relative to cwd (fopen will do this automatically)
-         */
-        const char *resolved_path = filename;
-        char resolved_buf[4096];
-
-        /* Check if file exists at the given path */
-        FILE *test_f = fopen(filename, "r");
-        if (!test_f && filename[0] != '/') {
-            /* Relative path failed, try with current working directory */
-            char cwd[4096];
-            if (getcwd(cwd, sizeof(cwd)) != NULL) {
-                snprintf(resolved_buf, sizeof(resolved_buf), "%s/%s", cwd,
-                         filename);
-                test_f = fopen(resolved_buf, "r");
-                if (test_f) {
-                    resolved_path = resolved_buf;
-                    fclose(test_f);
-                }
-            }
-        } else if (test_f) {
-            fclose(test_f);
+        wl_io_ctx_t *ctx =
+            wl_io_ctx_create_for_relation(rel, prog->intern);
+        if (!ctx) {
+            fprintf(stderr,
+                "error: failed to create I/O context for '%s'\n",
+                rel->name);
+            return -1;
         }
 
-        /* Read CSV file */
+        /* Optional validation pass */
+        if (adapter->validate) {
+            char errbuf[512];
+            errbuf[0] = '\0';
+            int vrc = adapter->validate(ctx, errbuf, sizeof errbuf,
+                    adapter->user_data);
+            if (vrc != 0) {
+                fprintf(stderr,
+                    "error: validation failed for '%s': %s\n",
+                    rel->name, errbuf);
+                wl_io_ctx_destroy(ctx);
+                return -1;
+            }
+        }
+
+        /* Delegate to adapter's read callback */
         int64_t *data = NULL;
         uint32_t nrows = 0;
-        uint32_t ncols = 0;
 
-        /* Check if relation has any string/symbol columns */
-        bool has_string_cols = false;
-        for (uint32_t c = 0; c < rel->column_count; c++) {
-            if (rel->columns[c].type == WIRELOG_TYPE_STRING) {
-                has_string_cols = true;
-                break;
-            }
-        }
-
-        int rc;
-        if (has_string_cols) {
-            /* Use extended reader for mixed types */
-            if (!prog->intern) {
-                fprintf(stderr,
-                        "error: no intern table available for relation '%s'\n",
-                        rel->name);
-                return -1;
-            }
-
-            /* Extract column types from relation */
-            wirelog_column_type_t *col_types = (wirelog_column_type_t *)malloc(
-                rel->column_count * sizeof(wirelog_column_type_t));
-            if (!col_types) {
-                fprintf(stderr, "error: memory allocation failed\n");
-                return -1;
-            }
-            for (uint32_t c = 0; c < rel->column_count; c++) {
-                col_types[c] = rel->columns[c].type;
-            }
-
-            rc = wl_csv_read_file_ex(resolved_path, delimiter, col_types,
-                                     rel->column_count, &data, &nrows, &ncols,
-                                     prog->intern);
-            free(col_types);
-        } else {
-            /* Use basic reader for integer-only columns */
-            rc = wl_csv_read_file(resolved_path, delimiter, &data, &nrows,
-                                  &ncols);
-        }
+        int rc = adapter->read(ctx, &data, &nrows, adapter->user_data);
+        wl_io_ctx_destroy(ctx);
 
         if (rc != 0) {
-            fprintf(stderr, "error: failed to read '%s' for relation '%s'\n",
-                    filename, rel->name);
+            fprintf(stderr,
+                "error: adapter '%s' failed to read data for '%s'\n",
+                scheme, rel->name);
+            free(data);
             return -1;
         }
 
         if (nrows > 0 && data) {
-            rc = wl_session_insert(sess, rel->name, data, nrows, ncols);
+            rc = wl_session_insert(sess, rel->name, data, nrows,
+                    rel->column_count);
             free(data);
             if (rc != 0) {
                 fprintf(stderr,
-                        "error: failed to insert data from '%s' for '%s'\n",
-                        filename, rel->name);
+                    "error: failed to insert data for '%s'\n",
+                    rel->name);
                 return -1;
             }
         } else {


### PR DESCRIPTION
## Summary

Closes #458. Part of #446 (I/O adapter umbrella). This is the core integration commit.

Replaces the hard-coded CSV loading path in session_facts.c with adapter-based dispatch. Each .input relation resolves its scheme from io="..." (defaulting to "csv"), looks up the registered adapter, and delegates to its read callback. session_facts.c is now fully scheme-agnostic.

## Changes

- `wirelog/session_facts.c` — rewritten to dispatch via wl_io_find_adapter
- `wirelog/io/io_ctx.c` + `io_ctx_internal.h` — new wl_io_ctx_create_for_relation production constructor
- `wirelog/io/csv_adapter.c` — intern trampoline uses wl_intern_put directly (0-based, matching legacy path)
- `tests/test_io_dispatch.c` — all 3 TDD tests PASS (mock adapter, CSV default, unknown scheme error)
- `bench/meson.build` — bench targets link io module

## Revertibility

Single commit. git revert cleanly restores the legacy CSV path without unwinding #451-#456.

## Test results

- meson test: 132/132 green
- Baseline snapshots (#448): byte-identical
- test_cli CSV cases: all pass
- io_dispatch: 3 PASS
- Review: APPROVE (1 comment fix applied)