### PR TITLE
feat(#558): Add WL_LOG ARENA observability for arena operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,15 @@ See `docs/ARCHITECTURE.md` for design details and `AGENTS.md` for agent-specific
 
 `WL_LOG` is the canonical structured-logger surface. Syntax
 `WL_LOG=SECTION:LEVEL[,...]`; sections include `JOIN`, `CONSOLIDATION`,
-`ARRANGEMENT`, `EVAL`, `SESSION`, `IO`, `PARSER`, `PLUGIN`, `GENERAL`;
-levels are `0..5` (NONE/ERROR/WARN/INFO/DEBUG/TRACE). `*` is a
-wildcard; later entries override earlier ones. Examples:
+`ARRANGEMENT`, `EVAL`, `SESSION`, `IO`, `PARSER`, `PLUGIN`, `COMPOUND`,
+`ARENA`, `GENERAL`; levels are `0..5` (NONE/ERROR/WARN/INFO/DEBUG/TRACE).
+`*` is a wildcard; later entries override earlier ones. Examples:
 
 ```
 WL_LOG=JOIN:4 ./app
 WL_LOG=*:2,JOIN:5 WL_LOG_FILE=/tmp/wl.log ./app
+WL_LOG=ARENA:4 ./app           # DEBUG-level arena allocator events
+WL_LOG=*:2,ARENA:5 ./app       # WARN baseline + TRACE for arena only
 ```
 
 Release builds should pass `-Dwirelog_log_max_level=error` so the

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2300,6 +2300,24 @@ test_compound_logging_exe = executable(
 test('compound_logging', test_compound_logging_exe, suite: 'log')
 
 # ============================================================================
+# Arena observability (Issue #558)
+# ============================================================================
+
+test_arena_observability_exe = executable(
+  'test_arena_observability',
+  files('test_arena_observability.c'),
+  arena_src,
+  files('../wirelog/arena/compound_arena.c'),
+  files(
+    '../wirelog/util/log.c',
+    '../wirelog/util/log_emit.c',
+  ),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+
+test('arena_observability', test_arena_observability_exe, suite: 'log')
+
+# ============================================================================
 # Inline-tier integration battery (Issue #532 Task 5)
 # ============================================================================
 

--- a/tests/test_arena_observability.c
+++ b/tests/test_arena_observability.c
@@ -1,0 +1,324 @@
+/*
+ * tests/test_arena_observability.c - WL_LOG ARENA observability (Issue #558).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives the ARENA section of the structured logger end-to-end. Each test
+ * configures WL_LOG with a section-specific level for ARENA, routes output
+ * to a tmpfile via WL_LOG_FILE, exercises the relevant arena entry points,
+ * and asserts the emitted text shape.
+ *
+ *   test_arena_alloc_reset_logged    -- DEBUG-level alloc + INFO-level reset
+ *                                       lines appear with size/capacity tags.
+ *   test_arena_free_warn_when_used   -- free() with outstanding bytes emits
+ *                                       a WARN line.
+ *   test_compound_arena_gc_logged    -- gc_epoch_boundary INFO line carries
+ *                                       epoch + freed_handles + remaining;
+ *                                       handle_alloc TRACE line is present
+ *                                       at TRACE level.
+ *   test_observability_gates         -- WL_LOG unset => zero output.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "../wirelog/arena/arena.h"
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/util/log.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#  include <process.h>
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#  define getpid   _getpid
+#else
+#  include <unistd.h>
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+static char tmp_path_[256];
+
+static const char *
+tmpdir_(void)
+{
+    const char *d = getenv("TMPDIR");
+    if (d && *d) return d;
+#if defined(_WIN32)
+    d = getenv("TEMP");
+    if (d && *d) return d;
+    d = getenv("TMP");
+    if (d && *d) return d;
+    return ".";
+#else
+    return "/tmp";
+#endif
+}
+
+static void
+make_tmpfile_(const char *tag)
+{
+    const char *d = tmpdir_();
+#if defined(_WIN32)
+    const char sep = '\\';
+#else
+    const char sep = '/';
+#endif
+    snprintf(tmp_path_, sizeof(tmp_path_),
+        "%s%cwl_arena_obs_%s_%ld_%ld.log",
+        d, sep, tag, (long)getpid(), (long)time(NULL));
+    (void)remove(tmp_path_);
+}
+
+static size_t
+read_file_(const char *path, char *buf, size_t bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    size_t n = fread(buf, 1, bufsz - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    return n;
+}
+
+static void
+clear_env_(void)
+{
+    unsetenv("WL_LOG");
+    unsetenv("WL_LOG_FILE");
+    unsetenv("WL_DEBUG_JOIN");
+    unsetenv("WL_CONSOLIDATION_LOG");
+}
+
+static void
+test_arena_alloc_reset_logged(void)
+{
+    TEST("arena: alloc(DEBUG) + reset(INFO) lines emitted at ARENA:4");
+    wl_arena_t *arena = NULL;
+
+    clear_env_();
+    make_tmpfile_("alloc");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "ARENA:4", 1);
+    wl_log_init();
+
+    arena = wl_arena_create(1024);
+    ASSERT(arena != NULL, "arena_create failed");
+
+    void *p = wl_arena_alloc(arena, 64);
+    ASSERT(p != NULL, "alloc failed");
+
+    wl_arena_reset(arena);
+    wl_arena_free(arena);
+    arena = NULL;
+
+    wl_log_shutdown();
+
+    char buf[2048] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[DEBUG][ARENA]") != NULL,
+        "missing [DEBUG][ARENA] alloc line");
+    ASSERT(strstr(buf, "alloc(size=64") != NULL,
+        "missing alloc size tag");
+    ASSERT(strstr(buf, "capacity=1024") != NULL,
+        "missing capacity tag");
+    ASSERT(strstr(buf, "[INFO][ARENA]") != NULL,
+        "missing [INFO][ARENA] reset line");
+    ASSERT(strstr(buf, "reset(used=") != NULL,
+        "missing reset(used=...) tag");
+
+    PASS();
+cleanup:
+    if (arena) wl_arena_free(arena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_arena_free_warn_when_used(void)
+{
+    TEST("arena: free() with outstanding bytes emits WARN");
+    wl_arena_t *arena = NULL;
+
+    clear_env_();
+    make_tmpfile_("freewarn");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "ARENA:2", 1);
+    wl_log_init();
+
+    arena = wl_arena_create(512);
+    ASSERT(arena != NULL, "arena_create failed");
+
+    void *p = wl_arena_alloc(arena, 32);
+    ASSERT(p != NULL, "alloc failed");
+
+    wl_arena_free(arena);
+    arena = NULL;
+
+    wl_log_shutdown();
+
+    char buf[1024] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[WARN][ARENA]") != NULL,
+        "missing [WARN][ARENA] prefix");
+    ASSERT(strstr(buf, "still allocated") != NULL,
+        "missing 'still allocated' tag");
+    /* DEBUG alloc must NOT appear under ARENA:2 (WARN ceiling). */
+    ASSERT(strstr(buf, "[DEBUG][ARENA]") == NULL,
+        "DEBUG line leaked past WARN ceiling");
+
+    PASS();
+cleanup:
+    if (arena) wl_arena_free(arena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_compound_arena_gc_logged(void)
+{
+    TEST("compound arena: gc_epoch_boundary INFO + handle_alloc TRACE");
+    wl_compound_arena_t *carena = NULL;
+
+    clear_env_();
+    make_tmpfile_("gc");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "ARENA:5", 1);
+    wl_log_init();
+
+    carena = wl_compound_arena_create(0x12345u, 256u, 8u);
+    ASSERT(carena != NULL, "compound_arena_create failed");
+
+    uint64_t h1 = wl_compound_arena_alloc(carena, 16);
+    uint64_t h2 = wl_compound_arena_alloc(carena, 24);
+    ASSERT(h1 != 0u && h2 != 0u, "compound alloc failed");
+
+    /* Drop one to zero so gc reports a freed handle. */
+    ASSERT(wl_compound_arena_retain(carena, h2, -1) == 0, "retain failed");
+
+    uint32_t reclaimed = wl_compound_arena_gc_epoch_boundary(carena);
+    ASSERT(reclaimed >= 1u, "gc reported no reclaimed handles");
+
+    wl_compound_arena_free(carena);
+    carena = NULL;
+
+    wl_log_shutdown();
+
+    char buf[4096] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[TRACE][ARENA]") != NULL,
+        "missing [TRACE][ARENA] handle_alloc line");
+    ASSERT(strstr(buf, "handle_alloc(epoch=") != NULL,
+        "missing handle_alloc tag");
+    ASSERT(strstr(buf, "[INFO][ARENA]") != NULL,
+        "missing [INFO][ARENA] gc line");
+    ASSERT(strstr(buf, "gc_epoch_boundary(epoch=") != NULL,
+        "missing gc_epoch_boundary tag");
+    ASSERT(strstr(buf, "freed_handles=") != NULL,
+        "missing freed_handles tag");
+    ASSERT(strstr(buf, "remaining=") != NULL,
+        "missing remaining tag");
+
+    PASS();
+cleanup:
+    if (carena) wl_compound_arena_free(carena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_observability_gates(void)
+{
+    TEST("observability: WL_LOG unset -> ARENA silent");
+    wl_arena_t *arena = NULL;
+
+    clear_env_();
+    make_tmpfile_("gate_off");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    wl_log_init();
+
+    arena = wl_arena_create(512);
+    ASSERT(arena != NULL, "arena_create failed");
+    (void)wl_arena_alloc(arena, 8);
+    wl_arena_reset(arena);
+    /* Free with zero outstanding bytes — no WARN to emit either. */
+    wl_arena_free(arena);
+    arena = NULL;
+
+    wl_log_shutdown();
+
+    char buf[512] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n == 0, "ARENA emitted output with WL_LOG unset");
+
+    PASS();
+cleanup:
+    if (arena) wl_arena_free(arena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+int
+main(void)
+{
+    printf("test_arena_observability (Issue #558)\n");
+    printf("=====================================\n");
+
+    test_arena_alloc_reset_logged();
+    test_arena_free_warn_when_used();
+    test_compound_arena_gc_logged();
+    test_observability_gates();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/arena/arena.c
+++ b/wirelog/arena/arena.c
@@ -8,6 +8,8 @@
 
 #include "arena.h"
 
+#include "wirelog/util/log.h"
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -16,7 +18,7 @@
 
 /* Round @n up to the next multiple of WL_ARENA_ALIGN. */
 #define WL_ARENA_ALIGN_UP(n) \
-    (((n) + (WL_ARENA_ALIGN - 1)) & ~(size_t)(WL_ARENA_ALIGN - 1))
+        (((n) + (WL_ARENA_ALIGN - 1)) & ~(size_t)(WL_ARENA_ALIGN - 1))
 
 wl_arena_t *
 wl_arena_create(size_t capacity)
@@ -51,6 +53,9 @@ wl_arena_alloc(wl_arena_t *arena, size_t size)
 
     void *ptr = (char *)arena->base + arena->used;
     arena->used += aligned;
+    WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_DEBUG,
+        "alloc(size=%zu, new_offset=%zu, capacity=%zu)",
+        size, arena->used, arena->capacity);
     return ptr;
 }
 
@@ -59,6 +64,9 @@ wl_arena_reset(wl_arena_t *arena)
 {
     if (!arena)
         return;
+    WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_INFO,
+        "reset(used=%zu -> 0, capacity=%zu)",
+        arena->used, arena->capacity);
     arena->used = 0;
 }
 
@@ -67,6 +75,11 @@ wl_arena_free(wl_arena_t *arena)
 {
     if (!arena)
         return;
+    if (arena->used > 0) {
+        WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_WARN,
+            "free() with %zu bytes still allocated",
+            arena->used);
+    }
     free(arena->base);
     free(arena);
 }

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -16,6 +16,7 @@
 
 #include "wirelog/util/log.h"
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -182,8 +183,8 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
     uint64_t handle = wl_compound_handle_pack(arena->session_seed,
             arena->current_epoch, offset);
     WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_TRACE,
-        "handle_alloc(epoch=%u, offset=%u, packed=0x%lx)",
-        arena->current_epoch, offset, (unsigned long)handle);
+        "handle_alloc(epoch=%u, offset=%u, packed=0x%" PRIx64 ")",
+        arena->current_epoch, offset, handle);
     return handle;
 }
 
