### PR TITLE
feat(#539): Phase 3 - Observability and error handling for compound IR lowering

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,6 +20,10 @@ ir_src = files(
   '../wirelog/session.c',
   '../wirelog/exec_plan_gen.c',
   '../wirelog/session_facts.c',
+  # program.c uses WL_LOG (Issue #539 observability); bundle the logger so
+  # every test executable that links ir_src resolves the symbols.
+  '../wirelog/util/log.c',
+  '../wirelog/util/log_emit.c',
 )
 
 optimizer_src = files(

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -8,6 +8,8 @@
  * Tests written first (TDD) before program implementation.
  */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,6 +18,29 @@
 #include "../wirelog/ir/program.h"
 #include "../wirelog/intern.h"
 #include "../wirelog/wirelog-parser.h"
+#include "../wirelog/util/log.h"
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#  include <process.h>
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#  define getpid   _getpid
+#else
+#  include <unistd.h>
+#endif
+
+#include <time.h>
 
 /* ======================================================================== */
 /* Test Helpers                                                             */
@@ -1608,6 +1633,115 @@ test_compound_participates_in_join(void)
     PASS();
 }
 
+/*
+ * Issue #539 Phase 3: observability coverage. Drives compound IR lowering
+ * with WL_LOG=COMPOUND:5 pointed at a tempfile and asserts that the
+ * build_atom_scan entry, metadata, and SCAN-annotation lines are all
+ * captured through the logger.
+ */
+static const char *
+obs_tmpdir_(void)
+{
+    const char *d = getenv("TMPDIR");
+    if (d && *d) return d;
+#if defined(_WIN32)
+    d = getenv("TEMP");
+    if (d && *d) return d;
+    d = getenv("TMP");
+    if (d && *d) return d;
+    return ".";
+#else
+    return "/tmp";
+#endif
+}
+
+static void
+test_compound_observability_logging(void)
+{
+    TEST("WL_LOG captures COMPOUND section during IR lowering");
+
+    char tmp_path[256];
+    const char *d = obs_tmpdir_();
+#if defined(_WIN32)
+    const char sep = '\\';
+#else
+    const char sep = '/';
+#endif
+    snprintf(tmp_path, sizeof(tmp_path),
+        "%s%cwl_compound_obs_%ld_%ld.log",
+        d, sep, (long)getpid(), (long)time(NULL));
+    (void)remove(tmp_path);
+
+    setenv("WL_LOG_FILE", tmp_path, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    struct wirelog_program *prog
+        = make_program(".decl pred(a: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- pred(f(x)).\n");
+    if (!prog) {
+        wl_log_shutdown();
+        unsetenv("WL_LOG");
+        unsetenv("WL_LOG_FILE");
+        FAIL("program is NULL");
+        return;
+    }
+
+    patch_compound_column(prog, "pred", 0, WIRELOG_COMPOUND_KIND_INLINE, "f", 1,
+        0);
+    if (wl_ir_program_convert_rules(prog, prog->ast) != 0) {
+        wl_ir_program_free(prog);
+        wl_log_shutdown();
+        unsetenv("WL_LOG");
+        unsetenv("WL_LOG_FILE");
+        FAIL("convert_rules failed");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    wl_log_shutdown();
+
+    /* Read the log file and verify key markers are present. */
+    char buf[4096] = { 0 };
+    FILE *f = fopen(tmp_path, "r");
+    if (!f) {
+        unsetenv("WL_LOG");
+        unsetenv("WL_LOG_FILE");
+        FAIL("could not open log file");
+        return;
+    }
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    (void)remove(tmp_path);
+    unsetenv("WL_LOG");
+    unsetenv("WL_LOG_FILE");
+
+    if (n == 0) {
+        FAIL("log file is empty");
+        return;
+    }
+    if (!strstr(buf, "[COMPOUND]")) {
+        FAIL("log missing [COMPOUND] section tag");
+        return;
+    }
+    if (!strstr(buf, "build_atom_scan: enter")) {
+        FAIL("log missing build_atom_scan entry message");
+        return;
+    }
+    if (!strstr(buf, "compound metadata:")) {
+        FAIL("log missing compound metadata message");
+        return;
+    }
+    if (!strstr(buf, "SCAN annotated as COMPOUND_INLINE")) {
+        FAIL("log missing SCAN annotation INFO message");
+        return;
+    }
+
+    PASS();
+}
+
 /* ======================================================================== */
 /* UNION Merge Tests                                                        */
 /* ======================================================================== */
@@ -2394,6 +2528,9 @@ main(void)
     test_compound_mixed_columns();
     test_compound_regular_atom_unchanged();
     test_compound_participates_in_join();
+
+    /* Phase 3 (Issue #539): observability via WL_LOG */
+    test_compound_observability_logging();
 
     /* UNION merge */
     test_union_merge_tc();

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -1743,6 +1743,174 @@ test_compound_observability_logging(void)
 }
 
 /* ======================================================================== */
+/* Phase 3: Error handling / validation tests (Issue #539)                   */
+/* ======================================================================== */
+
+/*
+ * Passing NULL program or NULL ast to convert_rules must return an error
+ * code, not segfault.
+ */
+static void
+test_convert_rules_null_inputs(void)
+{
+    TEST("wl_ir_program_convert_rules rejects NULL inputs");
+
+    if (wl_ir_program_convert_rules(NULL, NULL) == 0) {
+        FAIL("expected non-zero return for NULL program and ast");
+        return;
+    }
+
+    struct wirelog_program *prog
+        = make_program(".decl pred(a: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- pred(x).\n");
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    if (wl_ir_program_convert_rules(prog, NULL) == 0) {
+        wl_ir_program_free(prog);
+        FAIL("expected non-zero return for NULL ast");
+        return;
+    }
+
+    if (wl_ir_program_convert_rules(NULL, prog->ast) == 0) {
+        wl_ir_program_free(prog);
+        FAIL("expected non-zero return for NULL program");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+/*
+ * Corrupt column metadata with an out-of-range compound_kind value.
+ * build_atom_scan must skip the annotation and leave the leaf as SCAN
+ * instead of producing a malformed node type.
+ */
+static void
+test_compound_invalid_kind_skipped(void)
+{
+    TEST("Invalid compound_kind value leaves leaf as SCAN");
+
+    struct wirelog_program *prog
+        = make_program(".decl pred(a: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- pred(f(x)).\n");
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    /* Inject an out-of-range kind (cast from int). */
+    patch_compound_column(prog, "pred", 0,
+        (wirelog_compound_kind_t)99, "f", 1, 0);
+
+    if (wl_ir_program_convert_rules(prog, prog->ast) != 0) {
+        wl_ir_program_free(prog);
+        FAIL("convert_rules must tolerate corrupt compound_kind");
+        return;
+    }
+
+    const wirelog_ir_node_t *leaf
+        = find_relation_leaf(prog->rules[0].ir_root, "pred");
+    if (!leaf) {
+        wl_ir_program_free(prog);
+        FAIL("could not locate pred leaf");
+        return;
+    }
+
+    if (leaf->type != WIRELOG_IR_SCAN) {
+        wl_ir_program_free(prog);
+        FAIL("leaf must remain SCAN when compound_kind is invalid");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+/*
+ * INLINE compounds must carry a non-zero arity; arity=0 is treated as
+ * corrupt metadata and the annotation is skipped so downstream passes
+ * don't see a compound with no payload.
+ */
+static void
+test_compound_inline_zero_arity_skipped(void)
+{
+    TEST("INLINE compound with arity=0 leaves leaf as SCAN");
+
+    struct wirelog_program *prog
+        = make_program(".decl pred(a: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- pred(f(x)).\n");
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    /* arity=0 is invalid for an INLINE compound. */
+    patch_compound_column(prog, "pred", 0, WIRELOG_COMPOUND_KIND_INLINE, "f", 0,
+        0);
+
+    if (wl_ir_program_convert_rules(prog, prog->ast) != 0) {
+        wl_ir_program_free(prog);
+        FAIL("convert_rules must tolerate arity=0");
+        return;
+    }
+
+    const wirelog_ir_node_t *leaf
+        = find_relation_leaf(prog->rules[0].ir_root, "pred");
+    if (!leaf || leaf->type != WIRELOG_IR_SCAN) {
+        wl_ir_program_free(prog);
+        FAIL("leaf must remain SCAN when INLINE arity is 0");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+/*
+ * A program with zero relations still exercises convert_rules without
+ * hitting the compound annotation path. Sanity check that the empty/edge
+ * case doesn't regress.
+ */
+static void
+test_compound_no_relations_safe(void)
+{
+    TEST("convert_rules safe when program has no rules or relations");
+
+    struct wirelog_program *prog = wl_ir_program_create();
+    if (!prog) {
+        FAIL("program_create returned NULL");
+        return;
+    }
+
+    /* Build a minimal empty AST-like stub by parsing an empty program. */
+    char errbuf[128] = { 0 };
+    wl_parser_ast_node_t *ast
+        = wl_parser_parse_string("", errbuf, sizeof(errbuf));
+    if (!ast) {
+        wl_ir_program_free(prog);
+        FAIL("failed to parse empty program");
+        return;
+    }
+    prog->ast = ast;
+
+    if (wl_ir_program_convert_rules(prog, ast) != 0) {
+        wl_ir_program_free(prog);
+        FAIL("convert_rules failed on empty program");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
 /* UNION Merge Tests                                                        */
 /* ======================================================================== */
 
@@ -2531,6 +2699,12 @@ main(void)
 
     /* Phase 3 (Issue #539): observability via WL_LOG */
     test_compound_observability_logging();
+
+    /* Phase 3: error handling / validation (Issue #539) */
+    test_convert_rules_null_inputs();
+    test_compound_invalid_kind_skipped();
+    test_compound_inline_zero_arity_skipped();
+    test_compound_no_relations_safe();
 
     /* UNION merge */
     test_union_merge_tc();

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -13,6 +13,7 @@
 #include "../parser/ast.h"
 #include "../passes/magic_sets.h"
 #include "../intern.h"
+#include "../util/log.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -882,6 +883,11 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     const struct wirelog_program *prog, char ***out_var_names,
     uint32_t *out_var_count)
 {
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+        "build_atom_scan: enter relation=%s arity=%u",
+        atom && atom->name ? atom->name : "?",
+        atom ? atom->child_count : 0u);
+
     wirelog_ir_node_t *scan = wl_ir_node_create(WIRELOG_IR_SCAN);
     if (!scan)
         return NULL;
@@ -954,6 +960,13 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
 
                 /* First compound column annotates the SCAN. */
                 if (scan->type == WIRELOG_IR_SCAN) {
+                    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+                        "compound metadata: relation=%s col=%u kind=%d "
+                        "functor_id=%u arity=%u inline_offset=%u",
+                        atom->name, i, (int)col->compound_kind,
+                        col->compound_functor_id, col->compound_arity,
+                        col->compound_inline_col_offset);
+
                     scan->type = (col->compound_kind
                         == WIRELOG_COMPOUND_KIND_INLINE)
                         ? WIRELOG_IR_COMPOUND_INLINE
@@ -963,6 +976,12 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                     scan->compound_inline.arity = col->compound_arity;
                     scan->compound_inline.inline_col_offset
                         = col->compound_inline_col_offset;
+
+                    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_INFO,
+                        "SCAN annotated as %s for relation=%s col=%u",
+                        scan->type == WIRELOG_IR_COMPOUND_INLINE
+                            ? "COMPOUND_INLINE" : "COMPOUND_SIDE",
+                        atom->name, i);
                 }
             }
         }
@@ -1089,6 +1108,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
     for (uint32_t i = 1; i < rule_node->child_count; i++) {
         const wl_parser_ast_node_t *b = rule_node->children[i];
         if (b->type == WL_PARSER_AST_NODE_ATOM) {
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+                "convert_rule: build scan for body atom relation=%s",
+                b->name ? b->name : "?");
             scans[scan_count] = build_atom_scan(b, prog,
                     &scan_vars[scan_count], &scan_vcounts[scan_count]);
             scan_count++;

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -883,14 +883,35 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     const struct wirelog_program *prog, char ***out_var_names,
     uint32_t *out_var_count)
 {
+    /* Validate required arguments. atom, out_var_names, and out_var_count
+     * are dereferenced unconditionally below; prog is tolerated as NULL
+     * (skips compound annotation). */
+    if (!atom || !out_var_names || !out_var_count) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+            "build_atom_scan: invalid arguments atom=%p "
+            "out_var_names=%p out_var_count=%p",
+            (const void *)atom, (void *)out_var_names,
+            (void *)out_var_count);
+        if (out_var_names)
+            *out_var_names = NULL;
+        if (out_var_count)
+            *out_var_count = 0;
+        return NULL;
+    }
+
     WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
         "build_atom_scan: enter relation=%s arity=%u",
-        atom && atom->name ? atom->name : "?",
-        atom ? atom->child_count : 0u);
+        atom->name ? atom->name : "?", atom->child_count);
 
     wirelog_ir_node_t *scan = wl_ir_node_create(WIRELOG_IR_SCAN);
-    if (!scan)
+    if (!scan) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+            "build_atom_scan: wl_ir_node_create(SCAN) failed for relation=%s",
+            atom->name ? atom->name : "?");
+        *out_var_names = NULL;
+        *out_var_count = 0;
         return NULL;
+    }
 
     wl_ir_node_set_relation(scan, atom->name);
 
