### PR TITLE
feat(#554): mem_ledger=NULL policy for transient deep copies

### DIFF
--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -714,6 +714,83 @@ cleanup:
 }
 
 /* ======================================================================== */
+/* mem_ledger=NULL transient-copy policy (Issue #554, R-1)                  */
+/* ======================================================================== */
+
+static void
+test_deep_copy_mem_ledger_null(void)
+{
+    /* Issue #554 finalises the policy that deep copies are TRANSIENT
+     * relations: dst->mem_ledger is unconditionally NULL even when src
+     * is wired up to a real ledger.  This test installs a real ledger
+     * on src, snapshots its counters, deep-copies, and verifies:
+     *   1. dst->mem_ledger == NULL (R-1 contract).
+     *   2. src->mem_ledger counters are unchanged by the copy itself
+     *      (deep_copy must not report allocs to src's ledger). */
+    TEST("Issue #554: deep copy is transient -> dst->mem_ledger == NULL");
+    col_rel_t *src = build_populated("ledger_src", 4u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 0u /* unlimited */);
+    /* Stamp a baseline allocation that mimics what the surrounding
+     * pipeline would have charged for src's data buffer.  We can then
+     * observe whether deep_copy perturbs the ledger. */
+    const uint64_t baseline_bytes = 1024u;
+    wl_mem_ledger_alloc(&ledger, WL_MEM_SUBSYS_RELATION, baseline_bytes);
+    src->mem_ledger = &ledger;
+
+    /* Snapshot counters before the deep copy. */
+    uint64_t before_total = atomic_load_explicit(&ledger.current_bytes,
+            memory_order_relaxed);
+    uint64_t before_relation = atomic_load_explicit(
+        &ledger.subsys_bytes[WL_MEM_SUBSYS_RELATION], memory_order_relaxed);
+    uint64_t before_peak = atomic_load_explicit(&ledger.peak_bytes,
+            memory_order_relaxed);
+    ASSERT(before_total == baseline_bytes, "ledger baseline total wrong");
+    ASSERT(before_relation == baseline_bytes,
+        "ledger baseline relation wrong");
+
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "deep-copy failed");
+
+    /* Acceptance criterion 1: dst is transient -> ledger NULL. */
+    ASSERT(dst->mem_ledger == NULL,
+        "transient copy must have mem_ledger == NULL (R-1)");
+
+    /* Acceptance criterion 2: source ledger counters unchanged. */
+    uint64_t after_total = atomic_load_explicit(&ledger.current_bytes,
+            memory_order_relaxed);
+    uint64_t after_relation = atomic_load_explicit(
+        &ledger.subsys_bytes[WL_MEM_SUBSYS_RELATION], memory_order_relaxed);
+    uint64_t after_peak = atomic_load_explicit(&ledger.peak_bytes,
+            memory_order_relaxed);
+    ASSERT(after_total == before_total,
+        "deep_copy perturbed src->mem_ledger total");
+    ASSERT(after_relation == before_relation,
+        "deep_copy perturbed src->mem_ledger RELATION subsys");
+    ASSERT(after_peak == before_peak,
+        "deep_copy perturbed src->mem_ledger peak");
+
+    /* Source still references the ledger; src->mem_ledger is read-only
+     * input from deep_copy's perspective. */
+    ASSERT(src->mem_ledger == &ledger, "src->mem_ledger lost");
+
+    /* Detach the ledger before destroy so col_rel_free_contents does
+     * not double-account against our local stack ledger when it
+     * unwinds the columns buffer. */
+    src->mem_ledger = NULL;
+
+    PASS();
+cleanup:
+    if (src)
+        src->mem_ledger = NULL;
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+/* ======================================================================== */
 /* Large-buffer integration (Issue #553 Commit 7)                           */
 /* ======================================================================== */
 
@@ -793,6 +870,7 @@ main(void)
     test_retract_backup_copy_when_present();
     test_compound_arity_map_round_trip_inline();
     test_compound_arity_map_corrupt_input_degrades();
