### PR TITLE
fix(#543): Add boundary check in wl_col_rel_inline_locate to prevent heap-buffer-overflow

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2246,6 +2246,24 @@ test_col_rel_compound_schema_exe = executable(
 test('col_rel_compound_schema', test_col_rel_compound_schema_exe)
 
 # ============================================================================
+# Inline compound store/retrieve/retract ops (Issue #532 Task 3)
+# ============================================================================
+
+test_col_rel_inline_storage_exe = executable(
+  'test_col_rel_inline_storage',
+  files('test_col_rel_inline_storage.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('col_rel_inline_storage', test_col_rel_inline_storage_exe)
+
+# ============================================================================
 # Per-Worker Session State (Issue #315)
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2264,6 +2264,42 @@ test_col_rel_inline_storage_exe = executable(
 test('col_rel_inline_storage', test_col_rel_inline_storage_exe)
 
 # ============================================================================
+# Compound logging + error observability (Issue #532 Task 6)
+# ============================================================================
+
+test_compound_logging_exe = executable(
+  'test_compound_logging',
+  files('test_compound_logging.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('compound_logging', test_compound_logging_exe, suite: 'log')
+
+# ============================================================================
+# Inline-tier integration battery (Issue #532 Task 5)
+# ============================================================================
+
+test_columnar_inline_exe = executable(
+  'test_columnar_inline',
+  files('test_columnar_inline.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('columnar_inline', test_columnar_inline_exe)
+
+# ============================================================================
 # K-Fusion deep-copy + inline compound visibility (Issue #532 Task 4)
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2264,6 +2264,24 @@ test_col_rel_inline_storage_exe = executable(
 test('col_rel_inline_storage', test_col_rel_inline_storage_exe)
 
 # ============================================================================
+# K-Fusion deep-copy + inline compound visibility (Issue #532 Task 4)
+# ============================================================================
+
+test_k_fusion_inline_shadow_exe = executable(
+  'test_k_fusion_inline_shadow',
+  files('test_k_fusion_inline_shadow.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('k_fusion_inline_shadow', test_k_fusion_inline_shadow_exe, timeout: 60)
+
+# ============================================================================
 # Per-Worker Session State (Issue #315)
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2228,6 +2228,24 @@ test_partition_exe = executable(
 test('partition', test_partition_exe)
 
 # ============================================================================
+# col_rel_t compound metadata fields (Issue #532 Task 1)
+# ============================================================================
+
+test_col_rel_compound_schema_exe = executable(
+  'test_col_rel_compound_schema',
+  files('test_col_rel_compound_schema.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('col_rel_compound_schema', test_col_rel_compound_schema_exe)
+
+# ============================================================================
 # Per-Worker Session State (Issue #315)
 # ============================================================================
 

--- a/tests/test_col_rel_compound_schema.c
+++ b/tests/test_col_rel_compound_schema.c
@@ -223,18 +223,260 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Physical column layout (Issue #532 Task 2)                               */
+/* ======================================================================== */
+
+static void
+test_physical_column_expansion(void)
+{
+    TEST("physical-column expansion with mixed INLINE/SIDE/scalar");
+
+    /* Logical schema: [scalar, INLINE/2, scalar, INLINE/3, SIDE/5].
+     * Expected physical layout:
+     *   col 0  scalar     -> 1 slot  at offset 0
+     *   col 1  INLINE/2   -> 2 slots at offset 1..2
+     *   col 2  scalar     -> 1 slot  at offset 3
+     *   col 3  INLINE/3   -> 3 slots at offset 4..6
+     *   col 4  SIDE/5     -> 1 slot  at offset 7  (handle only)
+     * physical_ncols         = 8
+     * inline_physical_offset = 1  (first INLINE column)
+     * compound_count         = 2  (INLINE columns only). */
+    const col_rel_logical_col_t cols[5] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 3u, 1u },
+        { WIRELOG_COMPOUND_KIND_SIDE,   5u, 1u },
+    };
+    uint32_t offsets[5] = { 0 };
+    uint32_t physical = 0u;
+    uint32_t first_inline = 0u;
+    uint32_t compound_count = 0u;
+    col_rel_t *r = NULL;
+
+    int rc = col_rel_compute_physical_layout(cols, 5u, &physical, offsets,
+            &first_inline, &compound_count);
+    if (rc != 0) {
+        tests_failed++;
+        printf(" ... FAIL: compute_physical_layout rc=%d\n", rc);
+        return;
+    }
+
+    ASSERT(physical == 8u, "physical_ncols != 8");
+    ASSERT(offsets[0] == 0u, "offsets[0] != 0");
+    ASSERT(offsets[1] == 1u, "offsets[1] != 1");
+    ASSERT(offsets[2] == 3u, "offsets[2] != 3");
+    ASSERT(offsets[3] == 4u, "offsets[3] != 4");
+    ASSERT(offsets[4] == 7u, "offsets[4] != 7");
+    ASSERT(first_inline == 1u, "inline_physical_offset != 1");
+    ASSERT(compound_count == 2u, "compound_count != 2");
+
+    /* All-scalar schema degenerates: physical == logical, no inline offset. */
+    const col_rel_logical_col_t scalar_cols[3] = {
+        { WIRELOG_COMPOUND_KIND_NONE, 0u, 0u },
+        { WIRELOG_COMPOUND_KIND_NONE, 0u, 0u },
+        { WIRELOG_COMPOUND_KIND_NONE, 0u, 0u },
+    };
+    physical = 99u;
+    first_inline = 99u;
+    compound_count = 99u;
+    ASSERT(col_rel_compute_physical_layout(scalar_cols, 3u, &physical, NULL,
+        &first_inline, &compound_count)
+        == 0,
+        "scalar layout rejected");
+    ASSERT(physical == 3u, "scalar physical_ncols != 3");
+    ASSERT(first_inline == 0u, "scalar first_inline != 0");
+    ASSERT(compound_count == 0u, "scalar compound_count != 0");
+
+    /* apply_compound_schema: populates the owned map; destroy releases it. */
+    ASSERT(col_rel_alloc(&r, "phys_expand") == 0, "col_rel_alloc failed");
+    ASSERT(col_rel_apply_compound_schema(r, cols, 5u) == 0,
+        "apply_compound_schema failed");
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_INLINE,
+        "compound_kind not INLINE after apply");
+    ASSERT(r->compound_count == 2u, "compound_count on rel != 2");
+    ASSERT(r->inline_physical_offset == 1u,
+        "inline_physical_offset on rel != 1");
+    ASSERT(r->compound_arity_map != NULL,
+        "compound_arity_map not allocated");
+    ASSERT(r->compound_arity_map[0] == 1u, "rel arity_map[0] != 1");
+    ASSERT(r->compound_arity_map[1] == 2u, "rel arity_map[1] != 2");
+    ASSERT(r->compound_arity_map[2] == 1u, "rel arity_map[2] != 1");
+    ASSERT(r->compound_arity_map[3] == 3u, "rel arity_map[3] != 3");
+    ASSERT(r->compound_arity_map[4] == 1u,
+        "rel arity_map[4] != 1 (SIDE is 1 slot)");
+
+    /* Re-apply with a different schema: the previous arity_map is freed and
+     * replaced, not leaked. Switch to a SIDE-only schema to also verify the
+     * relation-level kind flips accordingly. */
+    const col_rel_logical_col_t side_only[2] = {
+        { WIRELOG_COMPOUND_KIND_SIDE, 3u, 1u },
+        { WIRELOG_COMPOUND_KIND_NONE, 0u, 0u },
+    };
+    ASSERT(col_rel_apply_compound_schema(r, side_only, 2u) == 0,
+        "reapply with SIDE schema failed");
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_SIDE,
+        "compound_kind not SIDE after reapply");
+    ASSERT(r->compound_count == 0u,
+        "compound_count should be 0 (no INLINE cols) after reapply");
+    ASSERT(r->inline_physical_offset == 0u,
+        "inline_physical_offset should be 0 on SIDE-only schema");
+    ASSERT(r->compound_arity_map[0] == 1u, "SIDE col width != 1");
+    ASSERT(r->compound_arity_map[1] == 1u, "scalar col width != 1");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+static void
+test_arity_overflow(void)
+{
+    TEST("arity overflow rejected (INLINE arity > MAX_ARITY)");
+
+    /* Spot-check the boundary: arity == MAX_ARITY must succeed, arity ==
+     * MAX_ARITY + 1 must fail. Also verify arity == 0 is rejected because
+     * an inline compound with no arguments is degenerate. */
+    col_rel_logical_col_t col = {
+        WIRELOG_COMPOUND_KIND_INLINE,
+        WL_COMPOUND_INLINE_MAX_ARITY, /* == 4, acceptable boundary */
+        1u,
+    };
+    uint32_t physical = 0u;
+    ASSERT(col_rel_compute_physical_layout(&col, 1u, &physical, NULL, NULL,
+        NULL)
+        == 0,
+        "boundary arity rejected");
+    ASSERT(physical == WL_COMPOUND_INLINE_MAX_ARITY,
+        "boundary physical_ncols mismatch");
+
+    col.arity = WL_COMPOUND_INLINE_MAX_ARITY + 1u; /* == 5, overflow */
+    ASSERT(col_rel_compute_physical_layout(&col, 1u, NULL, NULL, NULL, NULL)
+        == EINVAL,
+        "overflow arity not rejected");
+
+    col.arity = 0u;
+    ASSERT(col_rel_compute_physical_layout(&col, 1u, NULL, NULL, NULL, NULL)
+        == EINVAL,
+        "zero-arity INLINE not rejected");
+
+    /* Overflow leaves relation state untouched (no partial write). */
+    col_rel_t *r = NULL;
+    ASSERT(col_rel_alloc(&r, "overflow") == 0, "col_rel_alloc failed");
+    col.arity = WL_COMPOUND_INLINE_MAX_ARITY + 2u;
+    ASSERT(col_rel_apply_compound_schema(r, &col, 1u) == EINVAL,
+        "overflow not rejected via apply");
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "compound_kind mutated on failure");
+    ASSERT(r->compound_arity_map == NULL,
+        "compound_arity_map allocated on failure");
+    col_rel_destroy(r);
+
+    /* SIDE-kind arity is NOT capped by the inline limit -- SIDE columns
+     * hold only a handle in the row, regardless of functor arity. */
+    col_rel_logical_col_t side = {
+        WIRELOG_COMPOUND_KIND_SIDE,
+        16u, /* intentionally above WL_COMPOUND_INLINE_MAX_ARITY */
+        1u,
+    };
+    ASSERT(col_rel_compute_physical_layout(&side, 1u, &physical, NULL, NULL,
+        NULL)
+        == 0,
+        "SIDE arity incorrectly capped");
+    ASSERT(physical == 1u, "SIDE col should occupy exactly 1 physical slot");
+
+    PASS();
+cleanup:
+    return;
+}
+
+static void
+test_depth_validation(void)
+{
+    TEST("nesting depth validation (INLINE depth > MAX_DEPTH rejected)");
+    col_rel_t *r = NULL;
+
+    /* depth == MAX_DEPTH (= 1) is the acceptable boundary. */
+    col_rel_logical_col_t col = {
+        WIRELOG_COMPOUND_KIND_INLINE,
+        2u,
+        WL_COMPOUND_INLINE_MAX_DEPTH,
+    };
+    ASSERT(col_rel_compute_physical_layout(&col, 1u, NULL, NULL, NULL, NULL)
+        == 0,
+        "boundary depth rejected");
+
+    col.depth = WL_COMPOUND_INLINE_MAX_DEPTH + 1u; /* nested; must fail */
+    ASSERT(col_rel_compute_physical_layout(&col, 1u, NULL, NULL, NULL, NULL)
+        == EINVAL,
+        "depth overflow not rejected");
+
+    /* Mixing a depth-valid and depth-invalid column: function must still
+     * fail and must not partially commit to a physical count. */
+    const col_rel_logical_col_t mixed[2] = {
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 3u, 2u }, /* too deep */
+    };
+    uint32_t offsets[2] = { 99u, 99u };
+    uint32_t physical = 99u;
+    ASSERT(col_rel_compute_physical_layout(mixed, 2u, &physical, offsets,
+        NULL, NULL)
+        == EINVAL,
+        "mixed depth overflow not rejected");
+    ASSERT(physical == 99u, "physical_ncols modified on EINVAL");
+    ASSERT(offsets[0] == 99u && offsets[1] == 99u,
+        "offsets modified on EINVAL");
+
+    /* apply_compound_schema must refuse and preserve rel state on EINVAL. */
+    ASSERT(col_rel_alloc(&r, "depth_validation") == 0,
+        "col_rel_alloc failed");
+    ASSERT(col_rel_apply_compound_schema(r, mixed, 2u) == EINVAL,
+        "apply did not reject depth overflow");
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "compound_kind mutated by failed apply");
+    ASSERT(r->compound_arity_map == NULL,
+        "compound_arity_map allocated on failed apply");
+
+    /* SIDE columns are not subject to the inline depth limit (the side-
+     * relation path represents nesting via handle chains, not expansion). */
+    col_rel_logical_col_t side = {
+        WIRELOG_COMPOUND_KIND_SIDE,
+        3u,
+        5u, /* arbitrary: ignored for SIDE */
+    };
+    ASSERT(col_rel_compute_physical_layout(&side, 1u, NULL, NULL, NULL, NULL)
+        == 0,
+        "SIDE depth incorrectly validated");
+
+    /* NULL / zero-length inputs */
+    ASSERT(col_rel_compute_physical_layout(NULL, 0u, NULL, NULL, NULL, NULL)
+        == EINVAL,
+        "NULL input not rejected");
+    ASSERT(col_rel_compute_physical_layout(&col, 0u, NULL, NULL, NULL, NULL)
+        == EINVAL,
+        "zero logical_ncols not rejected");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
 int
 main(void)
 {
-    printf("test_col_rel_compound_schema (Issue #532 Task 1)\n");
-    printf("================================================\n");
+    printf("test_col_rel_compound_schema (Issue #532 Tasks 1 + 2)\n");
+    printf("=====================================================\n");
 
     test_col_rel_side_default();
     test_col_rel_inline_schema();
     test_col_rel_backward_compat();
+    test_physical_column_expansion();
+    test_arity_overflow();
+    test_depth_validation();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_compound_schema.c
+++ b/tests/test_col_rel_compound_schema.c
@@ -1,0 +1,242 @@
+/*
+ * test_col_rel_compound_schema.c - col_rel_t compound metadata (Issue #532 Task 1)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Unit tests for the compound-column metadata fields added to col_rel_t as
+ * part of the inline-tier schema extension (Issue #532, Commit 1).  These
+ * tests exercise data-structure additions only -- no logic that populates
+ * the fields lands in this commit.
+ *
+ *   test_col_rel_side_default
+ *       Freshly allocated relation has compound metadata in its zero
+ *       default (kind == NONE, count == 0, arity_map == NULL,
+ *       inline_physical_offset == 0), so SIDE-tier consumers that never
+ *       opt into inline expansion observe a clean slate.
+ *
+ *   test_col_rel_inline_schema
+ *       Manually populates the compound metadata on a relation to assert
+ *       that the struct layout accepts INLINE-tier values and that the
+ *       owned compound_arity_map is released on destroy without leaks.
+ *
+ *   test_col_rel_backward_compat
+ *       Confirms the new fields are safely zero-initialised by the
+ *       normal allocation paths (col_rel_alloc, col_rel_new_auto), so
+ *       legacy call sites that never touch compound metadata continue
+ *       to behave identically.
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_col_rel_side_default(void)
+{
+    TEST("col_rel_t compound defaults to SIDE-clean state");
+    col_rel_t *r = NULL;
+    int rc = col_rel_alloc(&r, "side_default");
+    if (rc != 0 || r == NULL) {
+        tests_failed++;
+        printf(" ... FAIL: col_rel_alloc failed rc=%d\n", rc);
+        return;
+    }
+
+    /* A relation that never opts into inline expansion must present
+     * compound_kind == NONE with no owned side-state.  The SIDE-tier
+     * storage path keys off this invariant. */
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "compound_kind not NONE by default");
+    ASSERT(r->compound_count == 0u, "compound_count not zero by default");
+    ASSERT(r->compound_arity_map == NULL,
+        "compound_arity_map not NULL by default");
+    ASSERT(r->inline_physical_offset == 0u,
+        "inline_physical_offset not zero by default");
+
+    /* Even with a schema applied, unchanged compound metadata must stay
+     * at its zero default -- set_schema does not touch these fields. */
+    const char *names[2] = { "a", "b" };
+    ASSERT(col_rel_set_schema(r, 2, names) == 0, "set_schema failed");
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "compound_kind perturbed by set_schema");
+    ASSERT(r->compound_arity_map == NULL,
+        "compound_arity_map perturbed by set_schema");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+static void
+test_col_rel_inline_schema(void)
+{
+    TEST("col_rel_t accepts INLINE compound metadata");
+    col_rel_t *r = NULL;
+    uint32_t *arity_map = NULL;
+    int rc = col_rel_alloc(&r, "inline_schema");
+    if (rc != 0 || r == NULL) {
+        tests_failed++;
+        printf(" ... FAIL: col_rel_alloc failed rc=%d\n", rc);
+        return;
+    }
+
+    /* Logical schema: (scalar, inline/2, scalar, inline/3).  Phase 2B will
+     * synthesise this map automatically; here we populate it directly to
+     * prove the struct can carry it and the destroy path frees it. */
+    const uint32_t logical_ncols = 4u;
+    arity_map = (uint32_t *)calloc(logical_ncols, sizeof(uint32_t));
+    ASSERT(arity_map != NULL, "calloc arity_map failed");
+    arity_map[0] = 1u;
+    arity_map[1] = 2u;
+    arity_map[2] = 1u;
+    arity_map[3] = 3u;
+
+    r->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+    r->compound_count = 2u;
+    r->compound_arity_map = arity_map;
+    /* col 0 takes one physical slot; the first inline compound starts at
+     * physical offset 1. */
+    r->inline_physical_offset = 1u;
+    arity_map = NULL; /* ownership transferred to r */
+
+    /* Round-trip reads: the fields hold what we wrote without truncation. */
+    ASSERT(r->compound_kind == WIRELOG_COMPOUND_KIND_INLINE,
+        "compound_kind round-trip mismatch");
+    ASSERT(r->compound_count == 2u, "compound_count round-trip mismatch");
+    ASSERT(r->compound_arity_map != NULL, "compound_arity_map lost");
+    ASSERT(r->compound_arity_map[0] == 1u, "arity_map[0] mismatch");
+    ASSERT(r->compound_arity_map[1] == 2u, "arity_map[1] mismatch");
+    ASSERT(r->compound_arity_map[2] == 1u, "arity_map[2] mismatch");
+    ASSERT(r->compound_arity_map[3] == 3u, "arity_map[3] mismatch");
+    ASSERT(r->inline_physical_offset == 1u,
+        "inline_physical_offset round-trip mismatch");
+
+    /* Prefix-sum sanity: sum(arity_map) == logical base (4 slots for
+     * logical columns 0..3) + expansion delta; compound_count of 2
+     * matches the two entries with arity > 1. */
+    uint32_t compound_seen = 0u;
+    uint32_t physical_total = 0u;
+    for (uint32_t i = 0; i < logical_ncols; i++) {
+        physical_total += r->compound_arity_map[i];
+        if (r->compound_arity_map[i] > 1u)
+            compound_seen++;
+    }
+    ASSERT(compound_seen == r->compound_count,
+        "compound_count inconsistent with arity_map");
+    ASSERT(physical_total == 7u, "physical column count mismatch");
+
+    PASS();
+cleanup:
+    /* If we failed before transferring ownership, free the local buffer
+     * so ASAN stays quiet. */
+    free(arity_map);
+    col_rel_destroy(r); /* frees r->compound_arity_map */
+}
+
+static void
+test_col_rel_backward_compat(void)
+{
+    TEST("col_rel_t legacy allocation paths zero compound metadata");
+    col_rel_t *via_alloc = NULL;
+    col_rel_t *via_auto = NULL;
+
+    ASSERT(col_rel_alloc(&via_alloc, "via_alloc") == 0, "col_rel_alloc failed");
+    ASSERT(via_alloc->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "col_rel_alloc did not zero compound_kind");
+    ASSERT(via_alloc->compound_count == 0u,
+        "col_rel_alloc did not zero compound_count");
+    ASSERT(via_alloc->compound_arity_map == NULL,
+        "col_rel_alloc did not zero compound_arity_map");
+    ASSERT(via_alloc->inline_physical_offset == 0u,
+        "col_rel_alloc did not zero inline_physical_offset");
+
+    via_auto = col_rel_new_auto("via_auto", 3u);
+    ASSERT(via_auto != NULL, "col_rel_new_auto failed");
+    ASSERT(via_auto->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "col_rel_new_auto did not zero compound_kind");
+    ASSERT(via_auto->compound_count == 0u,
+        "col_rel_new_auto did not zero compound_count");
+    ASSERT(via_auto->compound_arity_map == NULL,
+        "col_rel_new_auto did not zero compound_arity_map");
+    ASSERT(via_auto->inline_physical_offset == 0u,
+        "col_rel_new_auto did not zero inline_physical_offset");
+
+    /* Appending rows through the legacy row-oriented API on a plain
+     * relation must not touch compound metadata either. */
+    int64_t row[3] = { 1, 2, 3 };
+    ASSERT(col_rel_append_row(via_auto, row) == 0, "append_row failed");
+    ASSERT(via_auto->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "append_row perturbed compound_kind");
+    ASSERT(via_auto->compound_arity_map == NULL,
+        "append_row perturbed compound_arity_map");
+
+    PASS();
+cleanup:
+    col_rel_destroy(via_alloc);
+    col_rel_destroy(via_auto);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_col_rel_compound_schema (Issue #532 Task 1)\n");
+    printf("================================================\n");
+
+    test_col_rel_side_default();
+    test_col_rel_inline_schema();
+    test_col_rel_backward_compat();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_col_rel_inline_storage.c
+++ b/tests/test_col_rel_inline_storage.c
@@ -1,0 +1,276 @@
+/*
+ * test_col_rel_inline_storage.c - inline compound store/retrieve/retract
+ * (Issue #532 Task 3)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Verifies the inline compound storage ops added in eval.c:
+ *
+ *   test_inline_store_retrieve
+ *       Schema (scalar, inline/2, scalar, inline/3). Append a row, store
+ *       args into each inline column via wl_col_rel_store_inline_compound,
+ *       retrieve them back via wl_col_rel_retrieve_inline_compound, and
+ *       confirm the raw physical slots line up with the Task #2 prefix-sum
+ *       offset map (1, 3 for the two inline columns).
+ *
+ *   test_inline_retract_sync
+ *       Store, then retract. Physical slots must remain intact so delta
+ *       machinery and join matching can still see the original tuple
+ *       during retraction-seeded evaluation. Retract with multiplicity
+ *       zero is rejected as a precondition violation.
+ *
+ *   test_inline_multiarg
+ *       Two independent inline columns of different arities in the same
+ *       row round-trip without cross-talk; a second row writes different
+ *       values and leaves the first row unchanged.
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* Build the (scalar, inline/2, scalar, inline/3) fixture shared by each
+ * test: allocates a relation, applies the compound schema, materialises
+ * the 7-column physical schema, and appends one row of zeros so row 0 is
+ * addressable by the storage ops.  Returns 0 on success; caller owns the
+ * returned relation and must col_rel_destroy it. */
+static int
+build_inline_fixture(col_rel_t **out_rel)
+{
+    col_rel_t *r = NULL;
+    int rc = col_rel_alloc(&r, "inline_fixture");
+    if (rc != 0)
+        return rc;
+
+    const col_rel_logical_col_t logical[4] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 3u, 1u },
+    };
+    rc = col_rel_apply_compound_schema(r, logical, 4u);
+    if (rc != 0) {
+        col_rel_destroy(r);
+        return rc;
+    }
+    /* Physical schema: 1 + 2 + 1 + 3 = 7 slots. */
+    rc = col_rel_set_schema(r, 7u, NULL);
+    if (rc != 0) {
+        col_rel_destroy(r);
+        return rc;
+    }
+
+    const int64_t zeros[7] = { 0, 0, 0, 0, 0, 0, 0 };
+    rc = col_rel_append_row(r, zeros);
+    if (rc != 0) {
+        col_rel_destroy(r);
+        return rc;
+    }
+    *out_rel = r;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_inline_store_retrieve(void)
+{
+    TEST("wl_col_rel_store/retrieve_inline_compound round-trip");
+    col_rel_t *r = NULL;
+    int rc = build_inline_fixture(&r);
+    if (rc != 0 || r == NULL) {
+        tests_failed++;
+        printf(" ... FAIL: fixture rc=%d\n", rc);
+        return;
+    }
+
+    const int64_t args2[2] = { 1001, 1002 };
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 1u, args2, 2u) == 0,
+        "store inline/2 failed");
+
+    /* Raw physical slots must line up with the Task #2 offset map: logical
+     * column 1 begins at physical offset 1, so args2[0]..[1] land in
+     * columns 1, 2. */
+    ASSERT(col_rel_get(r, 0u, 1u) == 1001, "physical slot[1] mismatch");
+    ASSERT(col_rel_get(r, 0u, 2u) == 1002, "physical slot[2] mismatch");
+
+    int64_t out2[2] = { 0 };
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 0u, 1u, out2, 2u) == 0,
+        "retrieve inline/2 failed");
+    ASSERT(out2[0] == 1001 && out2[1] == 1002,
+        "retrieve inline/2 data mismatch");
+
+    /* Arity mismatch against the compound_arity_map must be rejected. */
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 1u, args2, 3u) == EINVAL,
+        "store accepted arity mismatch");
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 0u, 1u, out2, 3u) == EINVAL,
+        "retrieve accepted arity mismatch");
+
+    /* Row out of bounds is rejected. */
+    ASSERT(wl_col_rel_store_inline_compound(r, 99u, 1u, args2, 2u) == EINVAL,
+        "store accepted out-of-range row");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+static void
+test_inline_retract_sync(void)
+{
+    TEST("wl_col_rel_retract_inline_compound preserves physical slots");
+    col_rel_t *r = NULL;
+    int rc = build_inline_fixture(&r);
+    if (rc != 0 || r == NULL) {
+        tests_failed++;
+        printf(" ... FAIL: fixture rc=%d\n", rc);
+        return;
+    }
+
+    const int64_t args[3] = { 7, 11, 13 };
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 3u, args, 3u) == 0,
+        "store inline/3 failed");
+
+    /* Multiplicity 0 is rejected: retraction must carry a signed count. */
+    ASSERT(wl_col_rel_retract_inline_compound(r, 0u, 3u, 0) == EINVAL,
+        "retract accepted multiplicity == 0");
+
+    /* A valid retraction reports success and MUST NOT mutate physical
+     * slots: Z-set multiplicity is tracked at the delta layer, and join
+     * matching during retraction-seeded evaluation still needs to see
+     * the original tuple. */
+    ASSERT(wl_col_rel_retract_inline_compound(r, 0u, 3u, -1) == 0,
+        "retract inline/3 failed");
+
+    int64_t out3[3] = { 0 };
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 0u, 3u, out3, 3u) == 0,
+        "retrieve after retract failed");
+    ASSERT(out3[0] == 7 && out3[1] == 11 && out3[2] == 13,
+        "retract mutated physical slots");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+static void
+test_inline_multiarg(void)
+{
+    TEST("multiple inline columns round-trip independently");
+    col_rel_t *r = NULL;
+    int rc = build_inline_fixture(&r);
+    if (rc != 0 || r == NULL) {
+        tests_failed++;
+        printf(" ... FAIL: fixture rc=%d\n", rc);
+        return;
+    }
+
+    /* Append a second row so we can exercise two-row independence. */
+    const int64_t zeros[7] = { 0 };
+    ASSERT(col_rel_append_row(r, zeros) == 0, "append second row failed");
+
+    const int64_t r0_inline2[2] = { 21, 22 };
+    const int64_t r0_inline3[3] = { 31, 32, 33 };
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 1u, r0_inline2, 2u) == 0,
+        "row0 inline/2 store failed");
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 3u, r0_inline3, 3u) == 0,
+        "row0 inline/3 store failed");
+
+    const int64_t r1_inline2[2] = { 41, 42 };
+    const int64_t r1_inline3[3] = { 51, 52, 53 };
+    ASSERT(wl_col_rel_store_inline_compound(r, 1u, 1u, r1_inline2, 2u) == 0,
+        "row1 inline/2 store failed");
+    ASSERT(wl_col_rel_store_inline_compound(r, 1u, 3u, r1_inline3, 3u) == 0,
+        "row1 inline/3 store failed");
+
+    /* Row 0 must round-trip both inline columns unchanged after row 1's
+     * writes — no cross-talk in the column-major layout. */
+    int64_t out2[2] = { 0 };
+    int64_t out3[3] = { 0 };
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 0u, 1u, out2, 2u) == 0,
+        "row0 inline/2 retrieve failed");
+    ASSERT(out2[0] == 21 && out2[1] == 22, "row0 inline/2 corrupted");
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 0u, 3u, out3, 3u) == 0,
+        "row0 inline/3 retrieve failed");
+    ASSERT(out3[0] == 31 && out3[1] == 32 && out3[2] == 33,
+        "row0 inline/3 corrupted");
+
+    /* And row 1 carries its own distinct values. */
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 1u, 1u, out2, 2u) == 0,
+        "row1 inline/2 retrieve failed");
+    ASSERT(out2[0] == 41 && out2[1] == 42, "row1 inline/2 corrupted");
+    ASSERT(wl_col_rel_retrieve_inline_compound(r, 1u, 3u, out3, 3u) == 0,
+        "row1 inline/3 retrieve failed");
+    ASSERT(out3[0] == 51 && out3[1] == 52 && out3[2] == 53,
+        "row1 inline/3 corrupted");
+
+    /* A logical column index beyond the schema is rejected. */
+    ASSERT(wl_col_rel_store_inline_compound(r, 0u, 99u, r0_inline2, 2u)
+        == EINVAL, "store accepted logical_col out of range");
+
+    PASS();
+cleanup:
+    col_rel_destroy(r);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_col_rel_inline_storage (Issue #532 Task 3)\n");
+    printf("===============================================\n");
+
+    test_inline_store_retrieve();
+    test_inline_retract_sync();
+    test_inline_multiarg();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_columnar_inline.c
+++ b/tests/test_columnar_inline.c
@@ -1,0 +1,345 @@
+/*
+ * tests/test_columnar_inline.c - inline-tier integration test battery
+ * (Issue #532 Task 5).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * These tests compose the building blocks landed by Tasks #1-#4 and
+ * exercise them as one pipeline:
+ *
+ *   test_consolidation_inline_compound
+ *       Insert duplicate rows with inline compound columns, radix-sort
+ *       and compact, confirm duplicates collapse and inline slot values
+ *       are preserved bit-for-bit through the consolidation pass (Z-set
+ *       semantics).
+ *
+ *   test_asan_nested_insert_delete
+ *       Tight create/fill/retract/destroy loop.  Each iteration allocates
+ *       an INLINE-tier relation with a 3-wide compound column, stores
+ *       rows, retracts them (no physical mutation), then destroys the
+ *       relation.  Under -Db_sanitize=address the suite must report zero
+ *       leaks and zero use-after-free across ~1k cycles.
+ *
+ *   test_arrow_schema_inline_expansion
+ *       Backend abstraction (Invariant #5 of the K-Fusion contract):
+ *       after col_rel_apply_compound_schema, the relation's physical
+ *       ncols equals the sum of per-column widths and the arity map is
+ *       addressable at the reported inline_physical_offset.  Verifies
+ *       that callers operating purely through the columnar abstraction
+ *       see the expanded schema without knowledge of inline encoding.
+ *
+ *   test_simd_filter_inline
+ *       Scan/filter over a relation whose inline columns hold non-key
+ *       data.  Ensures inline slots pass through col_rel_compact() (the
+ *       hot SIMD-friendly row-copy helper) without corruption.  Formal
+ *       SIMD emission is verified post-build by scripts/ci; this test
+ *       is the behavioural sibling.
+ *
+ * The K-Fusion shadow test (K=4 / 100k rows) already landed in
+ * tests/test_k_fusion_inline_shadow.c (Task #4); no duplication here.
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* Build a (scalar, inline/<arity>) relation with `nrows` addressable rows.
+ * Schema is (key:scalar, c0..c{arity-1}:inline).  Physical ncols = 1+arity. */
+static int
+build_fixture_(col_rel_t **out_rel, const char *name, uint32_t arity,
+    uint32_t nrows)
+{
+    col_rel_t *rel = NULL;
+    if (col_rel_alloc(&rel, name) != 0 || !rel)
+        return -1;
+
+    const col_rel_logical_col_t cols[2] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u,    0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, arity, 1u },
+    };
+    if (col_rel_apply_compound_schema(rel, cols, 2) != 0) {
+        col_rel_destroy(rel);
+        return -1;
+    }
+
+    const uint32_t physical = 1u + arity;
+    const char *names[5] = { "k", "c0", "c1", "c2", "c3" };
+    if (col_rel_set_schema(rel, physical, names) != 0) {
+        col_rel_destroy(rel);
+        return -1;
+    }
+
+    int64_t zero[5] = { 0 };
+    for (uint32_t r = 0; r < nrows; r++) {
+        if (col_rel_append_row(rel, zero) != 0) {
+            col_rel_destroy(rel);
+            return -1;
+        }
+    }
+    *out_rel = rel;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_consolidation_inline_compound(void)
+{
+    TEST("consolidation preserves inline slots across radix-sort + compact");
+    col_rel_t *rel = NULL;
+    const uint32_t N = 256;
+    const uint32_t ARITY = 2u;
+
+    if (build_fixture_(&rel, "consolidation_fixture", ARITY, N) != 0)
+        FAIL("fixture failed");
+
+    /* Populate: key cycles 0..15, inline args encode (key*10, key*10+1). */
+    for (uint32_t r = 0; r < N; r++) {
+        int64_t key = (int64_t)(r % 16);
+        col_rel_set(rel, r, 0, key);
+        const int64_t args[2] = { key * 10, key * 10 + 1 };
+        ASSERT(wl_col_rel_store_inline_compound(rel, r, 1, args, ARITY) == 0,
+            "store failed");
+    }
+
+    /* Consolidation step: radix-sort on key then compact.  The key column
+     * (physical idx 0) is the sort key; inline slots ride along. */
+    col_rel_radix_sort(rel, 0, N);
+    col_rel_compact(rel);
+
+    /* Verify: rows are key-sorted and inline slots still resolve to
+     * (key*10, key*10+1) via the Task #3 retrieve accessor. */
+    int64_t prev_key = -1;
+    for (uint32_t r = 0; r < rel->nrows; r++) {
+        int64_t key = col_rel_get(rel, r, 0);
+        ASSERT(key >= prev_key, "radix-sort did not preserve key order");
+        prev_key = key;
+        int64_t args[2] = { 0, 0 };
+        ASSERT(wl_col_rel_retrieve_inline_compound(rel, r, 1, args, ARITY)
+            == 0, "retrieve failed");
+        ASSERT(args[0] == key * 10, "inline arg0 corrupted");
+        ASSERT(args[1] == key * 10 + 1, "inline arg1 corrupted");
+    }
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+}
+
+static void
+test_asan_nested_insert_delete(void)
+{
+    TEST("ASan: nested create/store/retract/destroy cycles leak-free");
+    const uint32_t CYCLES = 1000;
+    const uint32_t ARITY = 3u;
+
+    for (uint32_t i = 0; i < CYCLES; i++) {
+        col_rel_t *rel = NULL;
+        if (build_fixture_(&rel, "asan_cycle", ARITY, 8u) != 0) {
+            tests_failed++;
+            printf(" ... FAIL: fixture at cycle %u\n", i);
+            return;
+        }
+        for (uint32_t r = 0; r < 8u; r++) {
+            const int64_t args[3] = { (int64_t)r, (int64_t)r + 1,
+                                      (int64_t)r + 2 };
+            if (wl_col_rel_store_inline_compound(rel, r, 1, args, ARITY)
+                != 0) {
+                col_rel_destroy(rel);
+                tests_failed++;
+                printf(" ... FAIL: store at cycle %u row %u\n", i, r);
+                return;
+            }
+            /* Retract with multiplicity -1 — physical slots untouched,
+             * no allocation happens; any leak would accumulate across the
+             * 1000-cycle loop and trip ASan on shutdown. */
+            if (wl_col_rel_retract_inline_compound(rel, r, 1, -1) != 0) {
+                col_rel_destroy(rel);
+                tests_failed++;
+                printf(" ... FAIL: retract at cycle %u row %u\n", i, r);
+                return;
+            }
+        }
+        col_rel_destroy(rel);
+    }
+
+    PASS();
+    return;
+}
+
+static void
+test_arrow_schema_inline_expansion(void)
+{
+    TEST("schema expansion: physical ncols = sum(widths), offsets addressable");
+    col_rel_t *rel = NULL;
+
+    /* Mixed schema: scalar + inline/4 + scalar + inline/2 -> widths 1,4,1,2 -> 8.
+     * First INLINE column starts at physical offset 1. */
+    if (col_rel_alloc(&rel, "arrow_expansion") != 0 || !rel)
+        FAIL("alloc failed");
+
+    const col_rel_logical_col_t cols[4] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 4u, 1u },
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+    };
+
+    uint32_t physical = 0u;
+    uint32_t offset_map[4] = { 0 };
+    uint32_t first_inline = 0u;
+    uint32_t compound_count = 0u;
+    int rc = col_rel_compute_physical_layout(cols, 4, &physical, offset_map,
+            &first_inline, &compound_count);
+    ASSERT(rc == 0, "layout returned error");
+    ASSERT(physical == 8u, "physical ncols != 8");
+    ASSERT(compound_count == 2u, "compound_count != 2");
+    ASSERT(first_inline == 1u, "first_inline_offset != 1");
+    ASSERT(offset_map[0] == 0u, "offset[0] != 0");
+    ASSERT(offset_map[1] == 1u, "offset[1] != 1");
+    ASSERT(offset_map[2] == 5u, "offset[2] != 5"); /* 1 + 4 */
+    ASSERT(offset_map[3] == 6u, "offset[3] != 6"); /* 1 + 4 + 1 */
+
+    ASSERT(col_rel_apply_compound_schema(rel, cols, 4) == 0,
+        "apply_schema failed");
+    ASSERT(rel->compound_kind == WIRELOG_COMPOUND_KIND_INLINE,
+        "compound_kind != INLINE");
+    ASSERT(rel->compound_count == 2u, "compound_count mismatch");
+    ASSERT(rel->inline_physical_offset == 1u,
+        "inline_physical_offset mismatch");
+    ASSERT(rel->compound_arity_map != NULL, "arity_map NULL");
+    ASSERT(rel->compound_arity_map[0] == 1u, "width[0] != 1");
+    ASSERT(rel->compound_arity_map[1] == 4u, "width[1] != 4");
+    ASSERT(rel->compound_arity_map[2] == 1u, "width[2] != 1");
+    ASSERT(rel->compound_arity_map[3] == 2u, "width[3] != 2");
+
+    /* Round-trip through the backend-facing storage ops: writer and reader
+    * agree on what physical range logical column 1 (inline/4) occupies. */
+    const char *names[8] = { "k", "a0", "a1", "a2", "a3", "g", "b0", "b1" };
+    ASSERT(col_rel_set_schema(rel, 8u, names) == 0, "set_schema");
+    const int64_t zero[8] = { 0 };
+    ASSERT(col_rel_append_row(rel, zero) == 0, "append_row");
+
+    const int64_t a4[4] = { 101, 102, 103, 104 };
+    ASSERT(wl_col_rel_store_inline_compound(rel, 0, 1, a4, 4u) == 0,
+        "store inline/4");
+    const int64_t a2[2] = { 201, 202 };
+    ASSERT(wl_col_rel_store_inline_compound(rel, 0, 3, a2, 2u) == 0,
+        "store inline/2");
+
+    int64_t got4[4] = { 0 };
+    int64_t got2[2] = { 0 };
+    ASSERT(wl_col_rel_retrieve_inline_compound(rel, 0, 1, got4, 4u) == 0,
+        "retrieve inline/4");
+    ASSERT(wl_col_rel_retrieve_inline_compound(rel, 0, 3, got2, 2u) == 0,
+        "retrieve inline/2");
+    for (uint32_t k = 0; k < 4; k++)
+        ASSERT(got4[k] == a4[k], "inline/4 arg corrupted");
+    for (uint32_t k = 0; k < 2; k++)
+        ASSERT(got2[k] == a2[k], "inline/2 arg corrupted");
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+}
+
+static void
+test_simd_filter_inline(void)
+{
+    TEST("SIMD-friendly compact preserves inline payload");
+    col_rel_t *rel = NULL;
+    const uint32_t N = 64;
+    const uint32_t ARITY = 2u;
+
+    if (build_fixture_(&rel, "simd_filter", ARITY, N) != 0)
+        FAIL("fixture failed");
+
+    /* Populate with a pattern that makes corruption detectable: row r's
+     * inline slots hold (r*7, r*7+3). */
+    for (uint32_t r = 0; r < N; r++) {
+        col_rel_set(rel, r, 0, (int64_t)r);
+        const int64_t args[2] = { (int64_t)r * 7, (int64_t)r * 7 + 3 };
+        ASSERT(wl_col_rel_store_inline_compound(rel, r, 1, args, ARITY) == 0,
+            "store");
+    }
+
+    /* Compact is the row-copy helper that production code uses ahead of
+     * SIMD filter/join passes.  After compact, inline slots must round-trip
+     * unchanged — any stride miscalculation would scramble them. */
+    col_rel_compact(rel);
+
+    for (uint32_t r = 0; r < N; r++) {
+        int64_t args[2] = { 0, 0 };
+        ASSERT(wl_col_rel_retrieve_inline_compound(rel, r, 1, args, ARITY)
+            == 0, "retrieve");
+        ASSERT(args[0] == (int64_t)r * 7, "arg0 scrambled");
+        ASSERT(args[1] == (int64_t)r * 7 + 3, "arg1 scrambled");
+    }
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_columnar_inline (Issue #532 Task 5)\n");
+    printf("========================================\n");
+
+    test_consolidation_inline_compound();
+    test_asan_nested_insert_delete();
+    test_arrow_schema_inline_expansion();
+    test_simd_filter_inline();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_compound_logging.c
+++ b/tests/test_compound_logging.c
@@ -1,0 +1,439 @@
+/*
+ * tests/test_compound_logging.c - COMPOUND observability & error handling
+ * (Issue #532 Task 6).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives the COMPOUND section of the WL_LOG logger end-to-end.  Each test
+ * configures WL_LOG with a specific level for the COMPOUND section, routes
+ * output to a tmpfile via WL_LOG_FILE, and asserts that the emitted text
+ * carries the structured event tags added in relation.c/eval.c.
+ *
+ *   test_compound_logging       -- success-path TRACE emission carries the
+ *                                  [TRACE][COMPOUND] prefix and path=inline
+ *                                  tag.
+ *   test_error_arity_overflow   -- store() with a compound column declared
+ *                                  above WL_COMPOUND_INLINE_MAX_ARITY emits
+ *                                  error=arity_overflow during schema apply.
+ *   test_error_nesting          -- depth > WL_COMPOUND_INLINE_MAX_DEPTH
+ *                                  emits error=depth_overflow.
+ *   test_error_validation       -- row-out-of-range and arity-mismatch paths
+ *                                  emit their respective error tags.
+ *   test_observability_gates    -- WL_LOG unset produces zero output;
+ *                                  COMPOUND:2 suppresses TRACE/DEBUG while
+ *                                  WARN error messages still appear.
+ *
+ * The tests touch only the inline-tier surfaces (relation.c schema apply,
+ * eval.c store/retrieve/retract) — they do not spin a session or plan.
+ * K-Fusion contract references (§5 C1-C5) live in the instrumented
+ * source; here we verify the user-facing message shape.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/util/log.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#  include <process.h>
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#  define getpid   _getpid
+#else
+#  include <unistd.h>
+#endif
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* ======================================================================== */
+/* tmpfile helpers                                                          */
+/* ======================================================================== */
+
+static char tmp_path_[256];
+
+static const char *
+tmpdir_(void)
+{
+    const char *d = getenv("TMPDIR");
+    if (d && *d) return d;
+#if defined(_WIN32)
+    d = getenv("TEMP");
+    if (d && *d) return d;
+    d = getenv("TMP");
+    if (d && *d) return d;
+    return ".";
+#else
+    return "/tmp";
+#endif
+}
+
+static void
+make_tmpfile_(const char *tag)
+{
+    const char *d = tmpdir_();
+#if defined(_WIN32)
+    const char sep = '\\';
+#else
+    const char sep = '/';
+#endif
+    snprintf(tmp_path_, sizeof(tmp_path_),
+        "%s%cwl_compound_log_%s_%ld_%ld.log",
+        d, sep, tag, (long)getpid(), (long)time(NULL));
+    (void)remove(tmp_path_);
+}
+
+static size_t
+read_file_(const char *path, char *buf, size_t bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    size_t n = fread(buf, 1, bufsz - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    return n;
+}
+
+static void
+clear_env_(void)
+{
+    unsetenv("WL_LOG");
+    unsetenv("WL_LOG_FILE");
+    unsetenv("WL_DEBUG_JOIN");
+    unsetenv("WL_CONSOLIDATION_LOG");
+}
+
+/* ======================================================================== */
+/* Fixtures                                                                 */
+/* ======================================================================== */
+
+/* (scalar, inline/2) schema — mirrors the smallest viable inline fixture.
+ * Caller owns the returned relation and must col_rel_destroy it. */
+static int
+build_inline_fixture_(col_rel_t **out_rel)
+{
+    col_rel_t *rel = NULL;
+    if (col_rel_alloc(&rel, "logging_fixture") != 0 || !rel)
+        return -1;
+
+    const col_rel_logical_col_t cols[2] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+    };
+    if (col_rel_apply_compound_schema(rel, cols, 2) != 0) {
+        col_rel_destroy(rel);
+        return -1;
+    }
+    const char *names[3] = { "s", "c0", "c1" };
+    if (col_rel_set_schema(rel, 3, names) != 0) {
+        col_rel_destroy(rel);
+        return -1;
+    }
+    const int64_t zero_row[3] = { 0, 0, 0 };
+    if (col_rel_append_row(rel, zero_row) != 0) {
+        col_rel_destroy(rel);
+        return -1;
+    }
+    *out_rel = rel;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_compound_logging(void)
+{
+    TEST("compound logging: success path emits [TRACE][COMPOUND] path=inline");
+    col_rel_t *rel = NULL;
+
+    clear_env_();
+    make_tmpfile_("trace");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    if (build_inline_fixture_(&rel) != 0) FAIL("fixture failed");
+
+    const int64_t args[2] = { 11, 22 };
+    ASSERT(wl_col_rel_store_inline_compound(rel, 0, 1, args, 2) == 0,
+        "store failed");
+
+    wl_log_shutdown();
+
+    char buf[4096] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[TRACE][COMPOUND]") != NULL,
+        "missing [TRACE][COMPOUND] prefix");
+    ASSERT(strstr(buf, "event=store") != NULL, "missing event=store tag");
+    ASSERT(strstr(buf, "path=inline") != NULL, "missing path=inline tag");
+    ASSERT(strstr(buf, "arity=2") != NULL, "missing arity=2 tag");
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_error_arity_overflow(void)
+{
+    TEST("error: arity_overflow emitted for arity > MAX_ARITY");
+
+    clear_env_();
+    make_tmpfile_("arity");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    /* Arity = MAX+1 must be rejected during layout. */
+    const col_rel_logical_col_t cols[1] = {
+        { WIRELOG_COMPOUND_KIND_INLINE,
+          WL_COMPOUND_INLINE_MAX_ARITY + 1u, 1u },
+    };
+    uint32_t physical = 0u;
+    int rc = col_rel_compute_physical_layout(cols, 1, &physical, NULL, NULL,
+            NULL);
+    ASSERT(rc == EINVAL, "layout did not reject oversize arity");
+
+    wl_log_shutdown();
+
+    char buf[2048] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[WARN][COMPOUND]") != NULL,
+        "missing [WARN][COMPOUND] prefix");
+    ASSERT(strstr(buf, "error=arity_overflow") != NULL,
+        "missing error=arity_overflow tag");
+    /* Expected/got values must be present for actionable DX. */
+    ASSERT(strstr(buf, "expected=") != NULL, "missing expected=");
+    ASSERT(strstr(buf, "got=") != NULL, "missing got=");
+
+    PASS();
+cleanup:
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_error_nesting(void)
+{
+    TEST("error: depth_overflow emitted for depth > MAX_DEPTH");
+
+    clear_env_();
+    make_tmpfile_("depth");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    const col_rel_logical_col_t cols[1] = {
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u,
+          WL_COMPOUND_INLINE_MAX_DEPTH + 1u },
+    };
+    int rc = col_rel_compute_physical_layout(cols, 1, NULL, NULL, NULL, NULL);
+    ASSERT(rc == EINVAL, "layout did not reject oversize depth");
+
+    wl_log_shutdown();
+
+    char buf[2048] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "error=depth_overflow") != NULL,
+        "missing error=depth_overflow");
+
+    PASS();
+cleanup:
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_error_validation(void)
+{
+    TEST("error: row_oor and arity_mismatch tags");
+    col_rel_t *rel = NULL;
+
+    clear_env_();
+    make_tmpfile_("valid");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    if (build_inline_fixture_(&rel) != 0) FAIL("fixture failed");
+
+    /* Row out of range. */
+    const int64_t args[2] = { 1, 2 };
+    ASSERT(wl_col_rel_store_inline_compound(rel, 42u, 1, args, 2) == EINVAL,
+        "row_oor not rejected");
+
+    /* Arity mismatch: schema declares arity=2, we pass 3. */
+    const int64_t wrong[3] = { 1, 2, 3 };
+    ASSERT(wl_col_rel_store_inline_compound(rel, 0, 1, wrong, 3) == EINVAL,
+        "arity mismatch not rejected");
+
+    /* Retrieve on a non-INLINE relation -> not_inline tag.  Needs at least
+     * one row so the row_idx precondition passes and the locate path runs. */
+    col_rel_t *scalar_rel = NULL;
+    ASSERT(col_rel_alloc(&scalar_rel, "scalar_only") == 0, "scalar alloc");
+    const char *snames[1] = { "x" };
+    ASSERT(col_rel_set_schema(scalar_rel, 1, snames) == 0, "scalar schema");
+    const int64_t srow[1] = { 0 };
+    ASSERT(col_rel_append_row(scalar_rel, srow) == 0, "scalar append");
+    int64_t out_args[2] = { 0, 0 };
+    ASSERT(wl_col_rel_retrieve_inline_compound(scalar_rel, 0, 0,
+        out_args, 2) == EINVAL, "not_inline not rejected");
+    col_rel_destroy(scalar_rel);
+
+    wl_log_shutdown();
+
+    char buf[4096] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "error=row_oor") != NULL, "missing error=row_oor");
+    ASSERT(strstr(buf, "error=arity_mismatch") != NULL,
+        "missing error=arity_mismatch");
+    ASSERT(strstr(buf, "error=not_inline") != NULL,
+        "missing error=not_inline");
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_observability_gates(void)
+{
+    TEST("observability: WL_LOG unset -> silent; COMPOUND:2 -> WARN only");
+    col_rel_t *rel = NULL;
+
+    /* (a) Unset WL_LOG produces zero output. */
+    clear_env_();
+    make_tmpfile_("gate_off");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    wl_log_init();
+
+    if (build_inline_fixture_(&rel) != 0) FAIL("fixture failed");
+    const int64_t args[2] = { 5, 6 };
+    (void)wl_col_rel_store_inline_compound(rel, 0, 1, args, 2);
+    /* Trigger a WARN path too; must stay silent. */
+    (void)wl_col_rel_store_inline_compound(rel, 99u, 1, args, 2);
+    col_rel_destroy(rel);
+    rel = NULL;
+
+    wl_log_shutdown();
+
+    char buf[2048] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n == 0, "output emitted with WL_LOG unset");
+    (void)remove(tmp_path_);
+
+    /* (b) COMPOUND:2 (WARN ceiling) suppresses TRACE/DEBUG but keeps
+     * WARN error messages. */
+    clear_env_();
+    make_tmpfile_("gate_warn");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:2", 1);
+    wl_log_init();
+
+    if (build_inline_fixture_(&rel) != 0) FAIL("fixture failed");
+    ASSERT(wl_col_rel_store_inline_compound(rel, 0, 1, args, 2) == 0,
+        "store success");
+    ASSERT(wl_col_rel_store_inline_compound(rel, 99u, 1, args, 2) == EINVAL,
+        "row_oor rejected");
+
+    wl_log_shutdown();
+
+    memset(buf, 0, sizeof(buf));
+    n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "WARN-level log empty");
+    ASSERT(strstr(buf, "[WARN][COMPOUND]") != NULL,
+        "WARN line missing");
+    ASSERT(strstr(buf, "[TRACE][COMPOUND]") == NULL,
+        "TRACE leaked past WARN ceiling");
+    ASSERT(strstr(buf, "[DEBUG][COMPOUND]") == NULL,
+        "DEBUG leaked past WARN ceiling");
+
+    PASS();
+cleanup:
+    if (rel) col_rel_destroy(rel);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_compound_logging (Issue #532 Task 6)\n");
+    printf("=========================================\n");
+
+    test_compound_logging();
+    test_error_arity_overflow();
+    test_error_nesting();
+    test_error_validation();
+    test_observability_gates();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_k_fusion_inline_shadow.c
+++ b/tests/test_k_fusion_inline_shadow.c
@@ -1,0 +1,329 @@
+/*
+ * test_k_fusion_inline_shadow.c - K-Fusion deep-copy semantics over inline
+ * compounds (Issue #532 Task 4)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Validates the Option (iii) "immutable-during-epoch" K-fusion isolation
+ * strategy described in docs/ARCHITECTURE.md §4 "K-Fusion Parallelism".
+ *
+ * The contract under test:
+ *
+ *   - col_rel_t column buffers holding inline compound values are
+ *     written once (epoch setup) and read-only during the epoch.
+ *   - col_diff_arrangement_deep_copy gives each of K workers an
+ *     independent arrangement (own ht_head / ht_next / key_cols)
+ *     indexing the same immutable column buffers.
+ *   - No writer coordination is therefore required across workers
+ *     during the read phase (§4: "no cross-worker synchronization").
+ *
+ * Tests:
+ *
+ *   test_k_fusion_inline_shadow
+ *       100k rows with an inline/2 compound are populated sequentially.
+ *       K=4 workers, each using its own deep-copied arrangement, read
+ *       every row's compound through wl_col_rel_retrieve_inline_compound
+ *       concurrently and assert every (row, args) pair matches the
+ *       deterministic generator. TSan clean == no races on the shared
+ *       column buffers.
+ *
+ *   test_worker_isolation
+ *       Two deep-copied arrangements; mutating worker-A state
+ *       (reset_delta, ensure_ht_capacity) must leave worker-B state
+ *       untouched — confirming the copies do not alias ht_head/ht_next.
+ */
+
+#include "../wirelog/columnar/diff_arrangement.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define K_WORKERS 4
+#define SHADOW_NROWS 100000u
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* Deterministic generator — every worker expects the same values for
+ * every row, so divergence proves either visibility loss or a race. */
+static inline int64_t
+shadow_arg0(uint32_t row)
+{
+    return (int64_t)row * 10;
+}
+static inline int64_t
+shadow_arg1(uint32_t row)
+{
+    return (int64_t)row * 100;
+}
+
+/* Build (scalar, inline/2) relation, apply compound schema, materialise
+ * physical schema of 3 slots, and populate SHADOW_NROWS rows with the
+ * deterministic generator. The returned relation is immutable for the
+ * rest of the test run (Option (iii) epoch invariant). */
+static int
+build_shadow_relation(col_rel_t **out_rel, uint32_t nrows)
+{
+    col_rel_t *r = NULL;
+    int rc = col_rel_alloc(&r, "k_fusion_shadow");
+    if (rc != 0)
+        return rc;
+
+    const col_rel_logical_col_t logical[2] = {
+        { WIRELOG_COMPOUND_KIND_NONE,   0u, 0u },
+        { WIRELOG_COMPOUND_KIND_INLINE, 2u, 1u },
+    };
+    rc = col_rel_apply_compound_schema(r, logical, 2u);
+    if (rc != 0) {
+        col_rel_destroy(r);
+        return rc;
+    }
+    rc = col_rel_set_schema(r, 3u, NULL); /* 1 + 2 physical slots */
+    if (rc != 0) {
+        col_rel_destroy(r);
+        return rc;
+    }
+
+    /* Seed capacity in one shot to avoid realloc thrash on 100k rows. */
+    for (uint32_t i = 0; i < nrows; i++) {
+        const int64_t seed_row[3] = { (int64_t)i, 0, 0 };
+        rc = col_rel_append_row(r, seed_row);
+        if (rc != 0) {
+            col_rel_destroy(r);
+            return rc;
+        }
+        const int64_t args[2] = { shadow_arg0(i), shadow_arg1(i) };
+        rc = wl_col_rel_store_inline_compound(r, i, 1u, args, 2u);
+        if (rc != 0) {
+            col_rel_destroy(r);
+            return rc;
+        }
+    }
+    *out_rel = r;
+    return 0;
+}
+
+/* ======================================================================== */
+/* test_k_fusion_inline_shadow                                              */
+/* ======================================================================== */
+
+typedef struct {
+    col_diff_arrangement_t *arr;
+    const col_rel_t *rel;
+    uint32_t nrows;
+    uint32_t worker_id;
+    uint32_t errors;
+} shadow_worker_t;
+
+/* Worker body: every worker reads the full row range concurrently.  The
+ * col_rel_t column buffers are the shared immutable substrate (Option
+ * (iii)); the deep-copied arrangement is the worker-private indexing
+ * scaffolding. */
+static void *
+shadow_worker_main(void *arg)
+{
+    shadow_worker_t *w = (shadow_worker_t *)arg;
+    /* Spot-check the arrangement survived the deep-copy with its
+     * worker_id intact before we hammer the column buffers. */
+    if (w->arr == NULL || w->arr->worker_id != w->worker_id) {
+        w->errors++;
+        return NULL;
+    }
+    for (uint32_t i = 0; i < w->nrows; i++) {
+        int64_t args[2] = { 0, 0 };
+        int rc = wl_col_rel_retrieve_inline_compound(w->rel, i, 1u,
+                args, 2u);
+        if (rc != 0 || args[0] != shadow_arg0(i)
+            || args[1] != shadow_arg1(i)) {
+            w->errors++;
+            /* Keep iterating so a single bad row does not hide systemic
+             * corruption farther in. */
+        }
+    }
+    return NULL;
+}
+
+static void
+test_k_fusion_inline_shadow(void)
+{
+    TEST("K=4 deep-copy preserves inline compound visibility over 100k rows");
+    col_rel_t *rel = NULL;
+    col_diff_arrangement_t *master = NULL;
+    col_diff_arrangement_t *copies[K_WORKERS] = { NULL };
+    pthread_t threads[K_WORKERS];
+    shadow_worker_t workers[K_WORKERS] = { 0 };
+    bool thread_created[K_WORKERS] = { false };
+
+    int rc = build_shadow_relation(&rel, SHADOW_NROWS);
+    if (rc != 0) {
+        tests_failed++;
+        printf(" ... FAIL: fixture rc=%d\n", rc);
+        return;
+    }
+
+    /* The scalar id column (physical col 0) is the join key for this
+     * arrangement.  worker_id == 0 on the master — each copy stamps its
+     * own id below. */
+    const uint32_t key_cols[1] = { 0u };
+    master = col_diff_arrangement_create(key_cols, 1u, 0u);
+    ASSERT(master != NULL, "arrangement_create failed");
+    master->current_nrows = SHADOW_NROWS;
+
+    for (int w = 0; w < K_WORKERS; w++) {
+        copies[w] = col_diff_arrangement_deep_copy(master);
+        ASSERT(copies[w] != NULL, "deep_copy returned NULL");
+        copies[w]->worker_id = (uint32_t)(w + 1);
+
+        /* Deep-copy must not alias ht_head or ht_next with the master. */
+        ASSERT(copies[w]->ht_head != master->ht_head,
+            "ht_head pointer aliases master");
+        ASSERT(copies[w]->ht_next != master->ht_next,
+            "ht_next pointer aliases master");
+    }
+
+    for (int w = 0; w < K_WORKERS; w++) {
+        workers[w].arr = copies[w];
+        workers[w].rel = rel;
+        workers[w].nrows = SHADOW_NROWS;
+        workers[w].worker_id = (uint32_t)(w + 1);
+        workers[w].errors = 0;
+        int trc = pthread_create(&threads[w], NULL, shadow_worker_main,
+                &workers[w]);
+        ASSERT(trc == 0, "pthread_create failed");
+        thread_created[w] = true;
+    }
+
+    for (int w = 0; w < K_WORKERS; w++) {
+        if (thread_created[w])
+            pthread_join(threads[w], NULL);
+    }
+
+    uint32_t total_errors = 0;
+    for (int w = 0; w < K_WORKERS; w++)
+        total_errors += workers[w].errors;
+    if (total_errors != 0u) {
+        char msg[96];
+        snprintf(msg, sizeof(msg),
+            "cross-worker divergence: %u mismatched reads", total_errors);
+        FAIL(msg);
+    }
+
+    PASS();
+cleanup:
+    /* Best-effort thread drain on the FAIL path so TSan does not flag a
+     * leaked thread over a detached arrangement. */
+    for (int w = 0; w < K_WORKERS; w++) {
+        if (thread_created[w])
+            pthread_join(threads[w], NULL);
+    }
+    for (int w = 0; w < K_WORKERS; w++)
+        col_diff_arrangement_destroy(copies[w]);
+    col_diff_arrangement_destroy(master);
+    col_rel_destroy(rel);
+}
+
+/* ======================================================================== */
+/* test_worker_isolation                                                    */
+/* ======================================================================== */
+
+static void
+test_worker_isolation(void)
+{
+    TEST("deep-copy isolates per-worker arrangement state");
+    col_diff_arrangement_t *master = NULL;
+    col_diff_arrangement_t *a = NULL;
+    col_diff_arrangement_t *b = NULL;
+
+    const uint32_t key_cols[1] = { 0u };
+    master = col_diff_arrangement_create(key_cols, 1u, 0u);
+    ASSERT(master != NULL, "arrangement_create failed");
+    master->current_nrows = 128u;
+    master->base_nrows = 0u;
+
+    a = col_diff_arrangement_deep_copy(master);
+    b = col_diff_arrangement_deep_copy(master);
+    ASSERT(a != NULL && b != NULL, "deep_copy returned NULL");
+    ASSERT(a != b && a->ht_head != b->ht_head && a->ht_next != b->ht_next,
+        "worker copies share state");
+    a->worker_id = 1u;
+    b->worker_id = 2u;
+
+    /* Mutate worker A: reset_delta rolls base_nrows up to current_nrows. */
+    col_diff_arrangement_reset_delta(a);
+    ASSERT(a->base_nrows == 128u, "reset_delta did not update worker A");
+    ASSERT(b->base_nrows == 0u,
+        "worker B base_nrows leaked from worker A mutation");
+
+    /* Mutate worker A: force a hash-table grow, which reallocates
+     * ht_next.  Worker B's ht_next capacity must stay at the initial
+     * 1024-bucket default. */
+    uint32_t b_cap_before = b->ht_cap;
+    int rc = col_diff_arrangement_ensure_ht_capacity(a, 4096u);
+    ASSERT(rc == 0, "ensure_ht_capacity rc");
+    ASSERT(a->ht_cap >= 4096u, "worker A ht_cap did not grow");
+    ASSERT(b->ht_cap == b_cap_before,
+        "worker B ht_cap perturbed by worker A growth");
+
+    /* Identity sanity: worker_id survives the deep copy unmodified. */
+    ASSERT(a->worker_id == 1u && b->worker_id == 2u,
+        "worker_id corrupted");
+
+    PASS();
+cleanup:
+    col_diff_arrangement_destroy(a);
+    col_diff_arrangement_destroy(b);
+    col_diff_arrangement_destroy(master);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_k_fusion_inline_shadow (Issue #532 Task 4)\n");
+    printf("===============================================\n");
+
+    test_k_fusion_inline_shadow();
+    test_worker_isolation();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_k_fusion_inline_shadow.c
+++ b/tests/test_k_fusion_inline_shadow.c
@@ -229,8 +229,10 @@ test_k_fusion_inline_shadow(void)
     }
 
     for (int w = 0; w < K_WORKERS; w++) {
-        if (thread_created[w])
+        if (thread_created[w]) {
             pthread_join(threads[w], NULL);
+            thread_created[w] = false; /* avoid double-join in cleanup */
+        }
     }
 
     uint32_t total_errors = 0;
@@ -245,8 +247,8 @@ test_k_fusion_inline_shadow(void)
 
     PASS();
 cleanup:
-    /* Best-effort thread drain on the FAIL path so TSan does not flag a
-     * leaked thread over a detached arrangement. */
+    /* Drain any threads still in flight (only reachable via a FAIL that
+     * jumps here before the happy-path join loop runs). */
     for (int w = 0; w < K_WORKERS; w++) {
         if (thread_created[w])
             pthread_join(threads[w], NULL);

--- a/tests/test_k_fusion_inline_shadow.c
+++ b/tests/test_k_fusion_inline_shadow.c
@@ -38,9 +38,9 @@
 #include "../wirelog/columnar/diff_arrangement.h"
 #include "../wirelog/columnar/internal.h"
 #include "../wirelog/wirelog-types.h"
+#include "../wirelog/thread.h"
 
 #include <errno.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -185,7 +185,7 @@ test_k_fusion_inline_shadow(void)
     col_rel_t *rel = NULL;
     col_diff_arrangement_t *master = NULL;
     col_diff_arrangement_t *copies[K_WORKERS] = { NULL };
-    pthread_t threads[K_WORKERS];
+    thread_t threads[K_WORKERS];
     shadow_worker_t workers[K_WORKERS] = { 0 };
     bool thread_created[K_WORKERS] = { false };
 
@@ -222,15 +222,15 @@ test_k_fusion_inline_shadow(void)
         workers[w].nrows = SHADOW_NROWS;
         workers[w].worker_id = (uint32_t)(w + 1);
         workers[w].errors = 0;
-        int trc = pthread_create(&threads[w], NULL, shadow_worker_main,
+        int trc = thread_create(&threads[w], shadow_worker_main,
                 &workers[w]);
-        ASSERT(trc == 0, "pthread_create failed");
+        ASSERT(trc == 0, "thread_create failed");
         thread_created[w] = true;
     }
 
     for (int w = 0; w < K_WORKERS; w++) {
         if (thread_created[w]) {
-            pthread_join(threads[w], NULL);
+            thread_join(&threads[w]);
             thread_created[w] = false; /* avoid double-join in cleanup */
         }
     }
@@ -251,7 +251,7 @@ cleanup:
      * jumps here before the happy-path join loop runs). */
     for (int w = 0; w < K_WORKERS; w++) {
         if (thread_created[w])
-            pthread_join(threads[w], NULL);
+            thread_join(&threads[w]);
     }
     for (int w = 0; w < K_WORKERS; w++)
         col_diff_arrangement_destroy(copies[w]);

--- a/wirelog/columnar/diff_arrangement.c
+++ b/wirelog/columnar/diff_arrangement.c
@@ -79,6 +79,14 @@ col_diff_arrangement_get_delta_range(const col_diff_arrangement_t *arr,
     *out_current_nrows = arr->current_nrows;
 }
 
+/* Deep-copy the arrangement so a K-fusion worker can evaluate without
+ * touching sibling worker state. See docs/ARCHITECTURE.md §4 "K-Fusion
+ * Parallelism": "Each worker has isolated copies of differential
+ * arrangements" + "Deep-copy isolation simplifies correctness". The
+ * worker still reads the shared col_rel_t column buffers but, under the
+ * Option (iii) immutable-during-epoch invariant (Issue #532 Task 4),
+ * those buffers are not mutated during the read phase, so no locking
+ * is required. Isolation is validated by tests/test_k_fusion_inline_shadow.c. */
 col_diff_arrangement_t *
 col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
 {

--- a/wirelog/columnar/diff_arrangement.h
+++ b/wirelog/columnar/diff_arrangement.h
@@ -90,6 +90,20 @@ void col_diff_arrangement_get_delta_range(
  * Allocates new memory for the arrangement and all hash table buckets.
  * Each K-fusion worker gets an independent copy to avoid synchronization.
  *
+ * Contract (docs/ARCHITECTURE.md §4 "K-Fusion Parallelism"):
+ *   - "Each worker has isolated copies of differential arrangements
+ *      (no cross-worker synchronization)"
+ *   - "Deep-copy isolation simplifies correctness (no locks needed
+ *      for K-fusion workers)"
+ *
+ * Interaction with inline compound storage (Issue #532 Task 4):
+ *   Workers index the same underlying col_rel_t column buffers but
+ *   through private ht_head / ht_next arrays produced by this function.
+ *   The Option (iii) immutable-during-epoch strategy guarantees those
+ *   column buffers are not written during the worker read phase, so
+ *   concurrent retrieves of inline compounds are race-free without any
+ *   locking. See tests/test_k_fusion_inline_shadow.c.
+ *
  * @param arr: Source arrangement
  *
  * Returns: Pointer to new independent copy (caller must free with col_diff_arrangement_destroy)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4790,6 +4790,19 @@ wl_col_rel_inline_locate(const col_rel_t *rel, uint32_t logical_col,
 
     uint32_t offset = 0u;
     for (uint32_t i = 0; ; i++) {
+        /* Guard: all logical columns have been consumed without finding
+         * logical_col.  Checking offset >= ncols BEFORE indexing
+         * compound_arity_map prevents an out-of-bounds read when
+         * logical_col is >= logical_ncols (e.g. the caller passes 99
+         * for a 4-column schema).  The array has exactly logical_ncols
+         * entries, and after the last entry offset == ncols. */
+        if (offset >= rel->ncols) {
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                "event=locate error=logical_col_oor rel=%s "
+                "logical_col=%u physical_ncols=%u",
+                rel->name ? rel->name : "(anon)", logical_col, rel->ncols);
+            return EINVAL;
+        }
         uint32_t width = rel->compound_arity_map[i];
         if (width == 0u) {
             WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4750,3 +4750,114 @@ col_eval_stratum_multiworker(const wl_plan_stratum_t *sp,
 
     return 0;
 }
+
+/* ======================================================================== */
+/* Inline Compound Storage (Issue #532 Task 3)                              */
+/*                                                                          */
+/* Per-row accessors for the inline compound tier. The Task #2 physical     */
+/* layout gives each INLINE logical column `compound_arity_map[i]`          */
+/* contiguous physical slots; these ops resolve that offset by prefix       */
+/* sum and touch only the addressed range. Functor identity is schema-     */
+/* level, so no handle is stored per row.                                   */
+/* ======================================================================== */
+
+/* Resolve the physical offset and slot width of a logical column in an
+ * INLINE-kind relation. Returns 0 and writes *out_offset / *out_width on
+ * success; EINVAL if the relation is not INLINE, compound_arity_map is
+ * absent, a zero-width entry is seen (corruption), or the prefix sum
+ * walks past the physical schema (logical_col out of range). */
+static int
+wl_col_rel_inline_locate(const col_rel_t *rel, uint32_t logical_col,
+    uint32_t *out_offset, uint32_t *out_width)
+{
+    if (rel->compound_kind != WIRELOG_COMPOUND_KIND_INLINE)
+        return EINVAL;
+    if (!rel->compound_arity_map)
+        return EINVAL;
+
+    uint32_t offset = 0u;
+    for (uint32_t i = 0; ; i++) {
+        uint32_t width = rel->compound_arity_map[i];
+        if (width == 0u)
+            return EINVAL; /* Task #2 never emits zero-width entries */
+        if (offset + width > rel->ncols)
+            return EINVAL; /* logical_col beyond end of schema */
+        if (i == logical_col) {
+            *out_offset = offset;
+            *out_width = width;
+            return 0;
+        }
+        offset += width;
+    }
+}
+
+int
+wl_col_rel_store_inline_compound(col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, const int64_t *args, uint32_t arity)
+{
+    if (!rel || !args || arity == 0u)
+        return EINVAL;
+    if (row_idx >= rel->nrows)
+        return EINVAL;
+
+    uint32_t offset = 0u;
+    uint32_t width = 0u;
+    int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
+    if (rc != 0)
+        return rc;
+    if (width != arity)
+        return EINVAL;
+
+    for (uint32_t k = 0; k < arity; k++)
+        col_rel_set(rel, row_idx, offset + k, args[k]);
+    return 0;
+}
+
+int
+wl_col_rel_retrieve_inline_compound(const col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, int64_t *out_args, uint32_t arity)
+{
+    if (!rel || !out_args || arity == 0u)
+        return EINVAL;
+    if (row_idx >= rel->nrows)
+        return EINVAL;
+
+    uint32_t offset = 0u;
+    uint32_t width = 0u;
+    int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
+    if (rc != 0)
+        return rc;
+    if (width != arity)
+        return EINVAL;
+
+    for (uint32_t k = 0; k < arity; k++)
+        out_args[k] = col_rel_get(rel, row_idx, offset + k);
+    return 0;
+}
+
+int
+wl_col_rel_retract_inline_compound(col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, int64_t multiplicity)
+{
+    if (!rel || row_idx >= rel->nrows)
+        return EINVAL;
+    if (multiplicity == 0)
+        return EINVAL; /* retraction with zero multiplicity is nonsense */
+
+    uint32_t offset = 0u;
+    uint32_t width = 0u;
+    int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
+    if (rc != 0)
+        return rc;
+
+    /* Physical slots are deliberately NOT mutated: Z-set multiplicity is
+     * tracked at the delta/timestamps layer (col_rel_t::timestamps), and
+     * retraction-seeded semi-naive evaluation still needs the original
+     * tuple visible for join matching during the retraction pass. The
+     * caller is responsible for negating multiplicity in the session
+     * delta path; this op validates addressability of the compound. */
+    (void)offset;
+    (void)width;
+    (void)multiplicity;
+    return 0;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4765,23 +4765,46 @@ col_eval_stratum_multiworker(const wl_plan_stratum_t *sp,
  * INLINE-kind relation. Returns 0 and writes *out_offset / *out_width on
  * success; EINVAL if the relation is not INLINE, compound_arity_map is
  * absent, a zero-width entry is seen (corruption), or the prefix sum
- * walks past the physical schema (logical_col out of range). */
+ * walks past the physical schema (logical_col out of range).
+ *
+ * K-Fusion C2 (§5): locate is pure/read-only; failures surface as
+ * structured error tags so the fused driver can route the row to the
+ * SIDE tier without aborting the worker. */
 static int
 wl_col_rel_inline_locate(const col_rel_t *rel, uint32_t logical_col,
     uint32_t *out_offset, uint32_t *out_width)
 {
-    if (rel->compound_kind != WIRELOG_COMPOUND_KIND_INLINE)
+    if (rel->compound_kind != WIRELOG_COMPOUND_KIND_INLINE) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=locate error=not_inline rel=%s kind=%d logical_col=%u",
+            rel->name ? rel->name : "(anon)", (int)rel->compound_kind,
+            logical_col);
         return EINVAL;
-    if (!rel->compound_arity_map)
+    }
+    if (!rel->compound_arity_map) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+            "event=locate error=missing_arity_map rel=%s",
+            rel->name ? rel->name : "(anon)");
         return EINVAL;
+    }
 
     uint32_t offset = 0u;
     for (uint32_t i = 0; ; i++) {
         uint32_t width = rel->compound_arity_map[i];
-        if (width == 0u)
+        if (width == 0u) {
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+                "event=locate error=corrupt_width rel=%s logical_col=%u "
+                "scan_idx=%u",
+                rel->name ? rel->name : "(anon)", logical_col, i);
             return EINVAL; /* Task #2 never emits zero-width entries */
-        if (offset + width > rel->ncols)
+        }
+        if (offset + width > rel->ncols) {
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                "event=locate error=logical_col_oor rel=%s "
+                "logical_col=%u physical_ncols=%u",
+                rel->name ? rel->name : "(anon)", logical_col, rel->ncols);
             return EINVAL; /* logical_col beyond end of schema */
+        }
         if (i == logical_col) {
             *out_offset = offset;
             *out_width = width;
@@ -4795,21 +4818,38 @@ int
 wl_col_rel_store_inline_compound(col_rel_t *rel, uint32_t row_idx,
     uint32_t logical_col, const int64_t *args, uint32_t arity)
 {
-    if (!rel || !args || arity == 0u)
+    if (!rel || !args || arity == 0u) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=store path=inline error=bad_input rel=%p args=%p arity=%u",
+            (const void *)rel, (const void *)args, arity);
         return EINVAL;
-    if (row_idx >= rel->nrows)
+    }
+    if (row_idx >= rel->nrows) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=store path=inline error=row_oor rel=%s row=%u nrows=%u",
+            rel->name ? rel->name : "(anon)", row_idx, rel->nrows);
         return EINVAL;
+    }
 
     uint32_t offset = 0u;
     uint32_t width = 0u;
     int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
     if (rc != 0)
         return rc;
-    if (width != arity)
+    if (width != arity) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=store path=inline error=arity_mismatch rel=%s "
+            "logical_col=%u expected=%u got=%u",
+            rel->name ? rel->name : "(anon)", logical_col, width, arity);
         return EINVAL;
+    }
 
     for (uint32_t k = 0; k < arity; k++)
         col_rel_set(rel, row_idx, offset + k, args[k]);
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "event=store path=inline rel=%s row=%u logical_col=%u offset=%u "
+        "arity=%u",
+        rel->name ? rel->name : "(anon)", row_idx, logical_col, offset, arity);
     return 0;
 }
 
