### PR TITLE
fix(#508): Port bench + perf-gate build surface to Windows/MSVC (Phase 1)

### DIFF
--- a/bench/bench_argv.h
+++ b/bench/bench_argv.h
@@ -1,0 +1,153 @@
+/*
+ * bench_argv.h - Minimal portable argv parser for bench/ + datagen.
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Scope: a strict subset of POSIX getopt_long that covers exactly what
+ * bench_flowlog and datagen use today. Intentionally unlike glibc getopt:
+ *
+ *   Supported:
+ *     -x              bare short flag
+ *     -x arg          short with required argument (space-separated)
+ *     -xarg           short with glued argument
+ *     --name          bare long flag
+ *     --name arg      long with required argument (space-separated)
+ *     --              end-of-options terminator
+ *
+ *   NOT supported (by design - no caller needs them; adding them is a
+ *   measurement-design decision that belongs elsewhere):
+ *     --name=value    explicit equals form
+ *     -abc            bundled short flags
+ *     optional_argument / OPTIONAL_ARG
+ *     optreset, POSIXLY_CORRECT, W;, getopt_long_only
+ *     argv permutation (stops at first non-option)
+ *
+ * All state is caller-owned via bench_argv_state_t - no hidden globals,
+ * no thread-safety gymnastics. Return sentinel matches POSIX getopt:
+ *   - matched short char or long_opts[i].val on match
+ *   - '?' on unknown option or missing required argument (diagnostic to stderr)
+ *   - -1 at end of options (including after --)
+ *
+ * Callers replace getopt_long's `optarg` global with `state.optarg`.
+ */
+
+#ifndef BENCH_ARGV_H
+#define BENCH_ARGV_H
+
+#include <stdio.h>
+#include <string.h>
+
+/* --- libc portability shim used by bench binaries --- */
+/* MSVC C runtime does not expose strtok_r; the single-threaded bench
+ * binaries tolerate strtok's static state, so the shim is a straight
+ * macro substitution. Kept here so bench_flowlog.c and datagen.c are
+ * free of any #ifdef _MSC_VER of their own. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#  ifndef strtok_r
+#    define strtok_r(str, delim, saveptr) strtok((str), (delim))
+#  endif
+#endif
+
+/* Keep the POSIX spelling so long_opts tables read identically to the
+ * pre-port code. Guarded so callers that still include <getopt.h> for
+ * other reasons do not hit a redefinition. */
+#ifndef no_argument
+#  define no_argument       0
+#endif
+#ifndef required_argument
+#  define required_argument 1
+#endif
+
+typedef struct {
+    const char *name;
+    int         has_arg;  /* no_argument (0) or required_argument (1) */
+    int         val;      /* code returned when this option matches */
+} bench_argv_long_t;
+
+typedef struct {
+    int   optind;   /* next argv index to process; init to 1 */
+    char *optarg;   /* argument of the most recent match, or NULL */
+} bench_argv_state_t;
+
+#define BENCH_ARGV_INIT { 1, NULL }
+
+/* Single step of argv parsing. Returns matched option code, '?' on error,
+ * or -1 at end. Diagnostics are written to stderr prefixed with argv[0]. */
+static inline int
+bench_argv_next(int argc, char *const argv[],
+                const char *short_opts,
+                const bench_argv_long_t *long_opts,
+                bench_argv_state_t *st)
+{
+    st->optarg = NULL;
+    if (st->optind >= argc)
+        return -1;
+    const char *a = argv[st->optind];
+    if (a == NULL || a[0] != '-' || a[1] == '\0')
+        return -1; /* non-option argv: stop (no permutation) */
+    if (a[1] == '-' && a[2] == '\0') {
+        st->optind += 1; /* consume "--" */
+        return -1;
+    }
+
+    if (a[1] == '-') {
+        /* long option: "--name" */
+        const char *name = a + 2;
+        st->optind += 1;
+        if (long_opts) {
+            for (int i = 0; long_opts[i].name != NULL; ++i) {
+                if (strcmp(long_opts[i].name, name) != 0)
+                    continue;
+                if (long_opts[i].has_arg == 1) {
+                    if (st->optind >= argc) {
+                        fprintf(stderr,
+                            "%s: option '--%s' requires an argument\n",
+                            argv[0], name);
+                        return '?';
+                    }
+                    st->optarg = argv[st->optind];
+                    st->optind += 1;
+                }
+                return long_opts[i].val;
+            }
+        }
+        fprintf(stderr, "%s: unrecognized option '--%s'\n", argv[0], name);
+        return '?';
+    }
+
+    /* short option: -x or -xarg or -x arg */
+    int c = (unsigned char)a[1];
+    st->optind += 1;
+    const char *hit = (short_opts != NULL) ? strchr(short_opts, c) : NULL;
+    if (hit == NULL) {
+        fprintf(stderr, "%s: unrecognized option '-%c'\n",
+            argv[0], (char)c);
+        return '?';
+    }
+    if (hit[1] == ':') {
+        if (a[2] != '\0') {
+            st->optarg = (char *)(a + 2); /* glued: -xarg */
+        } else {
+            if (st->optind >= argc) {
+                fprintf(stderr,
+                    "%s: option '-%c' requires an argument\n",
+                    argv[0], (char)c);
+                return '?';
+            }
+            st->optarg = argv[st->optind];
+            st->optind += 1;
+        }
+    } else if (a[2] != '\0') {
+        /* Unsupported bundled flags: '-abc'. Fail loudly so we never
+         * silently mis-parse an option string the caller expected. */
+        fprintf(stderr,
+            "%s: bundled short options not supported ('-%c%s')\n",
+            argv[0], (char)c, a + 2);
+        return '?';
+    }
+    return c;
+}
+
+#endif /* BENCH_ARGV_H */

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -76,29 +76,8 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
     uint64_t kfusion_merge_ns, uint64_t kfusion_cleanup_ns,
     uint64_t exchange_ns);
 