+    test_deep_copy_mem_ledger_null();
     test_large_relation_buffers();
 
     printf("\nResults: %d/%d passed, %d failed\n",

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1025,6 +1025,18 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
  *   - Group J: dedup_*, col_shared, row_scratch always reset; any cache
  *     state will be rebuilt lazily on demand.
  *
+ * Memory-ledger policy (Issue #554, design rule R-1):
+ *   The deep copy is treated as a TRANSIENT relation.  dst->mem_ledger
+ *   is unconditionally set to NULL regardless of whether src is wired
+ *   up to a ledger.  Rationale: a deep copy is a short-lived workspace
+ *   relation (K-Fusion fork point, retraction backup, debug snapshot)
+ *   whose buffer growth and free events must NOT charge against the
+ *   originating session's RELATION subsystem budget.  If a deep copy
+ *   is later promoted into a long-lived role, the caller may wire up
+ *   dst->mem_ledger explicitly post-copy and the ledger will pick up
+ *   subsequent realloc/free events from there on.  Source ledger
+ *   counters are likewise never touched by this function.
+ *
  * @param src    Relation to clone.  Must be non-NULL.  May carry inline
  *               compound metadata, sharing flags, retraction backup,
  *               etc.; the function reads through src->columns even when
@@ -1086,6 +1098,13 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
      * Group I (pool_owned, arena_owned, mem_ledger): always reset.  The
      * copy is heap-allocated and never participates in pool/arena/ledger
      * accounting -- callers that need those must wire them up explicitly.
+     *
+     * mem_ledger policy (Issue #554, R-1):
+     *   The deep copy is a TRANSIENT relation: dst->mem_ledger stays NULL
+     *   so its buffer realloc/free events never charge the source
+     *   session's RELATION subsystem budget.  Source ledger counters are
+     *   never touched by this function (we only read src's columns and
+     *   metadata; no allocations are reported to src->mem_ledger).
      *
      * Group J (dedup_slots/cap/count, col_shared, row_scratch): always
      * reset.  The dedup hash table and row scratch are caches that will


### PR DESCRIPTION
## Summary

Stacked on #601 (feat/553-col-rel-deep-copy). Finalises Issue #554 by codifying the R-1 design rule that **deep copies are TRANSIENT relations** and unconditionally carry `mem_ledger == NULL`.

The mechanism already shipped with #553 (Group I in `col_rel_deep_copy` clears `mem_ledger` via the calloc-zero path); this PR adds the explicit contract documentation and a dedicated regression test that exercises the policy end-to-end against a real `wl_mem_ledger_t`.

- **Doxygen contract** on `col_rel_deep_copy` gains a dedicated *Memory-ledger policy* paragraph spelling out the rule, the rationale (a transient deep copy must not inflate the originating session's RELATION subsystem budget), and the post-copy upgrade path for callers that promote a copy to long-lived status.
- **Inline implementation comment** in the Group I block calls out the same R-1 reference and the additional guarantee that *source* ledger counters are never touched (`col_rel_deep_copy` only reads through `src->*` and never reports allocations to `src->mem_ledger`).
- **`test_deep_copy_mem_ledger_null`** in `tests/test_col_rel_deep_copy.c`:
  1. Builds a 3x4 relation, attaches a real `wl_mem_ledger_t` with a 1024-byte RELATION-subsystem baseline.
  2. Snapshots `current_bytes`, `subsys_bytes[RELATION]`, and `peak_bytes`.
  3. Calls `col_rel_deep_copy`.
  4. Asserts `dst->mem_ledger == NULL` (R-1 contract).
  5. Asserts every snapshotted counter is unchanged after the copy.
  6. Asserts `src->mem_ledger` still references the original ledger pointer (read-only input contract).

## Stacking note

This PR's base branch is `feat/553-col-rel-deep-copy`, not `main`. Once #601 merges to main, GitHub will auto-rebase the base of this PR. Reviewers comparing diffs should select #553 as the base to see only the #554 delta (1 commit, ~97 lines).

## Test plan

- [x] `meson compile -C build` clean
- [x] `meson test -C build` -> 157 OK / 0 Fail / 1 Skipped
- [x] `meson test -C build col_rel_deep_copy` -> 18/18 PASS (incl. the new `test_deep_copy_mem_ledger_null`)
- [ ] CI green on stacked branch

Closes #554