@@ -4817,21 +4857,39 @@ int
 wl_col_rel_retrieve_inline_compound(const col_rel_t *rel, uint32_t row_idx,
     uint32_t logical_col, int64_t *out_args, uint32_t arity)
 {
-    if (!rel || !out_args || arity == 0u)
+    if (!rel || !out_args || arity == 0u) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=retrieve path=inline error=bad_input rel=%p out=%p "
+            "arity=%u",
+            (const void *)rel, (const void *)out_args, arity);
         return EINVAL;
-    if (row_idx >= rel->nrows)
+    }
+    if (row_idx >= rel->nrows) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=retrieve path=inline error=row_oor rel=%s row=%u nrows=%u",
+            rel->name ? rel->name : "(anon)", row_idx, rel->nrows);
         return EINVAL;
+    }
 
     uint32_t offset = 0u;
     uint32_t width = 0u;
     int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
     if (rc != 0)
         return rc;
-    if (width != arity)
+    if (width != arity) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=retrieve path=inline error=arity_mismatch rel=%s "
+            "logical_col=%u expected=%u got=%u",
+            rel->name ? rel->name : "(anon)", logical_col, width, arity);
         return EINVAL;
+    }
 
     for (uint32_t k = 0; k < arity; k++)
         out_args[k] = col_rel_get(rel, row_idx, offset + k);
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "event=retrieve path=inline rel=%s row=%u logical_col=%u offset=%u "
+        "arity=%u",
+        rel->name ? rel->name : "(anon)", row_idx, logical_col, offset, arity);
     return 0;
 }
 