@@ -319,8 +320,8 @@ wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
     else
         arena->current_epoch = arena->max_epochs; /* sentinel: saturated */
     WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_INFO,
-        "gc_epoch_boundary(epoch=%u, freed_handles=%u, remaining=%lu)",
-        closed_epoch, reclaimed, (unsigned long)arena->live_handles);
+        "gc_epoch_boundary(epoch=%u, freed_handles=%u, remaining=%" PRIu64 ")",
+        closed_epoch, reclaimed, arena->live_handles);
     if (arena->current_epoch + 5u >= arena->max_epochs) {
         WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_WARN,
             "epoch nearing saturation (current=%u, max=%u)",

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -14,6 +14,8 @@
 
 #include "compound_arena.h"
 
+#include "wirelog/util/log.h"
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -177,8 +179,12 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
     gen->used = offset + aligned;
 
     arena->live_handles++;
-    return wl_compound_handle_pack(arena->session_seed, arena->current_epoch,
-               offset);
+    uint64_t handle = wl_compound_handle_pack(arena->session_seed,
+            arena->current_epoch, offset);
+    WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_TRACE,
+        "handle_alloc(epoch=%u, offset=%u, packed=0x%lx)",
+        arena->current_epoch, offset, (unsigned long)handle);
+    return handle;
 }
 
 /* Internal: locate the entry slot for a handle.  Returns the entry index or
@@ -305,11 +311,20 @@ wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
     /* Reset generation for reuse. */
     gen->used = 0;
     gen->entry_count = 0;