-#ifndef _MSC_VER
-/* getopt.h and getopt_long are POSIX-only; not available on Windows MSVC */
-#include <getopt.h>
-#else
-/* Windows MSVC: getopt/getopt_long not available */
-extern int
-getopt(int argc, char *const argv[], const char *optstring);
-extern int optind;
-extern char *optarg;
-
-/* Stub struct option for MSVC compatibility (getopt_long not used) */
-struct option {
-    const char *name;
-    int has_arg;
-    int *flag;
-    int val;
-};
-#define no_argument 0
-#define required_argument 1
-
-/* MSVC: strtok_r not available, use thread-local strtok fallback */
-#define strtok_r(str, delim, saveptr) strtok((str), (delim))
-#endif
+#include "bench_argv.h"
+#include "bench_util.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -920,10 +899,7 @@ run_cspa_incremental_workload(const char *data_dir, uint32_t workers,
      * Facts are loaded via col_session_insert_incremental.
      * NOTE: Currently unused (incremental measurement disabled).
      * Kept for reference: Phase 4+ delta-only evaluation. */
-    static const char *cspa_incr_source
-#ifndef _MSC_VER
-    __attribute__((unused))
-#endif
+    static const char *cspa_incr_source BENCH_UNUSED
         = ".decl assign(x: int32, y: int32)\n"
         ".decl dereference(x: int32, y: int32)\n"
         ".decl valueFlow(x: int32, y: int32)\n"
@@ -2842,81 +2818,75 @@ main(int argc, char **argv)
     uint32_t workers = 1;
     int repeat = 3;
 