@@ -4839,16 +4897,27 @@ int
 wl_col_rel_retract_inline_compound(col_rel_t *rel, uint32_t row_idx,
     uint32_t logical_col, int64_t multiplicity)
 {
-    if (!rel || row_idx >= rel->nrows)
+    if (!rel || row_idx >= rel->nrows) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=retract path=inline error=bad_input rel=%p row=%u",
+            (const void *)rel, row_idx);
         return EINVAL;
-    if (multiplicity == 0)
+    }
+    if (multiplicity == 0) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=retract path=inline error=zero_multiplicity rel=%s "
+            "row=%u logical_col=%u",
+            rel->name ? rel->name : "(anon)", row_idx, logical_col);
         return EINVAL; /* retraction with zero multiplicity is nonsense */
+    }
 
     uint32_t offset = 0u;
     uint32_t width = 0u;
     int rc = wl_col_rel_inline_locate(rel, logical_col, &offset, &width);
     if (rc != 0)
         return rc;
+    /* K-Fusion C3 (§5): physical slots preserved across retraction so the
+     * delta/timestamp layer can re-match the tuple during semi-naive. */
 
     /* Physical slots are deliberately NOT mutated: Z-set multiplicity is
      * tracked at the delta/timestamps layer (col_rel_t::timestamps), and
@@ -4858,6 +4927,10 @@ wl_col_rel_retract_inline_compound(col_rel_t *rel, uint32_t row_idx,
      * delta path; this op validates addressability of the compound. */
     (void)offset;
     (void)width;
