### PR TITLE
ci(#508): add nightly perf-gate workflow (Phase 3)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,0 +1,149 @@
+name: Perf Nightly
+
+# Nightly WL_LOG disabled-path perf gate (issue #508 Phase 3).
+#
+# Why separate from ci-main.yml / ci-pr.yml:
+#   The perf gate is intentionally opt-in (WIRELOG_PERF_GATE=1) because
+#   shared CI runners exhibit several-percent wall-clock noise above the
+#   1% wall budget. Running it per-PR would be flaky; running it never
+#   means regressions can slip to main. Nightly is the compromise.
+#
+# Runners:
+#   ubuntu-latest   - GCC; sets cpufreq governor to performance via
+#                     cpupower if available, pins to CPU 0 via taskset.
+#   windows-latest  - MSVC; bench_stability_prep() in the test handles
+#                     thread affinity + HIGH_PRIORITY_CLASS internally.
+#
+# Both runners are shared GitHub-hosted boxes. The coefficient-of-
+# variation self-check inside test_log_perf_gate converts noisy runs
+# to SKIP (exit 77) instead of FAIL, so background load never produces
+# a false regression signal. When the gate actually FAILs, it means
+# both wall-delta > 1% AND per-iter > 1 ns tripped on a measurement
+# stable enough to pass the CoV ceiling - a real regression.
+#
+# fail-fast: false  - both matrix entries run to completion even if
+# one fails, so we get a complete picture per night.
+
+on:
+  schedule:
+    # Daily at 04:00 UTC (overnight US Pacific / EU early morning).
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    name: Perf / ${{ matrix.os }} / ${{ matrix.compiler }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            cc: gcc
+          - os: windows-latest
+            compiler: msvc
+            cc: cl
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build linux-tools-common linux-tools-generic
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          pip install meson ninja
+          choco install pkgconfiglite -y
+
+      # Best-effort: request the 'performance' cpufreq governor. On
+      # GitHub's ubuntu-latest the governor is usually already
+      # 'performance' or 'schedutil'; if it is not and cpupower cannot
+      # set it (no permission / no governor driver), the test will SKIP
+      # with a diagnostic rather than FAIL.
+      - name: Set cpufreq governor (Linux, best-effort)
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          sudo cpupower frequency-set -g performance || true
+          for cpu in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor; do
+            echo "governor($cpu) = $(cat "$cpu" 2>/dev/null || echo 'unreadable')"
+          done
+
+      - name: Configure release + trace ceiling (Linux)
+        if: runner.os == 'Linux'
+        run: >
+          meson setup build-perf
+          --buildtype=release
+          -Dwirelog_log_max_level=trace
+          -Dtests=true
+          -DmbedTLS=disabled
+        env:
+          CC: ${{ matrix.cc }}
+
+      - name: Configure release + trace ceiling (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          meson setup build-perf --buildtype=release -Dwirelog_log_max_level=trace -Dtests=true -DmbedTLS=disabled
+
+      - name: Build (Linux)
+        if: runner.os == 'Linux'
+        run: meson compile -C build-perf
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          meson compile -C build-perf
+
+      # Linux: taskset pins the meson test harness to CPU 0. The test
+      # still benefits from the operator-imposed cpufreq=performance
+      # check pre-gate; if that check fails, the test SKIPs cleanly.
+      - name: Run perf suite (Linux)
+        if: runner.os == 'Linux'
+        env:
+          WIRELOG_PERF_GATE: '1'
+        run: |
+          taskset -c 0 meson test -C build-perf --suite perf --print-errorlogs --num-processes 1
+
+      # Windows: bench_stability_prep() sets thread affinity and raises
+      # priority class from inside the test process. No external wrapper
+      # needed; meson test invokes the binary directly.
+      - name: Run perf suite (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        env:
+          WIRELOG_PERF_GATE: '1'
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          meson test -C build-perf --suite perf --print-errorlogs --num-processes 1
+
+      - name: Publish results
+        if: always()
+        shell: bash
+        run: |
+          STATUS="${{ job.status }}"
+          echo "## Perf Nightly: ${{ matrix.os }} / ${{ matrix.compiler }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo "Status: **${STATUS}**" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f build-perf/meson-logs/testlog.txt ]; then
+            echo '<details><summary>Perf suite testlog</summary>' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -A 30 'test_log_perf_gate' build-perf/meson-logs/testlog.txt 2>/dev/null \
+              | head -200 >> "$GITHUB_STEP_SUMMARY" || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo '</details>' >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Closes the Phase 3 follow-up in #508 once #509 and #510 are merged.

## Summary

Adds `.github/workflows/perf-nightly.yml` — a nightly (04:00 UTC) + manually dispatchable GitHub Actions workflow that runs the WL_LOG disabled-path perf gate on `ubuntu-latest` (GCC) and `windows-latest` (MSVC).

- Opt-in `WIRELOG_PERF_GATE=1` env baked in.
- `continue-on-error: true` + `fail-fast: false` — nightly is a monitor, not a merge gate.
- Linux: best-effort `cpupower frequency-set -g performance`, then `taskset -c 0 meson test --suite perf`.
- Windows: relies on Phase 2's `bench_stability_prep()` inside the test process to pin affinity + raise priority class.
- Both paths: `--num-processes 1` (avoids the meson asyncio subprocess race seen on `windows-latest`).
- Step summary publishes `testlog.txt` snippet for quick triage.

## Why a nightly

Shared GitHub runners exhibit several-percent wall-clock noise — above the 1% budget. Per-PR CI would flake. No CI at all means regressions slip through. Nightly catches drift within 24 h, keeps PR CI silent.

## How the existing CoV gate keeps this honest on shared runners

Phase 2 (#510) added a baseline coefficient-of-variation self-check at 3 %. On a noisy nightly run, the test SKIPs with a diagnostic instead of FAILing. The only path to FAIL is a measurement that is (a) stable enough to pass the CoV ceiling AND (b) trips both `wall-delta > 1 %` AND `per-iter > 1 ns` — i.e., a real regression.

## Dependency chain

This PR only adds the workflow. Required runtime behavior ships in:

- #509 — Phase 1: bench + perf-gate build under MSVC.
- #510 — Phase 2: Windows-native runtime (`bench_stability_prep`, CoV gate, OR→AND).

Until both merge, the nightly runs against main-state code and SKIPs on Windows. The workflow is safe to land first or concurrently; it just won't produce signal on Windows until #510 lands.

## Expected failure modes in first runs (documented, not bugs)

1. **cpufreq governor unsettable on `ubuntu-latest`** — shared runners usually deny `cpupower frequency-set`. Expect mostly SKIP on Linux until a self-hosted perf-class runner exists. Enumeration loop logs the observed governor for postmortem.
2. **`vcvars64.bat` path assumes VS 2022 Enterprise** — matches the existing hardcoded path in `ci-main.yml`. If GitHub rotates the `windows-latest` image edition, both this workflow and `ci-main.yml` break together. Followup: `vswhere`-based discovery across both workflows.
3. **Serial perf suite** — `--num-processes 1` serializes tests. Only `test_log_perf_gate` lives in `suite: 'perf'` today; wall-time cost is nil. Revisit when the perf suite grows.

## Test plan

- [ ] After merge + PR #509 + PR #510 merge, run the workflow manually via `gh workflow run perf-nightly.yml` and inspect the step summary on both matrix entries.
- [ ] Observe the next two scheduled nightlies; confirm SKIP vs PASS behavior matches the expected failure-mode notes above.
- [ ] If Windows matrix entry consistently SKIPs via CoV gate, file a followup issue to evaluate a self-hosted `windows-latest` runner.

Completes issue #508 Phase 3.