-    static struct option long_opts[] = {
-        { "workload", required_argument, NULL, 'w' },
-        { "data", required_argument, NULL, 'd' },
-        { "data-weighted", required_argument, NULL, 'W' },
-        { "data-andersen", required_argument, NULL, 'A' },
-        { "data-dyck", required_argument, NULL, 'D' },
-        { "data-cspa", required_argument, NULL, 'C' },
-        { "data-csda", required_argument, NULL, 'S' },
-        { "data-galen", required_argument, NULL, 'G' },
-        { "data-polonius", required_argument, NULL, 'P' },
-        { "data-ddisasm", required_argument, NULL, 'I' },
-        { "data-crdt", required_argument, NULL, 'R' },
-        { "data-doop", required_argument, NULL, 'O' },
-        { "workers", required_argument, NULL, 'j' },
-        { "repeat", required_argument, NULL, 'r' },
-        { "format", required_argument, NULL, 'F' },
-        { "help", no_argument, NULL, 'h' },
-        { NULL, 0, NULL, 0 },
+    static bench_argv_long_t long_opts[] = {
+        { "workload", required_argument, 'w' },
+        { "data", required_argument, 'd' },
+        { "data-weighted", required_argument, 'W' },
+        { "data-andersen", required_argument, 'A' },
+        { "data-dyck", required_argument, 'D' },
+        { "data-cspa", required_argument, 'C' },
+        { "data-csda", required_argument, 'S' },
+        { "data-galen", required_argument, 'G' },
+        { "data-polonius", required_argument, 'P' },
+        { "data-ddisasm", required_argument, 'I' },
+        { "data-crdt", required_argument, 'R' },
+        { "data-doop", required_argument, 'O' },
+        { "workers", required_argument, 'j' },
+        { "repeat", required_argument, 'r' },
+        { "format", required_argument, 'F' },
+        { "help", no_argument, 'h' },
+        { NULL, 0, 0 },
     };
 
+    bench_argv_state_t args = BENCH_ARGV_INIT;
     int opt;
-#ifndef _MSC_VER
-    while ((opt = getopt_long(argc, argv, "w:d:W:A:D:C:S:G:P:I:R:O:j:r:F:h",
-        long_opts, NULL))
-        != -1) {
-#else
-    /* MSVC: getopt_long not available; use simple getopt fallback */
-    while ((opt = getopt(argc, argv, "w:d:W:A:D:C:S:G:P:I:R:O:j:r:F:h"))
-        != -1) {
-#endif
+    while ((opt = bench_argv_next(argc, argv,
+        "w:d:W:A:D:C:S:G:P:I:R:O:j:r:F:h", long_opts, &args)) != -1) {
         switch (opt) {
         case 'w':
-            workload = optarg;
+            workload = args.optarg;
             break;
         case 'd':
-            data_path = optarg;
+            data_path = args.optarg;
             break;
         case 'W':
-            data_weighted_path = optarg;
+            data_weighted_path = args.optarg;
             break;
         case 'A':
-            data_andersen_path = optarg;
+            data_andersen_path = args.optarg;
             break;
         case 'D':
-            data_dyck_path = optarg;
+            data_dyck_path = args.optarg;
             break;
         case 'C':
-            data_cspa_path = optarg;
+            data_cspa_path = args.optarg;
             break;
         case 'S':
-            data_csda_path = optarg;
+            data_csda_path = args.optarg;
             break;
         case 'G':
-            data_galen_path = optarg;
+            data_galen_path = args.optarg;
             break;
         case 'P':
-            data_polonius_path = optarg;
+            data_polonius_path = args.optarg;
             break;
         case 'I':
-            data_ddisasm_path = optarg;
+            data_ddisasm_path = args.optarg;
             break;
         case 'R':
-            data_crdt_path = optarg;
+            data_crdt_path = args.optarg;
             break;
         case 'O':
-            data_doop_path = optarg;
+            data_doop_path = args.optarg;
             break;
         case 'j':
-            workers = (uint32_t)strtoul(optarg, NULL, 10);
+            workers = (uint32_t)strtoul(args.optarg, NULL, 10);
             break;
         case 'r':
-            repeat = (int)strtol(optarg, NULL, 10);
+            repeat = (int)strtol(args.optarg, NULL, 10);
             break;
         case 'F':
-            g_format_json = (strcmp(optarg, "json") == 0);
+            g_format_json = (strcmp(args.optarg, "json") == 0);
             break;
         case 'h':
         default:

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -18,13 +18,15 @@
  * Compiler attribute shims
  * ================================================================ */
 
-/* Portable noinline for bench/perf-gate call sites.
- * MSVC C mode does not parse __attribute__((...)), so keep the two
- * spellings behind a single macro used at call sites. */
+/* Portable attribute shims for bench call sites. MSVC C mode does not
+ * parse __attribute__((...)), so keep the two spellings behind a single
+ * macro used at call sites. */
 #if defined(_MSC_VER) && !defined(__clang__)
 #  define BENCH_NOINLINE __declspec(noinline)
+#  define BENCH_UNUSED   /* MSVC has no attribute equivalent; no warning */
 #else
 #  define BENCH_NOINLINE __attribute__((noinline))
+#  define BENCH_UNUSED   __attribute__((unused))
 #endif
 
 /* ================================================================

--- a/bench/bench_util.h
+++ b/bench/bench_util.h
@@ -15,6 +15,19 @@
 #include <stdint.h>
 
 /* ================================================================
+ * Compiler attribute shims
+ * ================================================================ */
+
+/* Portable noinline for bench/perf-gate call sites.
+ * MSVC C mode does not parse __attribute__((...)), so keep the two
+ * spellings behind a single macro used at call sites. */
+#if defined(_MSC_VER) && !defined(__clang__)
+#  define BENCH_NOINLINE __declspec(noinline)
+#else
+#  define BENCH_NOINLINE __attribute__((noinline))
+#endif
+
+/* ================================================================
  * Wall-clock timing
  * ================================================================ */
 

--- a/bench/datagen.c
+++ b/bench/datagen.c
@@ -12,24 +12,7 @@
  *           [--edges M] [--seed S] [--weighted] [--output path.csv]
  */
 
-#ifndef _MSC_VER
-#include <getopt.h>
-#else
-extern int
-getopt(int argc, char *const argv[], const char *optstring);
-extern int optind;
-extern char *optarg;
-
-/* Stub struct option for MSVC compatibility (getopt_long not used) */
-struct option {
-    const char *name;
-    int has_arg;
-    int *flag;
-    int val;
-};
-#define no_argument 0
-#define required_argument 1
-#endif
+#include "bench_argv.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -139,43 +122,39 @@ main(int argc, char **argv)
     const char *output = NULL;
     const char *type_str = NULL;
 
-    static struct option long_opts[] = {
-        { "nodes", required_argument, NULL, 'n' },
-        { "edges", required_argument, NULL, 'e' },
-        { "type", required_argument, NULL, 't' },
-        { "seed", required_argument, NULL, 's' },
-        { "weighted", no_argument, NULL, 'w' },
-        { "output", required_argument, NULL, 'o' },
-        { "help", no_argument, NULL, 'h' },
-        { NULL, 0, NULL, 0 },
+    static bench_argv_long_t long_opts[] = {
+        { "nodes", required_argument, 'n' },
+        { "edges", required_argument, 'e' },
+        { "type", required_argument, 't' },
+        { "seed", required_argument, 's' },
+        { "weighted", no_argument, 'w' },
+        { "output", required_argument, 'o' },
+        { "help", no_argument, 'h' },
+        { NULL, 0, 0 },
     };
 
+    bench_argv_state_t args = BENCH_ARGV_INIT;
     int opt;
-#ifndef _MSC_VER
-    while ((opt = getopt_long(argc, argv, "n:e:t:s:wo:h", long_opts, NULL))
-           != -1) {
-#else
-    /* MSVC: getopt_long not available; use simple getopt fallback */
-    while ((opt = getopt(argc, argv, "n:e:t:s:wo:h")) != -1) {
-#endif
+    while ((opt = bench_argv_next(argc, argv, "n:e:t:s:wo:h", long_opts,
+        &args)) != -1) {
         switch (opt) {
         case 'n':
-            nodes = (int32_t)strtol(optarg, NULL, 10);
+            nodes = (int32_t)strtol(args.optarg, NULL, 10);
             break;
         case 'e':
-            edges = (int32_t)strtol(optarg, NULL, 10);
+            edges = (int32_t)strtol(args.optarg, NULL, 10);
             break;
         case 't':
-            type_str = optarg;
+            type_str = args.optarg;
             break;
         case 's':
-            seed = (uint32_t)strtoul(optarg, NULL, 10);
+            seed = (uint32_t)strtoul(args.optarg, NULL, 10);
             break;
         case 'w':
             weighted = 1;
             break;
         case 'o':
-            output = optarg;
+            output = args.optarg;
             break;
         case 'h':
         default:

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -70,42 +70,41 @@ bench_workqueue_src = files(
 # (C11 threads.h > POSIX pthreads > Windows MSVC).
 bench_thread_src = wirelog_thread_src
 
-# Skip bench_flowlog on Windows (uses POSIX getopt)
-if host_machine.system() != 'windows'
-  bench_flowlog = executable(
-    'bench_flowlog',
-    files('bench_flowlog.c'),
-    bench_parser_src,
-    bench_ir_src,
-    bench_optimizer_src,
-    bench_backend_src,
-    bench_io_src,
-    bench_arena_src,
-    bench_thread_src,
-    bench_workqueue_src,
-    include_directories: [wirelog_inc, wirelog_src_inc],
-    dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
-    c_args: ['-DWL_RADIX_BENCH'],
-    install: false,
-  )
+# Argv parsing routes through bench/bench_argv.h, so bench_flowlog and
+# bench_flowlog_seq build under MSVC too (issue #508 Phase 1).
+bench_flowlog = executable(
+  'bench_flowlog',
+  files('bench_flowlog.c'),
+  bench_parser_src,
+  bench_ir_src,
+  bench_optimizer_src,
+  bench_backend_src,
+  bench_io_src,
+  bench_arena_src,
+  bench_thread_src,
+  bench_workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  c_args: ['-DWL_RADIX_BENCH'],
+  install: false,
+)
 
-  bench_flowlog_seq = executable(
-    'bench_flowlog_seq',
-    files('bench_flowlog.c'),
-    bench_parser_src,
-    bench_ir_src,
-    bench_optimizer_src,
-    bench_backend_src,
-    bench_io_src,
-    bench_arena_src,
-    bench_thread_src,
-    bench_workqueue_src,
-    include_directories: [wirelog_inc, wirelog_src_inc],
-    dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
-    c_args: ['-DENABLE_K_FUSION=0', '-DWITH_K_FUSION=0'],
-    install: false,
-  )
-endif
+bench_flowlog_seq = executable(
+  'bench_flowlog_seq',
+  files('bench_flowlog.c'),
+  bench_parser_src,
+  bench_ir_src,
+  bench_optimizer_src,
+  bench_backend_src,
+  bench_io_src,
+  bench_arena_src,
+  bench_thread_src,
+  bench_workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  c_args: ['-DENABLE_K_FUSION=0', '-DWITH_K_FUSION=0'],
+  install: false,
+)
 
 # Column-major migration baseline benchmark (Issue #327)
 bench_col_layout = executable(
@@ -121,11 +120,8 @@ bench_col_layout = executable(
   install: false,
 )
 
-# Skip datagen on Windows (uses POSIX getopt_long)
-if host_machine.system() != 'windows'
-  datagen = executable(
-    'datagen',
-    files('datagen.c'),
-    install: false,
-  )
-endif
+datagen = executable(
+  'datagen',
+  files('datagen.c'),
+  install: false,
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -193,6 +193,16 @@ test_csv_exe = executable(
 
 test('csv', test_csv_exe)
 
+# Issue #508: bench_argv shim unit tests. Header-only, portable by
+# construction; runs on every platform including MSVC.
+test_bench_argv_exe = executable(
+  'test_bench_argv',
+  files('test_bench_argv.c'),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+test('bench_argv', test_bench_argv_exe,
+     suite: 'bench')
+
 # Issue #287: logger env parser tests (pure function; no env mutation).
 test_log_parse_exe = executable(
   'test_log_parse',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -270,23 +270,21 @@ endif
 #   meson setup build-release --buildtype=release -Dwirelog_log_max_level=trace
 #   meson compile -C build-release
 #   taskset -c 0 meson test -C build-release --suite perf
-# Skipped on Windows/MSVC: source uses __attribute__((noinline)) and the
-# runtime gate checks cpufreq governor (Linux-only). Dedicated perf
-# hardware targets are Linux anyway.
-if not is_windows
-  test_log_perf_gate_exe = executable(
-    'test_log_perf_gate',
-    files('test_log_perf_gate.c'),
-    files(
-      '../wirelog/util/log.c',
-      '../wirelog/util/log_emit.c',
-    ),
-    include_directories: [wirelog_inc, wirelog_src_inc],
-  )
-  test('log_perf_gate', test_log_perf_gate_exe,
-       suite: 'perf',
-       timeout: 120)
-endif
+# Now parses under MSVC via BENCH_NOINLINE (bench/bench_util.h). The
+# runtime still SKIPs on non-Linux because cpufreq_is_performance_() is
+# Linux-only; Windows-native measurement design is tracked by #508 Phase 2.
+test_log_perf_gate_exe = executable(
+  'test_log_perf_gate',
+  files('test_log_perf_gate.c'),
+  files(
+    '../wirelog/util/log.c',
+    '../wirelog/util/log_emit.c',
+  ),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+test('log_perf_gate', test_log_perf_gate_exe,
+     suite: 'perf',
+     timeout: 120)
 
 # Issue #287: end-to-end integration - WL_LOG=JOIN:5 + WL_LOG_FILE captures
 # one "[TRACE][JOIN] ... hello 42" line; unset produces zero output.

--- a/tests/test_bench_argv.c
+++ b/tests/test_bench_argv.c
@@ -1,0 +1,228 @@
+/*
+ * test_bench_argv.c - Unit tests for bench/bench_argv.h (issue #508).
+ *
+ * Covers every documented-supported shape plus every documented-rejected
+ * shape. Redirects stderr to a temp buffer during error-path tests so the
+ * test output stays clean.
+ */
+
+#include "../bench/bench_argv.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void
+test_short_space_separated(void)
+{
+    char *argv[] = { (char *)"prog", (char *)"-x", (char *)"foo", NULL };
+    int argc = 3;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == 'x');
+    assert(st.optarg != NULL && strcmp(st.optarg, "foo") == 0);
+    assert(st.optind == 3);
+    opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == -1);
+}
+
+static void
+test_short_glued(void)
+{
+    char *argv[] = { (char *)"prog", (char *)"-xfoo", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == 'x');
+    assert(strcmp(st.optarg, "foo") == 0);
+    assert(st.optind == 2);
+}
+
+static void
+test_long_space_separated(void)
+{
+    bench_argv_long_t longs[] = {
+        { "name", required_argument, 'n' },
+        { NULL, 0, 0 },
+    };
+    char *argv[] = { (char *)"prog", (char *)"--name", (char *)"foo", NULL };
+    int argc = 3;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "", longs, &st);
+    assert(opt == 'n');
+    assert(strcmp(st.optarg, "foo") == 0);
+    assert(st.optind == 3);
+}
+
+static void
+test_long_bare_flag(void)
+{
+    bench_argv_long_t longs[] = {
+        { "verbose", no_argument, 'v' },
+        { NULL, 0, 0 },
+    };
+    char *argv[] = { (char *)"prog", (char *)"--verbose", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "", longs, &st);
+    assert(opt == 'v');
+    assert(st.optarg == NULL);
+    assert(st.optind == 2);
+}
+
+static void
+test_double_dash_terminator(void)
+{
+    char *argv[] = {
+        (char *)"prog", (char *)"-x", (char *)"foo",
+        (char *)"--", (char *)"-y", NULL,
+    };
+    int argc = 5;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:y", NULL, &st);
+    assert(opt == 'x');
+    opt = bench_argv_next(argc, argv, "x:y", NULL, &st);
+    assert(opt == -1);
+    /* "--" should have been consumed; -y after it is untouched residue. */
+    assert(st.optind == 4);
+}
+
+/* Redirect stderr to an in-memory sink so error paths do not pollute test
+ * stdout. We do not assert message content -- only return codes. */
+static void
+redirect_stderr_to_devnull_(void)
+{
+#if defined(_WIN32)
+    (void)freopen("NUL", "w", stderr);
+#else
+    (void)freopen("/dev/null", "w", stderr);
+#endif
+}
+
+static void
+test_unknown_short(void)
+{
+    redirect_stderr_to_devnull_();
+    char *argv[] = { (char *)"prog", (char *)"-q", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == '?');
+}
+
+static void
+test_unknown_long(void)
+{
+    redirect_stderr_to_devnull_();
+    bench_argv_long_t longs[] = {
+        { "known", no_argument, 'k' },
+        { NULL, 0, 0 },
+    };
+    char *argv[] = { (char *)"prog", (char *)"--bogus", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "", longs, &st);
+    assert(opt == '?');
+}
+
+static void
+test_missing_short_arg(void)
+{
+    redirect_stderr_to_devnull_();
+    char *argv[] = { (char *)"prog", (char *)"-x", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == '?');
+}
+
+static void
+test_missing_long_arg(void)
+{
+    redirect_stderr_to_devnull_();
+    bench_argv_long_t longs[] = {
+        { "name", required_argument, 'n' },
+        { NULL, 0, 0 },
+    };
+    char *argv[] = { (char *)"prog", (char *)"--name", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "", longs, &st);
+    assert(opt == '?');
+}
+
+static void
+test_help_short(void)
+{
+    char *argv[] = { (char *)"prog", (char *)"-h", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "h", NULL, &st);
+    assert(opt == 'h');
+    assert(st.optarg == NULL);
+}
+
+static void
+test_empty_argv(void)
+{
+    char *argv[] = { (char *)"prog", NULL };
+    int argc = 1;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "x:", NULL, &st);
+    assert(opt == -1);
+    assert(st.optind == 1);
+}
+
+static void
+test_reentry_fresh_state(void)
+{
+    /* Two back-to-back parses with fresh state should yield the same
+     * sequence -- proves there is no hidden static state. */
+    char *argv[] = { (char *)"prog", (char *)"-x", (char *)"a",
+                     (char *)"-x", (char *)"b", NULL };
+    int argc = 5;
+
+    bench_argv_state_t st1 = BENCH_ARGV_INIT;
+    int o1a = bench_argv_next(argc, argv, "x:", NULL, &st1);
+    int o1b = bench_argv_next(argc, argv, "x:", NULL, &st1);
+    assert(o1a == 'x' && strcmp(st1.optarg, "b") == 0);
+    (void)o1b;
+
+    bench_argv_state_t st2 = BENCH_ARGV_INIT;
+    int o2a = bench_argv_next(argc, argv, "x:", NULL, &st2);
+    assert(o2a == 'x');
+    assert(strcmp(st2.optarg, "a") == 0); /* fresh state starts over */
+}
+
+static void
+test_bundled_short_rejected(void)
+{
+    redirect_stderr_to_devnull_();
+    char *argv[] = { (char *)"prog", (char *)"-ab", NULL };
+    int argc = 2;
+    bench_argv_state_t st = BENCH_ARGV_INIT;
+    int opt = bench_argv_next(argc, argv, "ab", NULL, &st);
+    assert(opt == '?'); /* bundled flags fail loud */
+}
+
+int
+main(void)
+{
+    test_short_space_separated();
+    test_short_glued();
+    test_long_space_separated();
+    test_long_bare_flag();
+    test_double_dash_terminator();
+    test_unknown_short();
+    test_unknown_long();
+    test_missing_short_arg();
+    test_missing_long_arg();
+    test_help_short();
+    test_empty_argv();
+    test_reentry_fresh_state();
+    test_bundled_short_rejected();
+    /* stderr was redirected; restore via printf to stdout which is the
+     * test runner's success channel. */
+    printf("test_bench_argv OK\n");
+    return 0;
+}

--- a/tests/test_log_perf_gate.c
+++ b/tests/test_log_perf_gate.c
@@ -41,7 +41,7 @@ enum {
     SKIP_EXIT = 77,   /* Meson "skip" exit code. */
 };
 
-__attribute__((noinline))
+BENCH_NOINLINE
 static uint64_t
 run_nolog(uint64_t iters, int a, int b, int c)
 {
@@ -52,7 +52,7 @@ run_nolog(uint64_t iters, int a, int b, int c)
     return acc;
 }
 
-__attribute__((noinline))
+BENCH_NOINLINE
 static uint64_t
 run_wllog(uint64_t iters, int a, int b, int c)
 {


### PR DESCRIPTION
## Summary

- Introduces `BENCH_NOINLINE` / `BENCH_UNUSED` compiler-attribute shims and a bespoke ~150-line `bench/bench_argv.h` argv parser (no vendored third-party source). Routes `bench_flowlog`, `bench_flowlog_seq`, `datagen`, and `test_log_perf_gate` through the shims so all four targets now build cleanly under MSVC.
- Drops 3 Windows-gating Meson guards (bench_flowlog + bench_flowlog_seq, datagen, test_log_perf_gate_exe). Remaining `not is_windows` gates are exactly the 4 POSIX-only targets kept on purpose (`test_log_threshold_race` + 3 `log_abi_*` shell-script tests) plus the pre-existing `io_plugin_dlopen` gate.
- Adds `tests/test_bench_argv.c` (13 cases covering short/long/glued/bare/`--`/unknown/missing-arg/`-h`/empty/re-entry/bundled-rejected) as the TDD gate for the parser.

## Scope (Phase 1 only)

- Closes the buildability gap opened by PR #507, which made Windows CI green by gating, not porting, the bench and perf-gate surface.
- Does **not** introduce a Windows-native perf-gate runtime. `test_log_perf_gate` now builds on MSVC but runtime is compile-coverage only — `cpufreq_is_performance_()` returns false on non-Linux so the test SKIPs with exit code 77.

## Out of scope (Phase 2/3 — remain tracked by #508)

- No baseline perf measurements on Windows.
- No CI workflow edits.
- No new perf thresholds or Windows-native stability gate (affinity / priority class / variance gate design).

## Verification performed

- **MSVC 19.50 / VS 2026 Community on Windows 11 Pro (local)**:
  - `meson setup build-win -Dtests=true -DmbedTLS=disabled`: OK
  - `meson compile -C build-win`: OK, 0 errors (pre-existing C4996 warnings only)
  - `meson test -C build-win --print-errorlogs --num-processes 1`:
    - 0 failures observed (counts: run 1 = 45 Ok / 0 Fail / 1 Skipped; run 2 = 72 Ok / 0 Fail / 1 Skipped — meson's asyncio subprocess launcher hits a non-deterministic Windows kernel-level `WinError 4551` "Application Verifier policy" mid-run on this host that aborts the runner before all tests dispatch; the issue is external to wirelog)
    - `test_bench_argv`: OK
    - `log_perf_gate`: SKIP with the expected opt-in message
  - `build-win/bench/datagen.exe --help`: prints full Usage block, exit 0
- **Grep invariants** (all PASS):
  - Zero `__attribute__((noinline))` in `tests/` and `bench/` outside the single macro definition in `bench/bench_util.h`
  - Zero `#ifdef _MSC_VER` / `#ifndef _MSC_VER` in `bench/bench_flowlog.c` and `bench/datagen.c`
  - Windows gates in `tests/meson.build` + `bench/meson.build` reduced to exactly the 4 POSIX-only targets described above
- **Linux regression**: delegated to CI (no local Linux box in this session).

## Test plan

- [ ] CI: Linux GCC + Clang must build and pass `meson test` as on `main`.
- [ ] CI: macOS must build and pass.
- [ ] CI: Windows MSVC must build `bench_flowlog`, `bench_flowlog_seq`, `datagen`, `test_log_perf_gate` and pass `test_bench_argv`; `log_perf_gate` expected to SKIP.

Closes part of #508 (Phase 1). Phase 2 (baseline measurement on a dedicated Windows perf host with a new stability gate) and Phase 3 (CI integration) remain open.