-    (void)multiplicity;
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+        "event=retract path=inline rel=%s row=%u logical_col=%u offset=%u "
+        "width=%u multiplicity=%lld",
+        rel->name ? rel->name : "(anon)", row_idx, logical_col, offset, width,
+        (long long)multiplicity);
     return 0;
 }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1065,6 +1065,43 @@ int
 col_rel_apply_compound_schema(col_rel_t *r,
     const col_rel_logical_col_t *logical_cols,
     uint32_t logical_ncols);
+
+/* ------------------------------------------------------------------------ */
+/* Inline-tier storage ops (Issue #532 Task 3).                             */
+/*                                                                          */
+/* Inline compounds occupy `compound_arity_map[logical_col]` contiguous     */
+/* physical slots starting at the prefix-sum of preceding widths. The       */
+/* functor identity is schema-level (see col_rel_apply_compound_schema),    */
+/* so only the arguments are materialised per row -- no handle slot.        */
+/* All three ops are O(logical_col) for offset resolution and preserve      */
+/* physical slot contents outside the addressed range.                      */
+/* ------------------------------------------------------------------------ */
+
+/* Write `arity` argument values into the inline compound at
+ * (row_idx, logical_col). Returns 0 on success; EINVAL when the relation
+ * is not INLINE, row_idx is out of range, logical_col is beyond the
+ * schema, or `arity` does not match compound_arity_map[logical_col]. */
+int
+wl_col_rel_store_inline_compound(col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, const int64_t *args, uint32_t arity);
+
+/* Copy the inline compound at (row_idx, logical_col) into out_args
+ * (must hold at least `arity` int64s). Returns 0 on success; EINVAL on
+ * the same precondition violations as store_inline_compound. */
+int
+wl_col_rel_retrieve_inline_compound(const col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, int64_t *out_args, uint32_t arity);
+
+/* Signal retraction of the inline compound at (row_idx, logical_col) with
+ * the given non-zero Z-set multiplicity. Physical slots are intentionally
+ * left intact: Z-set multiplicity lives in the delta/timestamps layer,
+ * and join matching during retraction-seeded semi-naive evaluation still
+ * needs to see the original tuple. Returns 0 on success; EINVAL for the
+ * usual precondition violations or when multiplicity is zero. */
+int
+wl_col_rel_retract_inline_compound(col_rel_t *rel, uint32_t row_idx,
+    uint32_t logical_col, int64_t multiplicity);
+
 int
 col_rel_append_row(col_rel_t *r, const int64_t *row);
 int

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -27,6 +27,7 @@
 #include "util/lockfree_queue.h"
 #include "workqueue.h"
 #include "arena/arena.h"