+    uint32_t closed_epoch = arena->current_epoch;
     /* Advance epoch if room; otherwise the arena saturates and alloc will
      * refuse further allocations (callers rotate arenas). */
     if (arena->current_epoch + 1 < arena->max_epochs)
         arena->current_epoch++;
     else
         arena->current_epoch = arena->max_epochs; /* sentinel: saturated */
+    WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_INFO,
+        "gc_epoch_boundary(epoch=%u, freed_handles=%u, remaining=%lu)",
+        closed_epoch, reclaimed, (unsigned long)arena->live_handles);
+    if (arena->current_epoch + 5u >= arena->max_epochs) {
+        WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_WARN,
+            "epoch nearing saturation (current=%u, max=%u)",
+            arena->current_epoch, arena->max_epochs);
+    }
     return reclaimed;
 }

--- a/wirelog/util/log.c
+++ b/wirelog/util/log.c
@@ -38,6 +38,7 @@ static const char *const wl_log_section_names_[WL_LOG_SEC__COUNT] = {
     [WL_LOG_SEC_PARSER] = "PARSER",
     [WL_LOG_SEC_PLUGIN] = "PLUGIN",
     [WL_LOG_SEC_COMPOUND] = "COMPOUND",
+    [WL_LOG_SEC_ARENA] = "ARENA",
 };
 
 const char *

