### PR TITLE
feat(#553): implement col_rel_deep_copy

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2246,6 +2246,24 @@ test_col_rel_compound_schema_exe = executable(
 test('col_rel_compound_schema', test_col_rel_compound_schema_exe)
 
 # ============================================================================
+# col_rel_deep_copy (Issue #553)
+# ============================================================================
+
+test_col_rel_deep_copy_exe = executable(
+  'test_col_rel_deep_copy',
+  files('test_col_rel_deep_copy.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('col_rel_deep_copy', test_col_rel_deep_copy_exe)
+
+# ============================================================================
 # Inline compound store/retrieve/retract ops (Issue #532 Task 3)
 # ============================================================================
 

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -354,6 +354,78 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Group C: timestamps (Issue #553 Commit 3)                                */
+/* ======================================================================== */
+
+static void
+test_timestamps_round_trip(void)
+{
+    TEST("Group C: timestamps array is deep-copied (capacity-sized)");
+    col_rel_t *src = build_populated("ts_src", 3u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* Manually attach a timestamps buffer matching src->capacity.  In
+     * production col_eval_stratum / append-with-ts paths populate this;
+     * here we wire it up directly to keep the test self-contained. */
+    src->timestamps = (col_delta_timestamp_t *)calloc(src->capacity,
+            sizeof(col_delta_timestamp_t));
+    ASSERT(src->timestamps != NULL, "calloc src timestamps failed");
+    for (uint32_t i = 0; i < src->nrows; i++) {
+        src->timestamps[i].iteration = i + 1u;
+        src->timestamps[i].stratum = 2u;
+        src->timestamps[i].worker = 0u;
+        src->timestamps[i].multiplicity = 1;
+    }
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->timestamps != NULL, "dst timestamps not allocated");
+    ASSERT(dst->timestamps != src->timestamps,
+        "timestamps buffer aliased between src and dst");
+    for (uint32_t i = 0; i < src->nrows; i++) {
+        ASSERT(dst->timestamps[i].iteration == src->timestamps[i].iteration,
+            "iteration mismatch");
+        ASSERT(dst->timestamps[i].stratum == src->timestamps[i].stratum,
+            "stratum mismatch");
+        ASSERT(dst->timestamps[i].multiplicity
+            == src->timestamps[i].multiplicity,
+            "multiplicity mismatch");
+    }
+
+    /* Mutate src timestamps and confirm dst stays unchanged. */
+    src->timestamps[0].iteration = 9999u;
+    ASSERT(dst->timestamps[0].iteration == 1u,
+        "dst timestamps perturbed by src mutation");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_timestamps_null_when_src_null(void)
+{
+    TEST("Group C: NULL src timestamps -> NULL dst timestamps");
+    col_rel_t *src = build_populated("no_ts_src", 2u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+    ASSERT(src->timestamps == NULL,
+        "src timestamps unexpectedly non-NULL by default");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->timestamps == NULL,
+        "dst timestamps allocated despite src being NULL");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -371,6 +443,8 @@ main(void)
     test_col_names_independent();
     test_schema_round_trip();
     test_destroy_source_copy_still_valid();
+    test_timestamps_round_trip();
+    test_timestamps_null_when_src_null();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -624,6 +624,96 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Group G: compound metadata via helper (Issue #553 Commit 6)              */
+/* ======================================================================== */
+
+static void
+test_compound_arity_map_round_trip_inline(void)
+{
+    TEST("Group G: INLINE compound_arity_map round-trips");
+    col_rel_t *src = build_populated("inline_src", 0u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* Logical schema (alpha, beta, gamma) -> physical (alpha, beta1,
+     * beta2, gamma) where beta is an inline compound of arity 2.  We
+     * already have ncols == 3 from build_populated; for this clone-the-
+     * map test that is enough -- the layout doesn't need to be valid
+     * end-to-end. */
+    src->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+    src->compound_count = 1u;
+    src->inline_physical_offset = 1u;
+    /* logical layout: scalar, INLINE/2 (covers physical 1..2), <fill>.
+     * Walk-by-physical sums: 1 + 2 = 3, matching ncols. */
+    src->compound_arity_map = (uint32_t *)calloc(2u, sizeof(uint32_t));
+    ASSERT(src->compound_arity_map != NULL, "calloc arity_map failed");
+    src->compound_arity_map[0] = 1u;
+    src->compound_arity_map[1] = 2u;
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->compound_kind == WIRELOG_COMPOUND_KIND_INLINE,
+        "compound_kind not copied");
+    ASSERT(dst->compound_count == 1u, "compound_count not copied");
+    ASSERT(dst->inline_physical_offset == 1u,
+        "inline_physical_offset not copied");
+    ASSERT(dst->compound_arity_map != NULL,
+        "dst compound_arity_map not allocated");
+    ASSERT(dst->compound_arity_map != src->compound_arity_map,
+        "compound_arity_map aliased between src and dst");
+    ASSERT(dst->compound_arity_map[0] == 1u, "arity_map[0] mismatch");
+    ASSERT(dst->compound_arity_map[1] == 2u, "arity_map[1] mismatch");
+
+    /* Mutate src; dst stays independent. */
+    src->compound_arity_map[1] = 99u;
+    ASSERT(dst->compound_arity_map[1] == 2u,
+        "dst arity_map aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_compound_arity_map_corrupt_input_degrades(void)
+{
+    TEST("Group G: corrupt arity_map degrades to NONE-kind on dst");
+    col_rel_t *src = build_populated("corrupt_src", 0u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* INLINE-kind but with a zero-width entry that prevents the helper
+     * from covering ncols == 3 -- col_rel_new_like degrades silently in
+     * this case, and col_rel_deep_copy must too. */
+    src->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+    src->compound_count = 1u;
+    src->inline_physical_offset = 0u;
+    src->compound_arity_map = (uint32_t *)calloc(3u, sizeof(uint32_t));
+    ASSERT(src->compound_arity_map != NULL, "calloc arity_map failed");
+    src->compound_arity_map[0] = 1u;
+    src->compound_arity_map[1] = 0u; /* corrupt: width-zero entry */
+    src->compound_arity_map[2] = 2u;
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    /* Helper bailed -> dst's compound metadata cleared to NONE. */
+    ASSERT(dst->compound_kind == WIRELOG_COMPOUND_KIND_NONE,
+        "corrupt input did not degrade to NONE-kind");
+    ASSERT(dst->compound_count == 0u,
+        "compound_count should be zero after degrade");
+    ASSERT(dst->compound_arity_map == NULL,
+        "compound_arity_map should be NULL after degrade");
+    ASSERT(dst->inline_physical_offset == 0u,
+        "inline_physical_offset should be zero after degrade");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -647,6 +737,8 @@ main(void)
     test_run_tracking_round_trip();
     test_retract_backup_null_when_src_null();
     test_retract_backup_copy_when_present();
+    test_compound_arity_map_round_trip_inline();
+    test_compound_arity_map_corrupt_input_degrades();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -426,6 +426,103 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Group D + Group F: merge buffer + run tracking (Issue #553 Commit 4)     */
+/* ======================================================================== */
+
+static void
+test_merge_buffer_round_trip(void)
+{
+    TEST("Group D: merge_columns is independently allocated");
+    col_rel_t *src = build_populated("merge_src", 2u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* Manually attach a merge buffer; in production the consolidation
+     * path provisions this lazily, but we install it explicitly to make
+     * the test independent of consolidation triggers. */
+    const uint32_t merge_cap = 8u;
+    src->merge_columns = col_columns_alloc(src->ncols, merge_cap);
+    ASSERT(src->merge_columns != NULL, "col_columns_alloc merge failed");
+    src->merge_buf_cap = merge_cap;
+    for (uint32_t c = 0; c < src->ncols; c++) {
+        for (uint32_t i = 0; i < merge_cap; i++) {
+            src->merge_columns[c][i] = (int64_t)((c + 1u) * 1000 + i);
+        }
+    }
+    src->sorted_nrows = src->nrows;
+    src->base_nrows = src->nrows;
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->merge_buf_cap == merge_cap, "merge_buf_cap not copied");
+    ASSERT(dst->merge_columns != NULL, "dst merge_columns not allocated");
+    ASSERT(dst->merge_columns != src->merge_columns,
+        "merge_columns array aliased");
+    for (uint32_t c = 0; c < src->ncols; c++) {
+        ASSERT(dst->merge_columns[c] != src->merge_columns[c],
+            "per-column merge buffer aliased");
+        for (uint32_t i = 0; i < merge_cap; i++) {
+            ASSERT(dst->merge_columns[c][i] == src->merge_columns[c][i],
+                "merge content mismatch");
+        }
+    }
+    ASSERT(dst->sorted_nrows == src->sorted_nrows,
+        "sorted_nrows not preserved");
+    ASSERT(dst->base_nrows == src->base_nrows, "base_nrows not preserved");
+
+    /* Mutate src merge buffer; dst stays independent. */
+    src->merge_columns[0][0] = (int64_t)-12345;
+    ASSERT(dst->merge_columns[0][0] == (int64_t)1000,
+        "dst merge buffer aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_run_tracking_round_trip(void)
+{
+    TEST("Group F: run_count + run_ends round-trip");
+    col_rel_t *src = build_populated("run_src", 5u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* Synthesize tiered-run state -- the consolidation path normally
+     * fills run_count + run_ends; we set them directly so this test is
+     * independent of the consolidation triggers. */
+    src->run_count = 3u;
+    src->run_ends[0] = 1u;
+    src->run_ends[1] = 3u;
+    src->run_ends[2] = 5u;
+    /* Remaining COL_MAX_RUNS-3 entries left zeroed by build_populated -> calloc. */
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->run_count == 3u, "run_count not copied");
+    ASSERT(dst->run_ends[0] == 1u, "run_ends[0] not copied");
+    ASSERT(dst->run_ends[1] == 3u, "run_ends[1] not copied");
+    ASSERT(dst->run_ends[2] == 5u, "run_ends[2] not copied");
+    /* Confirm trailing entries are still the zeroed default; if memcpy
+     * walked the wrong size we would see corrupted bytes. */
+    for (uint32_t i = 3; i < COL_MAX_RUNS; i++) {
+        ASSERT(dst->run_ends[i] == 0u,
+            "trailing run_ends entry corrupted");
+    }
+
+    /* Mutate src; dst's run_ends array (an inline fixed-size buffer) is
+     * untouched because it was bit-copied. */
+    src->run_ends[1] = 99u;
+    ASSERT(dst->run_ends[1] == 3u, "dst run_ends aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -445,6 +542,8 @@ main(void)
     test_destroy_source_copy_still_valid();
     test_timestamps_round_trip();
     test_timestamps_null_when_src_null();
+    test_merge_buffer_round_trip();
+    test_run_tracking_round_trip();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -186,6 +186,174 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Group A + Group B: columns, schema, col_names (Issue #553 Commit 2)      */
+/* ======================================================================== */
+
+/* Helper: build a 3-col, N-row relation with deterministic content. */
+static col_rel_t *
+build_populated(const char *name, uint32_t nrows)
+{
+    col_rel_t *r = NULL;
+    if (col_rel_alloc(&r, name) != 0)
+        return NULL;
+    const char *names[3] = { "alpha", "beta", "gamma" };
+    if (col_rel_set_schema(r, 3u, names) != 0) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    for (uint32_t i = 0; i < nrows; i++) {
+        int64_t row[3] = {
+            (int64_t)i,
+            (int64_t)(i * 10),
+            (int64_t)(i * 100),
+        };
+        if (col_rel_append_row(r, row) != 0) {
+            col_rel_destroy(r);
+            return NULL;
+        }
+    }
+    return r;
+}
+
+static void
+test_columns_independent_after_modify(void)
+{
+    TEST("Group A: column buffers are independent after mutation");
+    col_rel_t *src = build_populated("src", 5u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->columns != src->columns,
+        "columns array pointer aliased between src and dst");
+    for (uint32_t c = 0; c < src->ncols; c++) {
+        ASSERT(dst->columns[c] != src->columns[c],
+            "per-column buffer aliased");
+    }
+
+    /* Mutate every cell on dst and verify src is unchanged. */
+    for (uint32_t r0 = 0; r0 < dst->nrows; r0++) {
+        for (uint32_t c = 0; c < dst->ncols; c++) {
+            col_rel_set(dst, r0, c, (int64_t)-1);
+        }
+    }
+    for (uint32_t r0 = 0; r0 < src->nrows; r0++) {
+        ASSERT(col_rel_get(src, r0, 0) == (int64_t)r0,
+            "src col 0 perturbed by dst mutation");
+        ASSERT(col_rel_get(src, r0, 1) == (int64_t)(r0 * 10),
+            "src col 1 perturbed by dst mutation");
+        ASSERT(col_rel_get(src, r0, 2) == (int64_t)(r0 * 100),
+            "src col 2 perturbed by dst mutation");
+    }
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_col_names_independent(void)
+{
+    TEST("Group B: col_names strings are independent");
+    col_rel_t *src = build_populated("src", 1u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->col_names != NULL, "dst col_names not allocated");
+    ASSERT(dst->col_names != src->col_names,
+        "col_names array pointer aliased");
+    for (uint32_t i = 0; i < src->ncols; i++) {
+        ASSERT(dst->col_names[i] != src->col_names[i],
+            "per-name buffer aliased");
+        ASSERT(strcmp(dst->col_names[i], src->col_names[i]) == 0,
+            "col_names content mismatch");
+    }
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_schema_round_trip(void)
+{
+    TEST("Group B: ArrowSchema is independently reinit'd");
+    col_rel_t *src = build_populated("src", 1u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+    ASSERT(src->schema_ok == true, "src schema_ok unexpectedly false");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->schema_ok == true, "dst schema_ok not set");
+    ASSERT(dst->schema.release != NULL, "dst schema release callback NULL");
+    /* The format string ("+s" for struct) is independently allocated by
+     * ArrowSchemaSetTypeStruct -- if it were aliased, release of either
+     * schema would corrupt the other.  This is the cheapest single-check
+     * proof that the schemas are not bit-copies. */
+    ASSERT(dst->schema.format != src->schema.format,
+        "ArrowSchema format buffer aliased between src and dst");
+    ASSERT(dst->schema.children != src->schema.children,
+        "ArrowSchema children array aliased between src and dst");
+    ASSERT(dst->schema.n_children == src->schema.n_children,
+        "n_children mismatch");
+    for (int64_t i = 0; i < src->schema.n_children; i++) {
+        ASSERT(dst->schema.children[i] != src->schema.children[i],
+            "per-child schema aliased");
+        ASSERT(dst->schema.children[i]->name != NULL,
+            "per-child name not set");
+        ASSERT(strcmp(dst->schema.children[i]->name,
+            src->schema.children[i]->name) == 0,
+            "per-child schema name mismatch");
+    }
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_destroy_source_copy_still_valid(void)
+{
+    TEST("destroying src after deep-copy leaves dst fully usable");
+    col_rel_t *src = build_populated("src", 4u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+
+    /* Destroy src first so any aliased pointer would dangle. */
+    col_rel_destroy(src);
+    src = NULL;
+
+    /* Confirm dst still reports correct content. */
+    ASSERT(dst->ncols == 3u, "dst ncols corrupted post-src-destroy");
+    ASSERT(dst->nrows == 4u, "dst nrows corrupted post-src-destroy");
+    for (uint32_t r0 = 0; r0 < dst->nrows; r0++) {
+        ASSERT(col_rel_get(dst, r0, 0) == (int64_t)r0,
+            "dst col 0 corrupted post-src-destroy");
+        ASSERT(col_rel_get(dst, r0, 1) == (int64_t)(r0 * 10),
+            "dst col 1 corrupted post-src-destroy");
+        ASSERT(col_rel_get(dst, r0, 2) == (int64_t)(r0 * 100),
+            "dst col 2 corrupted post-src-destroy");
+    }
+    ASSERT(strcmp(dst->name, "src") == 0,
+        "dst name corrupted post-src-destroy");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -199,6 +367,10 @@ main(void)
     test_empty_0x0_relation();
     test_design_invariants_zero_state();
     test_graph_metadata_round_trip();
+    test_columns_independent_after_modify();
+    test_col_names_independent();
+    test_schema_round_trip();
+    test_destroy_source_copy_still_valid();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -523,6 +523,107 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Group E: retract backup defensive copy (Issue #553 Commit 5)             */
+/* ======================================================================== */
+
+static void
+test_retract_backup_null_when_src_null(void)
+{
+    TEST("Group E: NULL src retract_backup -> NULL dst retract_backup");
+    col_rel_t *src = build_populated("rb_src", 2u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+    ASSERT(src->retract_backup_columns == NULL,
+        "src retract_backup_columns unexpectedly non-NULL by default");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->retract_backup_columns == NULL,
+        "dst retract_backup_columns allocated despite src being NULL");
+    ASSERT(dst->retract_backup_nrows == 0u, "retract_backup_nrows leaked");
+    ASSERT(dst->retract_backup_capacity == 0u,
+        "retract_backup_capacity leaked");
+    ASSERT(dst->retract_backup_sorted_nrows == 0u,
+        "retract_backup_sorted_nrows leaked");
+    ASSERT(dst->retract_backup_run_count == 0u,
+        "retract_backup_run_count leaked");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_retract_backup_copy_when_present(void)
+{
+    TEST("Group E: defensive copy of retract_backup_* when populated");
+    col_rel_t *src = build_populated("rb_src", 0u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    /* Synthesize a mid-retraction snapshot.  In production, the live
+     * column buffer is parked into retract_backup_columns and a fresh
+     * empty grid is installed; we set up the same shape directly so the
+     * test does not depend on the retraction-eval pipeline. */
+    const uint32_t bcap = 4u;
+    const uint32_t bnrows = 3u;
+    src->retract_backup_columns = col_columns_alloc(src->ncols, bcap);
+    ASSERT(src->retract_backup_columns != NULL,
+        "col_columns_alloc retract_backup failed");
+    src->retract_backup_capacity = bcap;
+    src->retract_backup_nrows = bnrows;
+    src->retract_backup_sorted_nrows = bnrows;
+    src->retract_backup_run_count = 2u;
+    src->retract_backup_run_ends[0] = 1u;
+    src->retract_backup_run_ends[1] = 3u;
+    for (uint32_t c = 0; c < src->ncols; c++) {
+        for (uint32_t i = 0; i < bnrows; i++) {
+            src->retract_backup_columns[c][i] =
+                (int64_t)((c + 1u) * 100 + i + 1);
+        }
+    }
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->retract_backup_columns != NULL,
+        "dst retract_backup_columns not allocated");
+    ASSERT(dst->retract_backup_columns != src->retract_backup_columns,
+        "retract_backup_columns array aliased");
+    ASSERT(dst->retract_backup_capacity == bcap,
+        "retract_backup_capacity mismatch");
+    ASSERT(dst->retract_backup_nrows == bnrows,
+        "retract_backup_nrows mismatch");
+    ASSERT(dst->retract_backup_sorted_nrows == bnrows,
+        "retract_backup_sorted_nrows mismatch");
+    ASSERT(dst->retract_backup_run_count == 2u,
+        "retract_backup_run_count mismatch");
+    ASSERT(dst->retract_backup_run_ends[0] == 1u
+        && dst->retract_backup_run_ends[1] == 3u,
+        "retract_backup_run_ends mismatch");
+    for (uint32_t c = 0; c < src->ncols; c++) {
+        ASSERT(dst->retract_backup_columns[c]
+            != src->retract_backup_columns[c],
+            "per-column retract_backup buffer aliased");
+        for (uint32_t i = 0; i < bnrows; i++) {
+            ASSERT(dst->retract_backup_columns[c][i]
+                == src->retract_backup_columns[c][i],
+                "retract_backup content mismatch");
+        }
+    }
+
+    /* Mutate src; dst stays independent. */
+    src->retract_backup_columns[0][0] = (int64_t)-1;
+    ASSERT(dst->retract_backup_columns[0][0] == (int64_t)101,
+        "dst retract_backup aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -544,6 +645,8 @@ main(void)
     test_timestamps_null_when_src_null();
     test_merge_buffer_round_trip();
     test_run_tracking_round_trip();
+    test_retract_backup_null_when_src_null();
+    test_retract_backup_copy_when_present();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -714,6 +714,60 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* Large-buffer integration (Issue #553 Commit 7)                           */
+/* ======================================================================== */
+
+static void
+test_large_relation_buffers(void)
+{
+    /* 5M rows x 1 col x sizeof(int64_t) ~= 40 MB.  Smaller than the
+     * issue body's 100 MB target so CI stays fast, but big enough to
+     * exercise the bulk allocation + memcpy paths and prove the deep
+     * copy survives realistic workloads. */
+    TEST("large 5M-row x 1-col relation deep-copies cleanly");
+    const uint32_t target_rows = 5u * 1000u * 1000u;
+    col_rel_t *src = NULL;
+    col_rel_t *dst = NULL;
+    int rc = col_rel_alloc(&src, "large_src");
+    ASSERT(rc == 0 && src != NULL, "col_rel_alloc src failed");
+    const char *names[1] = { "id" };
+    ASSERT(col_rel_set_schema(src, 1u, names) == 0, "set_schema failed");
+    for (uint32_t i = 0; i < target_rows; i++) {
+        int64_t row[1] = { (int64_t)i };
+        ASSERT(col_rel_append_row(src, row) == 0, "append_row failed");
+    }
+    ASSERT(src->nrows == target_rows, "src nrows mismatch after build");
+
+    rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "large deep-copy failed");
+    ASSERT(dst->nrows == src->nrows, "dst nrows mismatch");
+    ASSERT(dst->columns != src->columns, "columns array aliased");
+    ASSERT(dst->columns[0] != src->columns[0], "column buffer aliased");
+
+    /* Spot-check head, midpoint and tail; full equality would dominate
+     * test wall-clock without adding coverage. */
+    ASSERT(col_rel_get(dst, 0u, 0) == 0,
+        "dst[0] mismatch");
+    ASSERT(col_rel_get(dst, target_rows / 2u, 0)
+        == (int64_t)(target_rows / 2u),
+        "dst midpoint mismatch");
+    ASSERT(col_rel_get(dst, target_rows - 1u, 0)
+        == (int64_t)(target_rows - 1u),
+        "dst tail mismatch");
+
+    /* Mutate src tail; dst stays independent. */
+    col_rel_set(src, target_rows - 1u, 0, (int64_t)-1);
+    ASSERT(col_rel_get(dst, target_rows - 1u, 0)
+        == (int64_t)(target_rows - 1u),
+        "dst tail aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -739,6 +793,7 @@ main(void)
     test_retract_backup_copy_when_present();
     test_compound_arity_map_round_trip_inline();
     test_compound_arity_map_corrupt_input_degrades();
+    test_large_relation_buffers();
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -1,0 +1,206 @@
+/*
+ * test_col_rel_deep_copy.c - col_rel_deep_copy contract (Issue #553)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Unit tests for col_rel_deep_copy.  The function produces a fully owned
+ * deep copy of a source relation; subsequent commits expand the surface
+ * area covered (columns, schema, timestamps, merge buffer, retract
+ * backup, compound metadata).  Each test in this file is the smallest
+ * proof that one slice of the contract holds end-to-end.
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* ======================================================================== */
+/* Group H/I/J + NULL-arg scaffold (Issue #553 Commit 1)                    */
+/* ======================================================================== */
+
+static void
+test_null_args_rejected(void)
+{
+    TEST("NULL src and NULL out are rejected with EINVAL");
+    col_rel_t *out = NULL;
+    col_rel_t *dummy = NULL;
+
+    /* NULL src */
+    ASSERT(col_rel_deep_copy(NULL, &out, NULL) == EINVAL,
+        "NULL src not rejected");
+    ASSERT(out == NULL, "out perturbed on NULL-src failure");
+
+    /* NULL out */
+    int rc = col_rel_alloc(&dummy, "src");
+    ASSERT(rc == 0 && dummy != NULL, "col_rel_alloc failed");
+    ASSERT(col_rel_deep_copy(dummy, NULL, NULL) == EINVAL,
+        "NULL out not rejected");
+
+    /* Both NULL */
+    ASSERT(col_rel_deep_copy(NULL, NULL, NULL) == EINVAL,
+        "double NULL not rejected");
+
+    PASS();
+cleanup:
+    col_rel_destroy(dummy);
+}
+
+static void
+test_empty_0x0_relation(void)
+{
+    TEST("deep-copy of an empty 0x0 relation succeeds and is destroyable");
+    col_rel_t *src = NULL;
+    col_rel_t *dst = NULL;
+    int rc = col_rel_alloc(&src, "empty");
+    ASSERT(rc == 0 && src != NULL, "col_rel_alloc src failed");
+
+    rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0, "col_rel_deep_copy returned non-zero");
+    ASSERT(dst != NULL, "dst not populated on success");
+    ASSERT(dst != src, "dst aliased src pointer");
+    ASSERT(dst->ncols == 0u, "ncols not zero on empty copy");
+    ASSERT(dst->nrows == 0u, "nrows not zero on empty copy");
+    ASSERT(dst->capacity == 0u, "capacity not zero on empty copy");
+    ASSERT(dst->name != NULL && strcmp(dst->name, "empty") == 0,
+        "name not deep-copied");
+    ASSERT(dst->name != src->name, "name buffer aliased between src and dst");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_design_invariants_zero_state(void)
+{
+    TEST("Group I/J zero-state invariants on a copy");
+    col_rel_t *src = NULL;
+    col_rel_t *dst = NULL;
+    int rc = col_rel_alloc(&src, "src");
+    ASSERT(rc == 0 && src != NULL, "col_rel_alloc src failed");
+
+    /* Manually flip Group I bits on src; the copy must not inherit them. */
+    src->pool_owned = true;
+    src->arena_owned = true;
+    /* mem_ledger left NULL -- we cannot construct a real ledger here, but
+     * the contract is "always reset", so a NULL src->mem_ledger still
+     * proves the dst path doesn't dereference it. */
+
+    rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+
+    /* Group I: ownership flags reset, ledger NULL. */
+    ASSERT(dst->pool_owned == false, "pool_owned leaked from src");
+    ASSERT(dst->arena_owned == false, "arena_owned leaked from src");
+    ASSERT(dst->mem_ledger == NULL, "mem_ledger not reset");
+
+    /* Group J: caches cleared. */
+    ASSERT(dst->dedup_slots == NULL, "dedup_slots not reset");
+    ASSERT(dst->dedup_cap == 0u, "dedup_cap not reset");
+    ASSERT(dst->dedup_count == 0u, "dedup_count not reset");
+    ASSERT(dst->col_shared == NULL, "col_shared not reset");
+    ASSERT(dst->row_scratch == NULL, "row_scratch not reset");
+
+    /* Restore src ownership flags so destroy paths behave correctly. */
+    src->pool_owned = false;
+    src->arena_owned = false;
+
+    PASS();
+cleanup:
+    if (src) {
+        src->pool_owned = false;
+        src->arena_owned = false;
+    }
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+static void
+test_graph_metadata_round_trip(void)
+{
+    TEST("Group H graph-column metadata round-trips");
+    col_rel_t *src = NULL;
+    col_rel_t *dst = NULL;
+    int rc = col_rel_alloc(&src, "graph_src");
+    ASSERT(rc == 0 && src != NULL, "col_rel_alloc src failed");
+
+    src->has_graph_column = true;
+    src->graph_col_idx = 7u;
+
+    rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+    ASSERT(dst->has_graph_column == true, "has_graph_column not copied");
+    ASSERT(dst->graph_col_idx == 7u, "graph_col_idx not copied");
+
+    /* Mutate src and confirm dst is independent. */
+    src->graph_col_idx = 99u;
+    ASSERT(dst->graph_col_idx == 7u, "graph_col_idx aliased through src");
+
+    PASS();
+cleanup:
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_col_rel_deep_copy (Issue #553)\n");
+    printf("===================================\n");
+
+    test_null_args_rejected();
+    test_empty_0x0_relation();
+    test_design_invariants_zero_state();
+    test_graph_metadata_round_trip();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1176,6 +1176,28 @@ col_rel_new_like(const char *name, const col_rel_t *src);
 col_rel_t *
 col_rel_pool_new_like(delta_pool_t *pool, const char *name,
     const col_rel_t *like);
+/*
+ * col_rel_deep_copy (Issue #553):
+ * Produce a fully independent deep copy of `src`.  Unlike col_rel_new_like
+ * (which clones schema only), col_rel_deep_copy clones every owned buffer
+ * and metadata field of the source relation so that subsequent mutations
+ * on either relation are completely isolated.
+ *
+ * On success, *out is set to a heap-allocated col_rel_t whose fields are
+ * deep copies or fresh zero state per the field-group taxonomy in #553.
+ * Pool/arena ownership is reset (always heap-owned), col_shared/dedup_*
+ * caches are cleared, and the schema is rebuilt via manual reinit (the
+ * Arrow release callback cannot be aliased across copies).
+ *
+ * Returns 0 on success, EINVAL when src or out is NULL, ENOMEM on
+ * allocation failure.  On failure *out is set to NULL.
+ *
+ * The `arena` parameter is currently reserved (always heap-allocated);
+ * it is accepted to mirror the FROZEN signature in the issue body so that
+ * future arena-aware optimizations are ABI-compatible.
+ */
+int
+col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena);
 col_rel_t *
 col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
     const char *name, uint32_t ncols);

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1111,6 +1111,24 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
         }
     }
 
+    /*
+     * Group C: timestamps array.  Sized to capacity (not nrows) so that
+     * append_row paths after the copy do not need to grow the timestamps
+     * buffer in lockstep with the columns buffer.  Skipped when src has
+     * timestamp tracking disabled (timestamps == NULL).
+     */
+    if (src->timestamps && src->capacity > 0u) {
+        dst->timestamps = (col_delta_timestamp_t *)malloc(
+            (size_t)src->capacity * sizeof(col_delta_timestamp_t));
+        if (!dst->timestamps) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        memcpy(dst->timestamps, src->timestamps,
+            (size_t)src->capacity * sizeof(col_delta_timestamp_t));
+    }
+
     if (src->schema_ok) {
         ArrowSchemaInit(&dst->schema);
         if (ArrowSchemaSetTypeStruct(&dst->schema, (int64_t)src->ncols)

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1197,6 +1197,21 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
             (size_t)src->capacity * sizeof(col_delta_timestamp_t));
     }
 
+    /*
+     * Group G: compound-column metadata (Issue #534, #553).  Mirror the
+     * col_rel_new_like / col_rel_pool_new_like clone path: when the
+     * source carries an INLINE-tier arity map, deep-copy it through the
+     * shared col_rel_clone_compound_meta helper.  Helper failure is
+     * handled with the existing graceful-degrade contract (compound
+     * metadata cleared to NONE-kind on dst), keeping behavior aligned
+     * with col_rel_new_like.  Sources with WIRELOG_COMPOUND_KIND_NONE
+     * leave dst at the zero default already established by calloc.
+     */
+    if (src->compound_kind != WIRELOG_COMPOUND_KIND_NONE
+        && src->compound_arity_map && src->ncols > 0u) {
+        (void)col_rel_clone_compound_meta(dst, src);
+    }
+
     if (src->schema_ok) {
         ArrowSchemaInit(&dst->schema);
         if (ArrowSchemaSetTypeStruct(&dst->schema, (int64_t)src->ncols)

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1058,6 +1058,84 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
      * calloc above already zeroed every byte, so no explicit assignment
      * is required here -- the comment is the contract.
      */
+
+    /*
+     * Group A: column buffers.  Allocate a private ncols x capacity grid
+     * via col_columns_alloc, then memcpy the live nrows of each column.
+     * Reading through src->columns[c] is correct even when col_shared[c]
+     * is true (the buffer is borrowed-readable); the copy unconditionally
+     * owns its storage so col_shared stays NULL on dst (Group J).
+     */
+    if (src->ncols > 0u && src->capacity > 0u) {
+        dst->columns = col_columns_alloc(src->ncols, src->capacity);
+        if (!dst->columns) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        if (src->columns) {
+            for (uint32_t c = 0; c < src->ncols; c++) {
+                if (src->columns[c] && src->nrows > 0u) {
+                    memcpy(dst->columns[c], src->columns[c],
+                        (size_t)src->nrows * sizeof(int64_t));
+                }
+            }
+        }
+    }
+
+    /*
+     * Group B: col_names array + ArrowSchema (manual reinit).
+     *
+     * Schema is rebuilt the same way col_rel_set_schema does it
+     * (ArrowSchemaInit + ArrowSchemaSetTypeStruct + per-child
+     * ArrowSchemaInitFromType + ArrowSchemaSetName) rather than
+     * memcpy'd; the ArrowSchema release callback would otherwise
+     * alias between src and dst, leading to a double-release.
+     */
+    if (src->ncols > 0u && src->col_names) {
+        dst->col_names = (char **)calloc(src->ncols, sizeof(char *));
+        if (!dst->col_names) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        for (uint32_t i = 0; i < src->ncols; i++) {
+            if (src->col_names[i]) {
+                dst->col_names[i] = wl_strdup(src->col_names[i]);
+                if (!dst->col_names[i]) {
+                    col_rel_free_contents(dst);
+                    free(dst);
+                    return ENOMEM;
+                }
+            }
+        }
+    }
+
+    if (src->schema_ok) {
+        ArrowSchemaInit(&dst->schema);
+        if (ArrowSchemaSetTypeStruct(&dst->schema, (int64_t)src->ncols)
+            != NANOARROW_OK) {
+            ArrowSchemaRelease(&dst->schema);
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        for (uint32_t i = 0; i < src->ncols; i++) {
+            if (ArrowSchemaInitFromType(dst->schema.children[i],
+                NANOARROW_TYPE_INT64)
+                != NANOARROW_OK) {
+                ArrowSchemaRelease(&dst->schema);
+                col_rel_free_contents(dst);
+                free(dst);
+                return ENOMEM;
+            }
+            const char *cname = (dst->col_names && dst->col_names[i])
+                ? dst->col_names[i] : "";
+            ArrowSchemaSetName(dst->schema.children[i], cname);
+        }
+        dst->schema_ok = true;
+    }
+
     *out = dst;
     return 0;
 }

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1136,6 +1136,41 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
     }
 
     /*
+     * Group E: zero-copy retraction backup (Issue #300, #369).  Outside
+     * a retraction step every retract_backup_* field is NULL/0, so this
+     * branch is normally inert -- but if a deep copy ever lands inside
+     * a retraction window, the copy must own its own backup or any
+     * subsequent restore would corrupt src's columns.  We therefore
+     * defensively allocate retract_backup_capacity rows and memcpy
+     * retract_backup_nrows live entries per column, plus mirror the run
+     * tracking scalars + fixed array.
+     */
+    dst->retract_backup_nrows = src->retract_backup_nrows;
+    dst->retract_backup_capacity = src->retract_backup_capacity;
+    dst->retract_backup_sorted_nrows = src->retract_backup_sorted_nrows;
+    dst->retract_backup_run_count = src->retract_backup_run_count;
+    memcpy(dst->retract_backup_run_ends, src->retract_backup_run_ends,
+        sizeof(src->retract_backup_run_ends));
+    if (src->retract_backup_columns && src->ncols > 0u
+        && src->retract_backup_capacity > 0u) {
+        dst->retract_backup_columns = col_columns_alloc(src->ncols,
+                src->retract_backup_capacity);
+        if (!dst->retract_backup_columns) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        for (uint32_t c = 0; c < src->ncols; c++) {
+            if (src->retract_backup_columns[c]
+                && src->retract_backup_nrows > 0u) {
+                memcpy(dst->retract_backup_columns[c],
+                    src->retract_backup_columns[c],
+                    (size_t)src->retract_backup_nrows * sizeof(int64_t));
+            }
+        }
+    }
+
+    /*
      * Group F: tiered run-tracking metadata (Issue #369).  Both fields
      * are fixed-size POD: a scalar count plus a COL_MAX_RUNS-element
      * array of run end offsets.  Direct copy (the retract-backup mirror

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -776,6 +776,56 @@ col_rel_col_idx(const col_rel_t *r, const char *name)
 
 /* ---- convenience constructors ------------------------------------------- */
 
+/*
+ * col_rel_clone_compound_meta:
+ * Replicate src's compound metadata onto dst. Mirrors the logical-column
+ * walk used by col_rel_new_like / col_rel_pool_new_like (Issue #534): walk
+ * src->compound_arity_map summing widths until physical ncols are covered,
+ * then deep-copy that many entries so dst and src destroy paths stay
+ * independent (K-Fusion isolation, Issue #553).
+ *
+ * Src must satisfy: src->compound_kind != WIRELOG_COMPOUND_KIND_NONE,
+ * src->compound_arity_map != NULL, src->ncols > 0. Callers gate on these.
+ *
+ * Returns 0 on success (compound metadata installed on dst), -1 on
+ * width-inconsistency or allocation failure (dst's compound metadata is
+ * left untouched, matching the existing graceful-degrade behaviour).
+ */
+static int
+col_rel_clone_compound_meta(col_rel_t *dst, const col_rel_t *src)
+{
+    /* compound_arity_map is keyed by LOGICAL column index, but we record
+     * at least as many entries as the physical ncols to match the
+     * source's allocation footprint. Walk the source map summing widths
+     * until we cover ncols physical slots, then copy that many entries.
+     * Bail gracefully on any inconsistency. */
+    uint32_t logical_count = 0u;
+    uint32_t acc = 0u;
+    while (acc < src->ncols) {
+        if (src->compound_arity_map[logical_count] == 0u) {
+            /* Corrupt width -- leave compound metadata cleared rather
+             * than propagating the inconsistency. */
+            return -1;
+        }
+        acc += src->compound_arity_map[logical_count];
+        logical_count++;
+    }
+    if (logical_count == 0u || acc != src->ncols)
+        return -1;
+
+    uint32_t *copy = (uint32_t *)malloc(
+        (size_t)logical_count * sizeof(uint32_t));
+    if (!copy)
+        return -1;
+    memcpy(copy, src->compound_arity_map,
+        (size_t)logical_count * sizeof(uint32_t));
+    dst->compound_arity_map = copy;
+    dst->compound_kind = src->compound_kind;
+    dst->compound_count = src->compound_count;
+    dst->inline_physical_offset = src->inline_physical_offset;
+    return 0;
+}
+
 /* Helper: create a new owned relation with given ncols and auto-named cols. */
 col_rel_t *
 col_rel_new_auto(const char *name, uint32_t ncols)
@@ -810,38 +860,12 @@ col_rel_new_like(const char *name, const col_rel_t *src)
      * outputs remain INLINE-kind and the logical<->physical translation
      * stays valid for downstream ops. compound_arity_map is a separately
      * owned heap array; we deep-copy it so dst and src destroy paths stay
-     * independent (K-Fusion isolation). */
+     * independent (K-Fusion isolation). Failure is non-fatal: the helper
+     * leaves dst's compound metadata cleared (NONE-kind), matching the
+     * pre-#553 graceful-degrade contract. */
     if (src->compound_kind != WIRELOG_COMPOUND_KIND_NONE
         && src->compound_arity_map && src->ncols > 0u) {
-        /* compound_arity_map is keyed by LOGICAL column index, but we
-         * record at least as many entries as the physical ncols to match
-         * the source's allocation footprint. Walk the source map summing
-         * widths until we cover ncols physical slots, then copy that many
-         * entries. Bail gracefully on any inconsistency. */
-        uint32_t logical_count = 0u;
-        uint32_t acc = 0u;
-        while (acc < src->ncols) {
-            if (src->compound_arity_map[logical_count] == 0u) {
-                /* Corrupt width — leave compound metadata cleared rather
-                 * than propagating the inconsistency. */
-                logical_count = 0u;
-                break;
-            }
-            acc += src->compound_arity_map[logical_count];
-            logical_count++;
-        }
-        if (logical_count > 0u && acc == src->ncols) {
-            uint32_t *copy = (uint32_t *)malloc(
-                (size_t)logical_count * sizeof(uint32_t));
-            if (copy) {
-                memcpy(copy, src->compound_arity_map,
-                    (size_t)logical_count * sizeof(uint32_t));
-                r->compound_arity_map = copy;
-                r->compound_kind = src->compound_kind;
-                r->compound_count = src->compound_count;
-                r->inline_physical_offset = src->inline_physical_offset;
-            }
-        }
+        (void)col_rel_clone_compound_meta(r, src);
     }
     return r;
 }
@@ -897,28 +921,7 @@ col_rel_pool_new_like(delta_pool_t *pool, const char *name,
      * with the same deep-copy discipline. */
     if (like->compound_kind != WIRELOG_COMPOUND_KIND_NONE
         && like->compound_arity_map && like->ncols > 0u) {
-        uint32_t logical_count = 0u;
-        uint32_t acc = 0u;
-        while (acc < like->ncols) {
-            if (like->compound_arity_map[logical_count] == 0u) {
-                logical_count = 0u;
-                break;
-            }
-            acc += like->compound_arity_map[logical_count];
-            logical_count++;
-        }
-        if (logical_count > 0u && acc == like->ncols) {
-            uint32_t *copy = (uint32_t *)malloc(
-                (size_t)logical_count * sizeof(uint32_t));
-            if (copy) {
-                memcpy(copy, like->compound_arity_map,
-                    (size_t)logical_count * sizeof(uint32_t));
-                r->compound_arity_map = copy;
-                r->compound_kind = like->compound_kind;
-                r->compound_count = like->compound_count;
-                r->inline_physical_offset = like->inline_physical_offset;
-            }
-        }
+        (void)col_rel_clone_compound_meta(r, like);
     }
     r->nrows = 0;
     return r;

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -996,21 +996,58 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
 
 /* ---- deep copy ----------------------------------------------------------- */
 
-/*
- * col_rel_deep_copy (Issue #553):
- * Produce a fully-owned deep copy of `src`.  See the contract in
- * wirelog/columnar/internal.h next to the declaration.
+/**
+ * @brief Produce a fully-owned deep copy of a col_rel_t (Issue #553).
  *
- * Implementation strategy: zero-allocate `dst` with calloc so that
- * col_rel_free_contents is safe to call at any unwind point.  All Group
- * I/J fields (pool/arena ownership, ledgers, caches, sharing) start at
- * their zero defaults and are NEVER inherited from src.
+ * Allocates a new heap-resident relation and clones every owned buffer
+ * and metadata field so the result is byte-equivalent to @p src yet
+ * shares no storage with it.  Mutating either side after the call (data
+ * appends, schema upgrades, retraction, consolidation) leaves the other
+ * untouched.  This is the K-Fusion isolation primitive: callers that
+ * need to fork a relation across worker boundaries should use this in
+ * preference to col_rel_new_like + replay.
  *
- * NOTE: This commit ships the scaffold (Issue #553 Commit 1) covering
- * Groups H, I, J and the scalar bookkeeping fields.  Subsequent commits
- * land Groups A/B (columns + schema + names), C (timestamps), D+F
- * (merge buffer + run tracking), E (retract backup), and G (compound
- * metadata).  At this stage callers may only deep-copy 0x0 relations.
+ * Field-group taxonomy (per #553 body):
+ *   - Groups A/B: columns, col_names, ArrowSchema -- deep copied.  The
+ *     ArrowSchema is rebuilt via the same manual reinit used by
+ *     col_rel_set_schema (ArrowSchemaInit + ArrowSchemaSetTypeStruct +
+ *     per-child ArrowSchemaInitFromType + ArrowSchemaSetName).  The
+ *     schema struct is NEVER bit-copied because the release callback /
+ *     private_data would alias and trigger a double-release on destroy.
+ *   - Group C: timestamps array sized to capacity (not nrows).
+ *   - Group D: persistent merge buffer sized to merge_buf_cap.
+ *   - Group E: retraction backup defensively deep-copied if populated.
+ *   - Group F: run_count + run_ends fixed array memcpy'd.
+ *   - Group G: compound_arity_map cloned via col_rel_clone_compound_meta;
+ *     corrupt arity maps degrade dst to NONE-kind (matches new_like).
+ *   - Group H: has_graph_column, graph_col_idx direct copy.
+ *   - Group I: pool_owned, arena_owned, mem_ledger always reset.
+ *   - Group J: dedup_*, col_shared, row_scratch always reset; any cache
+ *     state will be rebuilt lazily on demand.
+ *
+ * @param src    Relation to clone.  Must be non-NULL.  May carry inline
+ *               compound metadata, sharing flags, retraction backup,
+ *               etc.; the function reads through src->columns even when
+ *               col_shared[c] is true (borrowed-readable contract).
+ * @param out    Out-parameter for the heap-allocated copy.  Must be
+ *               non-NULL.  On any failure *out is left as NULL.
+ * @param arena  Reserved.  Currently ignored -- the deep copy always
+ *               heap-owns its buffers so subsequent col_rel_destroy on
+ *               the result is correct without an arena reference.
+ *               Accepted to match the FROZEN signature in the issue
+ *               body and reserve room for an arena-aware variant.
+ *
+ * @retval 0       Success; @p *out points at the newly allocated copy.
+ * @retval EINVAL  src or out was NULL.
+ * @retval ENOMEM  Allocation of dst, name, columns, col_names, schema,
+ *                 timestamps, merge buffer, or retraction backup
+ *                 failed.  Partial state is unwound via
+ *                 col_rel_free_contents + free(dst); calloc-zero-init
+ *                 makes that safe at any unwind point.
+ *
+ * @note The result inherits no pool/arena/ledger affiliation from
+ *       @p src.  Callers that need ledger accounting on the copy must
+ *       wire up dst->mem_ledger themselves.
  */
 int
 col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -994,6 +994,74 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
     return r;
 }
 
+/* ---- deep copy ----------------------------------------------------------- */
+
+/*
+ * col_rel_deep_copy (Issue #553):
+ * Produce a fully-owned deep copy of `src`.  See the contract in
+ * wirelog/columnar/internal.h next to the declaration.
+ *
+ * Implementation strategy: zero-allocate `dst` with calloc so that
+ * col_rel_free_contents is safe to call at any unwind point.  All Group
+ * I/J fields (pool/arena ownership, ledgers, caches, sharing) start at
+ * their zero defaults and are NEVER inherited from src.
+ *
+ * NOTE: This commit ships the scaffold (Issue #553 Commit 1) covering
+ * Groups H, I, J and the scalar bookkeeping fields.  Subsequent commits
+ * land Groups A/B (columns + schema + names), C (timestamps), D+F
+ * (merge buffer + run tracking), E (retract backup), and G (compound
+ * metadata).  At this stage callers may only deep-copy 0x0 relations.
+ */
+int
+col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
+{
+    (void)arena; /* reserved; see contract block in internal.h */
+    if (!src || !out)
+        return EINVAL;
+    *out = NULL;
+
+    col_rel_t *dst = (col_rel_t *)calloc(1, sizeof(*dst));
+    if (!dst)
+        return ENOMEM;
+
+    /* Name: deep-copy the optional null-terminated owned string. */
+    if (src->name) {
+        dst->name = wl_strdup(src->name);
+        if (!dst->name) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+    }
+
+    /* Scalar bookkeeping (Groups A scalars + D scalars). */
+    dst->ncols = src->ncols;
+    dst->nrows = src->nrows;
+    dst->capacity = src->capacity;
+    dst->sorted_nrows = src->sorted_nrows;
+    dst->base_nrows = src->base_nrows;
+
+    /* Group H: graph-column metadata (Issue #535). */
+    dst->has_graph_column = src->has_graph_column;
+    dst->graph_col_idx = src->graph_col_idx;
+
+    /*
+     * Group I (pool_owned, arena_owned, mem_ledger): always reset.  The
+     * copy is heap-allocated and never participates in pool/arena/ledger
+     * accounting -- callers that need those must wire them up explicitly.
+     *
+     * Group J (dedup_slots/cap/count, col_shared, row_scratch): always
+     * reset.  The dedup hash table and row scratch are caches that will
+     * be rebuilt lazily; col_shared is unconditionally cleared because
+     * deep copies own all of their columns.
+     *
+     * calloc above already zeroed every byte, so no explicit assignment
+     * is required here -- the comment is the contract.
+     */
+    *out = dst;
+    return 0;
+}
+
 /* ---- radix sort ---------------------------------------------------------- */
 
 /*

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1112,6 +1112,39 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
     }
 
     /*
+     * Group D: persistent merge buffer.  When src has a merge buffer
+     * sized to merge_buf_cap rows, allocate the same shape for dst and
+     * memcpy merge_buf_cap entries per column.  The buffer is reused
+     * across consolidation iterations, so any in-flight content is
+     * preserved.  merge_buf_cap is copied unconditionally; sorted_nrows
+     * and base_nrows were already taken in the scalar bookkeeping pass.
+     */
+    dst->merge_buf_cap = src->merge_buf_cap;
+    if (src->merge_columns && src->ncols > 0u && src->merge_buf_cap > 0u) {
+        dst->merge_columns = col_columns_alloc(src->ncols, src->merge_buf_cap);
+        if (!dst->merge_columns) {
+            col_rel_free_contents(dst);
+            free(dst);
+            return ENOMEM;
+        }
+        for (uint32_t c = 0; c < src->ncols; c++) {
+            if (src->merge_columns[c]) {
+                memcpy(dst->merge_columns[c], src->merge_columns[c],
+                    (size_t)src->merge_buf_cap * sizeof(int64_t));
+            }
+        }
+    }
+
+    /*
+     * Group F: tiered run-tracking metadata (Issue #369).  Both fields
+     * are fixed-size POD: a scalar count plus a COL_MAX_RUNS-element
+     * array of run end offsets.  Direct copy (the retract-backup mirror
+     * lands in Group E).
+     */
+    dst->run_count = src->run_count;
+    memcpy(dst->run_ends, src->run_ends, sizeof(src->run_ends));
+
+    /*
      * Group C: timestamps array.  Sized to capacity (not nrows) so that
      * append_row paths after the copy do not need to grow the timestamps
      * buffer in lockstep with the columns buffer.  Skipped when src has


### PR DESCRIPTION
## Summary

Implement `col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)` per the body spec of #553. Produces an independent heap-owned copy of a relation with all 12 field groups (A-J) handled correctly. This is the Phase-0 Foundation primitive that unblocks #559, #560, #567, #569 / the broader rotation effort in #550.

## Atomic-commit decomposition

| # | SHA | Description |
|---|-----|-------------|
| 0 | a9e79ca | refactor: extract `col_rel_clone_compound_meta` helper |
| 1 | b90de43 | feat: scaffold (Groups H, I, J) + scalar invariants + tests |
| 2 | 5b600d2 | feat: Group A+B (columns, schema manual reinit, names) |
| 3 | 0ef3995 | feat: Group C (timestamps) |
| 4 | 3f62c4e | feat: Group D+F (merge buffer, run tracking) |
| 5 | 977ee6d | feat: Group E (retraction backup, defensive) |
| 6 | 7dd2086 | feat: Group G (compound metadata via helper) |
| 7 | 76420dd | docs: contract + large-buffer test |

Every commit compiles standalone and passes `meson test -C build`.

## Acceptance criteria coverage (from #553 body)

- Function compiles without errors/warnings — verified
- All 12 field groups (A-J) correctly copied/set/reset — verified
- Error handling: NULL src/out -> EINVAL — verified
- 17 unit tests in `tests/test_col_rel_deep_copy.c`: NULL guards, empty 0x0, design invariants, columns/names/schema/timestamps/merge/run/retract/compound round-trips, modify-copy-verify-source isolation, destroy-source-copy-still-valid, 5M-row x 1-col stress (~40 MB)
- Buffers independent (modify copy, source unchanged) — verified
- All existing tests pass — `meson test -C build`: 157 OK, 0 Fail, 1 Skipped
- ASan: Verified clean via b_sanitize=address rebuild on test_col_rel_deep_copy (1/1 OK, exit=0)

## Intentional spec deviations (acknowledged in commit messages and code docs)

1. **Return codes use errno-style** (`0` / `EINVAL` / `ENOMEM`) instead of `WL_OK` / `WL_ERROR_INVALID_ARGUMENT` / `WL_ERROR_MEMORY` — those macros do not exist in this tree. Matches the convention in `col_rel_alloc` (relation.c:240) and `col_rel_set_schema` (relation.c:178, 219).
2. **`arena` parameter is reserved** (`(void)arena`) — the FROZEN signature from the issue body is honored, but the implementation always heap-allocates. Documented in `internal.h:1180-1200` and the doxygen block at `relation.c:998-1040`. Leaves room for an arena-aware variant later.
3. **Group G corrupt arity_map degrades to NONE-kind** rather than failing the whole copy. Mirrors the documented `col_rel_new_like` graceful-degrade contract (`relation.c:863-869`), so callers see one consistent failure mode rather than two.

## Implementation notes worth flagging

- **Schema is manually reinitialized**, NOT memcpy'd and NOT via `ArrowSchemaDeepCopy` (which does not exist in this nanoarrow build). Mirrors `col_rel_set_schema:215-231`. Avoids the release-callback aliasing hazard on a struct copy.
- **`col_shared` source columns** are read through normally (borrowed pointers are readable); the copy unconditionally produces an unshared, fully heap-owned set of columns and `dst->col_shared = NULL`.
- **Failure unwind is uniform** — `dst = calloc(1, sizeof(*dst))` then any error path goes through `col_rel_free_contents(dst); free(dst); *out = NULL;` — zero-init guarantees free is safe at every partial-allocation point.
- The 12-group taxonomy (A-J) is the correct read of the body's spec — the body's 6-field pseudocode would alias the schema release callback and leak `merge_columns`, `retract_backup_columns`, `compound_arity_map`, and `timestamps`. The expanded interpretation lines up with what downstream rotation/remap users (#569/#570) actually need.

## Test plan

- [x] `meson compile -C build` clean (zero warnings)
- [x] `meson test -C build` (157 OK / 0 Fail / 1 Skipped — pre-existing skip unrelated)
- [x] `meson test -C build test_col_rel_deep_copy` (17/17 PASS)
- [x] `meson test -C build --suite asan` (1/1 OK — repo's allocator-stress lane)
- [x] `b_sanitize=address` rebuild + run of `test_col_rel_deep_copy`: 1/1 OK, exit=0
- [x] No Co-Authored-By / no emojis in any commit
- [x] Atomic commit hygiene — each commit compiles + tests green standalone (mid-stack spot check + full sequence verified)

Closes #553.