+#include "wirelog-types.h"
 
 #include "nanoarrow/nanoarrow.h"
 
@@ -270,6 +271,50 @@ typedef struct {
      * from plan's edb_has_graph_column[]; default false via calloc. */
     bool has_graph_column;
     uint32_t graph_col_idx;
+    /* Compound-column metadata (Issue #532: inline tier).
+     *
+     * Relation-level summary of how compound columns are stored.  For
+     * relations with no compound columns, all four fields are zero/NULL
+     * and ncols == logical column count (no expansion).
+     *
+     * compound_kind
+     *   WIRELOG_COMPOUND_KIND_NONE   -- no compound columns (default)
+     *   WIRELOG_COMPOUND_KIND_INLINE -- >=1 inline compound column; the
+     *                                   physical schema (ncols/columns)
+     *                                   has been expanded, each inline
+     *                                   compound occupying `arity`
+     *                                   contiguous physical slots.
+     *   WIRELOG_COMPOUND_KIND_SIDE   -- compound values live in a
+     *                                   side-relation; physical schema
+     *                                   matches the logical schema one-
+     *                                   to-one (no expansion).
+     *
+     * compound_count
+     *   Number of inline-kind logical columns in this relation.  Zero
+     *   when compound_kind != INLINE.
+     *
+     * compound_arity_map
+     *   Owned array of length equal to the LOGICAL column count.  Entry
+     *   i is the expansion arity of logical column i: 1 for a scalar
+     *   column, N (>=1) for an inline compound of arity N.  NULL when
+     *   compound_kind != INLINE; Phase 2B populates this during schema
+     *   inference.  Freed on relation destruction.
+     *
+     * inline_physical_offset
+     *   Physical column index at which the first inline compound slot
+     *   begins.  Zero when compound_kind != INLINE.  When non-zero it
+     *   matches the prefix-sum of compound_arity_map entries that
+     *   precede the first inline compound.
+     *
+     * Phase 1 (this commit) introduces the fields only.  Logic that
+     * populates and consumes them lands in Phase 2 (Issue #532, Tasks
+     * #2-#4).  All allocation paths zero-initialise these slots via
+     * calloc(), and col_rel_free_contents() frees compound_arity_map.
+     */
+    wirelog_compound_kind_t compound_kind;
+    uint32_t compound_count;
+    uint32_t *compound_arity_map;
+    uint32_t inline_physical_offset;
 } col_rel_t;
 
 /* ======================================================================== */

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -991,6 +991,80 @@ int
 col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names);
 int
 col_rel_alloc(col_rel_t **out, const char *name);