--- a/wirelog/util/log.h
+++ b/wirelog/util/log.h
@@ -74,6 +74,7 @@ typedef enum {
     WL_LOG_SEC_PARSER,
     WL_LOG_SEC_PLUGIN,
     WL_LOG_SEC_COMPOUND,
+    WL_LOG_SEC_ARENA,
     WL_LOG_SEC__COUNT
 } wl_log_section_t;
 


### PR DESCRIPTION
## Summary

**Issue #558** — Add WL_LOG ARENA observability for arena operations.

This PR introduces structured logging for arena allocator operations, enabling visibility into allocation patterns, garbage collection behavior, and epoch saturation during rotation.

### Deliverables

1. **WL_LOG ARENA Section** (wirelog/util/log.h, log.c)
   - New section: `WL_LOG_SEC_ARENA` for arena operations
   - Integrated into section registry and gating system

2. **Arena Logging** (wirelog/arena/arena.c)
   - DEBUG: `alloc(size, new_offset, capacity)`
   - INFO: `reset(used bytes → 0, capacity)`
   - WARN: `free() with outstanding allocations` (only when used > 0)

3. **Compound Arena Logging** (wirelog/arena/compound_arena.c)
   - TRACE: `handle_alloc(epoch, offset, packed handle)`
   - INFO: `gc_epoch_boundary(epoch, freed_handles, remaining)`
   - WARN: `epoch nearing saturation(current, max)` when within 5 epochs of max

4. **Tests** (tests/test_arena_observability.c)
   - TDD harness with 4 tests
   - Verifies DEBUG/INFO/WARN levels and filtering
   - Validates format and presence of key fields
   - Tests WL_LOG unset behavior

5. **Documentation** (CLAUDE.md)
   - Updated WL_LOG section list
   - ARENA usage examples

### Verification

✅ Compile-erasure: TRACE/DEBUG sites stripped under `-Dwirelog_log_max_level=error`  
✅ Non-invasive: Fire-and-forget logging, no allocator behavior changes  
✅ Portability: PRIx64/PRIu64 macros for Windows LLP64 compatibility  
✅ Tests: 7/7 log suite OK, 3/3 abi suite OK, e2e_asan clean  
✅ CLAUDE.md: No Co-Authored-By, no emojis  

### Code Review

**Status:** APPROVED-WITH-MINOR (by code-reviewer)

**Strengths:**
- Log level taxonomy well-calibrated (DEBUG/INFO/WARN/TRACE)
- Saturation logic scalable (`current_epoch + 5 >= max_epochs`)
- Truly fire-and-forget implementation
- Negative test coverage (verifies level-gating)

### Timeline

- Phase 0 observability: **0.5 days** ✅ COMPLETE
- Atomic commits: feat + fix for portability
- Ready for Phase 1 integration

### Commits

1. **af00236** — feat(#558): Add WL_LOG ARENA observability for arena operations
   - ARENA section, logging sites, TDD tests, documentation

2. **b13993f** — fix(#558): Use PRIx64/PRIu64 for Windows LLP64 portability
   - Replace (unsigned long) casts with inttypes.h macros

Closes #558