@@ -957,6 +978,31 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                     continue;
                 if (col->compound_kind == WIRELOG_COMPOUND_KIND_NONE)
                     continue;
+
+                /* Validate compound_kind is a known annotatable value.
+                 * Defensive: unknown kinds (from corrupt metadata) are
+                 * skipped rather than producing a malformed SCAN type. */
+                if (col->compound_kind != WIRELOG_COMPOUND_KIND_INLINE
+                    && col->compound_kind != WIRELOG_COMPOUND_KIND_SIDE) {
+                    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                        "invalid compound_kind=%d for relation=%s col=%u, "
+                        "skipping annotation",
+                        (int)col->compound_kind, atom->name, i);
+                    continue;
+                }
+
+                /* INLINE compounds require a non-zero arity. A zero arity
+                 * indicates missing/corrupt metadata — skip rather than
+                 * annotate, so downstream passes don't see a compound
+                 * with no payload. */
+                if (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE
+                    && col->compound_arity == 0) {
+                    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                        "inline compound with arity=0 for relation=%s "
+                        "col=%u, skipping annotation",
+                        atom->name, i);
+                    continue;
+                }
 
                 /* First compound column annotates the SCAN. */
                 if (scan->type == WIRELOG_IR_SCAN) {
@@ -1107,12 +1153,20 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
     uint32_t scan_count = 0;
     for (uint32_t i = 1; i < rule_node->child_count; i++) {
         const wl_parser_ast_node_t *b = rule_node->children[i];
+        if (!b)
+            continue;
         if (b->type == WL_PARSER_AST_NODE_ATOM) {
             WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
                 "convert_rule: build scan for body atom relation=%s",
                 b->name ? b->name : "?");
             scans[scan_count] = build_atom_scan(b, prog,
                     &scan_vars[scan_count], &scan_vcounts[scan_count]);
+            if (!scans[scan_count]) {
+                WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+                    "convert_rule: build_atom_scan returned NULL for "
+                    "body atom index=%u relation=%s",
+                    i, b->name ? b->name : "?");
+            }
             scan_count++;
         }
     }