+
+/* ------------------------------------------------------------------------ */
+/* Compound-column layout (Issue #532 Task 2).                              */
+/*                                                                          */
+/* Inline-tier invariants: compounds wider than MAX_ARITY or deeper than    */
+/* MAX_DEPTH must be lowered to the SIDE tier. Physical-layout inference    */
+/* rejects violations with EINVAL.                                          */
+/* ------------------------------------------------------------------------ */
+
+#define WL_COMPOUND_INLINE_MAX_ARITY 4u
+#define WL_COMPOUND_INLINE_MAX_DEPTH 1u
+
+/* Logical column descriptor consumed by col_rel_compute_physical_layout.
+ * kind  -- NONE for scalar columns, INLINE or SIDE for compound columns.
+ * arity -- functor arity when kind != NONE (ignored for NONE).
+ * depth -- compound nesting depth; 0 for scalar, 1 for flat compound.
+ *          INLINE columns with depth > WL_COMPOUND_INLINE_MAX_DEPTH are
+ *          rejected. */
+typedef struct {
+    wirelog_compound_kind_t kind;
+    uint32_t arity;
+    uint32_t depth;
+} col_rel_logical_col_t;
+
+/* Compute the physical column layout implied by `logical_cols`.
+ *
+ *   *out_physical_ncols       -- sum of per-column slot widths, where
+ *                                NONE/SIDE columns contribute 1 slot each
+ *                                and INLINE columns contribute `arity`
+ *                                slots each.
+ *   out_offset_map[i]         -- physical index at which logical column
+ *                                i's first slot begins (prefix sum of
+ *                                widths). Caller provides the buffer; it
+ *                                must hold >= logical_ncols entries.
+ *   *out_inline_physical_offset -- physical index of the first INLINE
+ *                                  column, or 0 if none.
+ *   *out_compound_count       -- number of INLINE logical columns.
+ *
+ * Any out_* pointer may be NULL to skip that output. On EINVAL the outputs
+ * are left unmodified.
+ *
+ * Returns 0 on success, EINVAL on bad inputs (NULL logical_cols,
+ * logical_ncols == 0, or any INLINE column with arity == 0,
+ * arity > WL_COMPOUND_INLINE_MAX_ARITY, or depth > WL_COMPOUND_INLINE_MAX_DEPTH). */
+int
+col_rel_compute_physical_layout(const col_rel_logical_col_t *logical_cols,
+    uint32_t logical_ncols,
+    uint32_t *out_physical_ncols,
+    uint32_t *out_offset_map,
+    uint32_t *out_inline_physical_offset,
+    uint32_t *out_compound_count);
+
+/* Populate the relation's compound_kind / compound_count /
+ * compound_arity_map / inline_physical_offset fields from `logical_cols`.
+ *
+ * Relation-level compound_kind is chosen as:
+ *   INLINE   if any logical column is INLINE;
+ *   SIDE     if all compound columns are SIDE and no INLINE is present;
+ *   NONE     if every logical column is scalar.
+ *
+ * Allocates compound_arity_map via malloc (size logical_ncols entries);
+ * ownership transfers to the relation and is released by
+ * col_rel_destroy. Any pre-existing compound_arity_map is freed first.
+ *
+ * This function does NOT resize r->columns -- callers that want the
+ * physical schema materialised must pass the physical_ncols returned by
+ * col_rel_compute_physical_layout to col_rel_set_schema separately.
+ *
+ * Returns 0 on success, EINVAL on bad inputs, ENOMEM on allocation
+ * failure. On error the relation's compound fields are unchanged. */
+int
+col_rel_apply_compound_schema(col_rel_t *r,
+    const col_rel_logical_col_t *logical_cols,
+    uint32_t logical_ncols);
 int
 col_rel_append_row(col_rel_t *r, const int64_t *row);
 int

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -10,6 +10,7 @@
  */
 
 #include "columnar/internal.h"
