### PR TITLE
fix(bench): Update DOOP zxing dataset URL to HuggingFace mirror

### DIFF
--- a/bench/data/doop/download.sh
+++ b/bench/data/doop/download.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 # Download DOOP (zxing) benchmark dataset
-# Source: FlowLog artifact (VLDB 2026)
+# Source: FlowLog VLDB 2026 artifact (mirrored on HuggingFace).
+# The original host (pages.cs.wisc.edu/~m0riarty) is no longer available.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-URL="https://pages.cs.wisc.edu/~m0riarty/dataset/csv/zxing.zip"
+URL="${DOOP_ZXING_URL:-https://huggingface.co/datasets/NemoYuu/flowlog_benchmark/resolve/main/dataset/csv/zxing.zip}"
 TMPZIP="/tmp/zxing_doop_$$.zip"
 TMPDIR="/tmp/zxing_doop_$$"
 
-echo "Downloading zxing dataset (~112 MB)..."
-curl -L "$URL" -o "$TMPZIP"
+cleanup() { rm -rf "$TMPZIP" "$TMPDIR"; }
+trap cleanup EXIT
+
+echo "Downloading zxing dataset (~112 MB) from $URL ..."
+curl --fail -L "$URL" -o "$TMPZIP"
+
+# Fail fast if the server returned HTML (e.g. 404 page) instead of a zip.
+if ! unzip -tq "$TMPZIP" > /dev/null 2>&1; then
+    echo "ERROR: downloaded file is not a valid zip archive." >&2
+    echo "       Check connectivity and DOOP_ZXING_URL." >&2
+    exit 1
+fi
 
 echo "Extracting required CSV files..."
 mkdir -p "$TMPDIR"
@@ -28,5 +39,4 @@ for f in $REQUIRED; do
     cp "$TMPDIR/zxing/${f}.csv" "$SCRIPT_DIR/"
 done
 
-rm -rf "$TMPDIR" "$TMPZIP"
 echo "Done. 34 CSV files copied to $SCRIPT_DIR/"


### PR DESCRIPTION
## Summary

- The original DOOP zxing dataset host (`pages.cs.wisc.edu/~m0riarty`) now returns `404` and is no longer maintained, so `bench/data/doop/download.sh` cannot fetch the dataset.
- Point the script at the FlowLog VLDB 2026 artifact mirror on HuggingFace (`NemoYuu/flowlog_benchmark`), which the upstream project now uses for distribution.
- Harden the script so similar breakage is caught immediately rather than producing misleading `cannot find zipfile directory` failures.

## Script hardening

- Honour `DOOP_ZXING_URL` to override the source without editing the file.
- `curl --fail` so HTTP errors abort the script.
- Validate the archive with `unzip -tq` before extraction; if the server returned HTML (e.g. a 404 page), surface a clear error.
- Move the tmpdir/zip cleanup into a `trap` so partial downloads are removed even on early exit.

## Verification

- Ran `bash bench/data/doop/download.sh` from a clean state: 34 CSV files (~83 MB) extracted successfully.
- Full validation pipeline: `bash scripts/run_doop_validation.sh --workers 1 --repeat 1` returned `OK` (6,276,653 output tuples, 28 iterations, 136.3 s wall, ~16.4 GB peak RSS).

## Test plan

- [ ] CI fetches the dataset on a build host without the previous 404.
- [ ] `DOOP_ZXING_URL=<bad-url> bash bench/data/doop/download.sh` fails fast with the new error message rather than an `unzip` diagnostic.
- [ ] `scripts/run_doop_validation.sh` still reports `PASS` against the newly downloaded dataset.