--- a/wirelog/util/log.c
+++ b/wirelog/util/log.c
@@ -37,6 +37,7 @@ static const char *const wl_log_section_names_[WL_LOG_SEC__COUNT] = {
     [WL_LOG_SEC_IO] = "IO",
     [WL_LOG_SEC_PARSER] = "PARSER",
     [WL_LOG_SEC_PLUGIN] = "PLUGIN",
+    [WL_LOG_SEC_COMPOUND] = "COMPOUND",
 };
 
 const char *

--- a/wirelog/util/log.h
+++ b/wirelog/util/log.h
@@ -73,6 +73,7 @@ typedef enum {
     WL_LOG_SEC_IO,
     WL_LOG_SEC_PARSER,
     WL_LOG_SEC_PLUGIN,
+    WL_LOG_SEC_COMPOUND,
     WL_LOG_SEC__COUNT
 } wl_log_section_t;
 


### PR DESCRIPTION
## Summary

Phase 3 of Issue #539 hardens compound column IR lowering with structured observability and defensive error handling, so operators can trace compound detection and downstream passes never see a malformed compound SCAN.

- **Observability (9862bbe):** new `WL_LOG_SEC_COMPOUND` section; `build_atom_scan()` emits DEBUG on entry, DEBUG on metadata copy, and INFO on SCAN annotation; `convert_rule()` emits DEBUG at each body-atom scan build. Enable at runtime with `WL_LOG=COMPOUND:<level>`.
- **Error handling (dba3970):** `build_atom_scan()` validates `atom`, `out_var_names`, `out_var_count` with early-return ERROR log; rejects unknown `compound_kind` and `INLINE` with `arity=0` with WARN + skip (leaves leaf as SCAN); `convert_rule()` NULL-guards body children and logs ERROR when scan construction fails.
- **Test coverage:** `tests/test_program.c` gains 5 new tests - WL_LOG integration (`WL_LOG_FILE`-driven, asserts `[COMPOUND]` tag + all three messages), NULL-input rejection in `wl_ir_program_convert_rules`, corrupt `compound_kind` is skipped, `INLINE` arity=0 is skipped, empty program is safe. `tests/meson.build` now bundles `log.c` + `log_emit.c` into `ir_src` so every test executable linking `program.c` resolves the logger symbols.

## Verification

- `meson test -C build` -- **144 Ok, 0 Fail, 1 Skipped** (skipped test is `test_log_perf_gate`, which requires `WIRELOG_PERF_GATE=1` and dedicated perf hardware; expected on shared runners).
- `tests/test_program`: **57/57 passed** under MSAN/UBSAN/ASAN (`halt_on_error=1`, `MALLOC_PERTURB_=1`).
- Both commits are atomic and include implementation + tests together.

## Commits

- `9862bbe` feat(#539): Add observability logging to compound IR lowering
- `dba3970` feat(#539): Add error handling to compound IR lowering

Closes part of #539 (Phase 3).

## Test plan

- [x] `meson test -C build` passes with 0 failures.
- [x] `tests/test_program` passes all 57 tests (including 5 new Phase 3 tests).
- [x] ASAN/UBSAN/MSAN clean under meson test harness.
- [x] `WL_LOG=COMPOUND:5` captures expected log lines end-to-end via `WL_LOG_FILE`.
- [x] Commit messages follow wirelog conventions (no emojis, clear scope).