+#include "wirelog/util/log.h"
 
 #include "../wirelog-internal.h"
 
@@ -254,16 +255,31 @@ col_rel_alloc(col_rel_t **out, const char *name)
 /* Reject an INLINE column that violates the inline-tier invariants. Returns
  * EINVAL on violation, 0 when the column is acceptable. Non-INLINE columns
  * are always acceptable at this layer (SIDE widths are handled below and
- * NONE columns are scalars). */
+ * NONE columns are scalars).
+ *
+ * K-Fusion C1 (§5): INLINE columns must fit within arity<=MAX_ARITY and
+ * depth<=MAX_DEPTH; wider/deeper functors must lower to the SIDE tier.
+ * Violations are structured logs (error=arity_overflow|depth_overflow) so
+ * operators can diagnose schema-mismatch without abort. */
 static int
 col_rel_validate_inline_col(const col_rel_logical_col_t *col)
 {
     if (col->kind != WIRELOG_COMPOUND_KIND_INLINE)
         return 0;
-    if (col->arity == 0u || col->arity > WL_COMPOUND_INLINE_MAX_ARITY)
+    if (col->arity == 0u || col->arity > WL_COMPOUND_INLINE_MAX_ARITY) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=validate path=inline error=arity_overflow "
+            "expected=1..%u got=%u",
+            (unsigned)WL_COMPOUND_INLINE_MAX_ARITY, col->arity);
         return EINVAL;
-    if (col->depth > WL_COMPOUND_INLINE_MAX_DEPTH)
+    }
+    if (col->depth > WL_COMPOUND_INLINE_MAX_DEPTH) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=validate path=inline error=depth_overflow "
+            "expected=0..%u got=%u",
+            (unsigned)WL_COMPOUND_INLINE_MAX_DEPTH, col->depth);
         return EINVAL;
+    }
     return 0;
 }
 
@@ -287,14 +303,22 @@ col_rel_compute_physical_layout(const col_rel_logical_col_t *logical_cols,
     uint32_t *out_inline_physical_offset,
     uint32_t *out_compound_count)
 {
-    if (!logical_cols || logical_ncols == 0u)
+    if (!logical_cols || logical_ncols == 0u) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=layout error=bad_input logical_cols=%p logical_ncols=%u",
+            (const void *)logical_cols, logical_ncols);
         return EINVAL;
+    }
 
-    /* Validate before touching outputs so EINVAL leaves everything intact. */
+    /* Validate before touching outputs so EINVAL leaves everything intact.
+    * Per-column failures are already logged inside validate_inline_col. */
     for (uint32_t i = 0; i < logical_ncols; i++) {
         int rc = col_rel_validate_inline_col(&logical_cols[i]);
-        if (rc != 0)
+        if (rc != 0) {
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                "event=layout error=validation logical_col=%u", i);
             return rc;
+        }
     }
 
     uint32_t physical = 0u;
@@ -321,6 +345,11 @@ col_rel_compute_physical_layout(const col_rel_logical_col_t *logical_cols,
         *out_inline_physical_offset = first_inline_offset;
     if (out_compound_count)
         *out_compound_count = compound_count;
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+        "event=layout path=%s logical=%u physical=%u compound=%u "
+        "first_inline_offset=%u",
+        compound_count > 0u ? "inline" : "scalar",
+        logical_ncols, physical, compound_count, first_inline_offset);
     return 0;
 }
 
@@ -329,8 +358,11 @@ col_rel_apply_compound_schema(col_rel_t *r,
     const col_rel_logical_col_t *logical_cols,
     uint32_t logical_ncols)
 {
-    if (!r)
+    if (!r) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "event=apply_schema error=null_relation");
         return EINVAL;
+    }
 
     /* Reuse the pure layout routine for validation + offset math so the
      * two entry points cannot drift. We don't need the per-column offsets
@@ -344,8 +376,12 @@ col_rel_apply_compound_schema(col_rel_t *r,
 
     uint32_t *arity_map
         = (uint32_t *)malloc((size_t)logical_ncols * sizeof(uint32_t));
-    if (!arity_map)
+    if (!arity_map) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+            "event=apply_schema error=oom bytes=%zu",
+            (size_t)logical_ncols * sizeof(uint32_t));
         return ENOMEM;
+    }
 
     bool has_inline = false;
     bool has_side = false;
@@ -362,12 +398,22 @@ col_rel_apply_compound_schema(col_rel_t *r,
     r->compound_arity_map = arity_map;
     r->compound_count = compound_count;
     r->inline_physical_offset = inline_offset;
-    if (has_inline)
+    const char *path_tag;
+    if (has_inline) {
         r->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
-    else if (has_side)
+        path_tag = "inline";
+    } else if (has_side) {
         r->compound_kind = WIRELOG_COMPOUND_KIND_SIDE;
-    else
+        path_tag = "side";
+    } else {
         r->compound_kind = WIRELOG_COMPOUND_KIND_NONE;
+        path_tag = "none";
+    }
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
+        "event=apply_schema path=%s rel=%s logical=%u compound_count=%u "
+        "inline_offset=%u",
+        path_tag, r->name ? r->name : "(anon)", logical_ncols,
+        compound_count, inline_offset);
     return 0;
 }
 

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -132,6 +132,7 @@ col_rel_free_contents(col_rel_t *r)
         free(r->col_names);
     }
     free(r->dedup_slots);
+    free(r->compound_arity_map);
     if (r->schema_ok)
         ArrowSchemaRelease(&r->schema);
     memset(r, 0, sizeof(*r));

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -247,6 +247,130 @@ col_rel_alloc(col_rel_t **out, const char *name)
     return 0;
 }
 
+/* ------------------------------------------------------------------------ */
+/* Compound-column layout (Issue #532 Task 2).                              */
+/* ------------------------------------------------------------------------ */
+
+/* Reject an INLINE column that violates the inline-tier invariants. Returns
+ * EINVAL on violation, 0 when the column is acceptable. Non-INLINE columns
+ * are always acceptable at this layer (SIDE widths are handled below and
+ * NONE columns are scalars). */
+static int
+col_rel_validate_inline_col(const col_rel_logical_col_t *col)
+{
+    if (col->kind != WIRELOG_COMPOUND_KIND_INLINE)
+        return 0;
+    if (col->arity == 0u || col->arity > WL_COMPOUND_INLINE_MAX_ARITY)
+        return EINVAL;
+    if (col->depth > WL_COMPOUND_INLINE_MAX_DEPTH)
+        return EINVAL;
+    return 0;
+}
+
+/* Width contribution of one logical column in the physical schema.
+ * NONE/SIDE contribute a single slot (SIDE stores only the opaque handle
+ * into the side-relation). INLINE contributes `arity` slots; callers must
+ * have already accepted the column via col_rel_validate_inline_col. */
+static uint32_t
+col_rel_slot_width(const col_rel_logical_col_t *col)
+{
+    if (col->kind == WIRELOG_COMPOUND_KIND_INLINE)
+        return col->arity;
+    return 1u;
+}
+
+int
+col_rel_compute_physical_layout(const col_rel_logical_col_t *logical_cols,
+    uint32_t logical_ncols,
+    uint32_t *out_physical_ncols,
+    uint32_t *out_offset_map,
+    uint32_t *out_inline_physical_offset,
+    uint32_t *out_compound_count)
+{
+    if (!logical_cols || logical_ncols == 0u)
+        return EINVAL;
+
+    /* Validate before touching outputs so EINVAL leaves everything intact. */
+    for (uint32_t i = 0; i < logical_ncols; i++) {
+        int rc = col_rel_validate_inline_col(&logical_cols[i]);
+        if (rc != 0)
+            return rc;
+    }
+
+    uint32_t physical = 0u;
+    uint32_t compound_count = 0u;
+    uint32_t first_inline_offset = 0u;
+    bool saw_inline = false;
+
+    for (uint32_t i = 0; i < logical_ncols; i++) {
+        if (out_offset_map)
+            out_offset_map[i] = physical;
+        if (logical_cols[i].kind == WIRELOG_COMPOUND_KIND_INLINE) {
+            if (!saw_inline) {
+                first_inline_offset = physical;
+                saw_inline = true;
+            }
+            compound_count++;
+        }
+        physical += col_rel_slot_width(&logical_cols[i]);
+    }
+
+    if (out_physical_ncols)
+        *out_physical_ncols = physical;
+    if (out_inline_physical_offset)
+        *out_inline_physical_offset = first_inline_offset;
+    if (out_compound_count)
+        *out_compound_count = compound_count;
+    return 0;
+}
+
+int
+col_rel_apply_compound_schema(col_rel_t *r,
+    const col_rel_logical_col_t *logical_cols,
+    uint32_t logical_ncols)
+{
+    if (!r)
+        return EINVAL;
+
+    /* Reuse the pure layout routine for validation + offset math so the
+     * two entry points cannot drift. We don't need the per-column offsets
+     * here, but the prefix sum walks every column exactly once. */
+    uint32_t compound_count = 0u;
+    uint32_t inline_offset = 0u;
+    int rc = col_rel_compute_physical_layout(logical_cols, logical_ncols,
+            NULL, NULL, &inline_offset, &compound_count);
+    if (rc != 0)
+        return rc;
+
+    uint32_t *arity_map
+        = (uint32_t *)malloc((size_t)logical_ncols * sizeof(uint32_t));
+    if (!arity_map)
+        return ENOMEM;
+
+    bool has_inline = false;
+    bool has_side = false;
+    for (uint32_t i = 0; i < logical_ncols; i++) {
+        arity_map[i] = col_rel_slot_width(&logical_cols[i]);
+        if (logical_cols[i].kind == WIRELOG_COMPOUND_KIND_INLINE)
+            has_inline = true;
+        else if (logical_cols[i].kind == WIRELOG_COMPOUND_KIND_SIDE)
+            has_side = true;
+    }
+
+    /* Commit: free any prior map before taking ownership of the new one. */
+    free(r->compound_arity_map);
+    r->compound_arity_map = arity_map;
+    r->compound_count = compound_count;
+    r->inline_physical_offset = inline_offset;
+    if (has_inline)
+        r->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+    else if (has_side)
+        r->compound_kind = WIRELOG_COMPOUND_KIND_SIDE;
+    else
+        r->compound_kind = WIRELOG_COMPOUND_KIND_NONE;
+    return 0;
+}
+
 int
 col_rel_append_row(col_rel_t *r, const int64_t *row)
 {


### PR DESCRIPTION
## Summary

Fix ASAN heap-buffer-overflow in PR #543 by adding boundary check in `wl_col_rel_inline_locate()` function.

**Root Cause:** The function was accessing `compound_arity_map[i]` without verifying that `offset < rel->ncols`. When processing rows with compound columns, OOB logical_col values could cause reads past the allocated buffer.

**Fix:** Added early boundary check `if (offset >= rel->ncols)` before accessing the array, ensuring safe termination with EINVAL.

## Changes

- **File:** `wirelog/columnar/eval.c`
- **Function:** `wl_col_rel_inline_locate()` 
- **Change:** +13 lines (boundary check)
- **Commit:** 332f2e5

## Testing

- ✅ ASAN: `test_col_rel_inline_storage` 3/3 PASS (previously abort on test 3)
- ✅ Inline-tier tests: 37/37 PASS (8 binaries, ASAN clean)
- ✅ Full test suite: 149/150 PASS, 1 skipped (perf gate, code unrelated)
- ✅ ABI suite: 3/3 PASS
- ✅ Build: 498/498 targets

## Verification

The fix has been verified to:
1. Eliminate the heap-buffer-overflow in `test_col_rel_inline_storage`
2. Maintain ASAN cleanness across all 37 inline-tier tests
3. Pass ABI compatibility checks
4. Not introduce any test regressions