### PR TITLE
feat(#559): add compound_arena field to wl_col_session_t

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -60,6 +60,7 @@ bench_io_src = files(
 
 bench_arena_src = files(
   subdir_wirelog / 'arena/arena.c',
+  subdir_wirelog / 'arena/compound_arena.c',
 )
 
 bench_workqueue_src = files(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -383,6 +383,7 @@ backend_src = files(
 
 arena_src = files(
   '../wirelog/arena/arena.c',
+  '../wirelog/arena/compound_arena.c',
 )
 
 workqueue_src = files(
@@ -1812,6 +1813,28 @@ test_session_exe = executable(
 test('session', test_session_exe)
 
 # ============================================================================
+# Session Compound Arena Lifecycle (Issue #559) - Phase 0 gateway
+# ============================================================================
+
+test_session_compound_arena_lifecycle_exe = executable(
+  'test_session_compound_arena_lifecycle',
+  files('test_session_compound_arena_lifecycle.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('session_compound_arena_lifecycle',
+     test_session_compound_arena_lifecycle_exe)
+
+# ============================================================================
 # Recursive Aggregation Plan Tests - DISABLED in Phase 2C
 # ============================================================================
 #
@@ -2433,7 +2456,6 @@ test_e2e_asan_side_relation_nested_exe = executable(
   backend_src,
   intern_src,
   arena_src,
-  files('../wirelog/arena/compound_arena.c'),
   thread_src,
   workqueue_src,
   include_directories: [wirelog_inc, wirelog_src_inc],

--- a/tests/test_session_compound_arena_lifecycle.c
+++ b/tests/test_session_compound_arena_lifecycle.c
@@ -1,0 +1,148 @@
+/*
+ * test_session_compound_arena_lifecycle.c - Issue #559 lifecycle gateway test
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Verifies that wl_col_session_t owns a heap-allocated wl_compound_arena_t
+ * across its lifecycle:
+ *   - col_session_create allocates the arena (sess->compound_arena != NULL).
+ *   - The arena is usable: a small wl_compound_arena_alloc returns a non-NULL
+ *     handle that round-trips through the 20-bit session-seed field.
+ *   - col_session_destroy frees the arena (no leaks under ASan).
+ *
+ * This is the Phase 0 gateway for the side-relation tier; downstream issues
+ * replace the placeholder seed and wire the arena into operator paths.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+            return;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)     \
+        do {                      \
+            if (!(cond)) {        \
+                FAIL(msg);        \
+            }                     \
+        } while (0)
+
+/* ======================================================================== */
+/* Helper: build a minimal columnar plan                                    */
+/* ======================================================================== */
+
+static wl_plan_t *
+build_plan(const char *src)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0)
+        return NULL;
+    return plan;
+}
+
+/* ======================================================================== */
+/* Test                                                                     */
+/* ======================================================================== */
+
+static void
+test_session_compound_arena_lifecycle(void)
+{
+    TEST("session.compound_arena: create -> alloc -> destroy");
+
+    wl_plan_t *plan = build_plan(".decl a(x: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
+    ASSERT(plan != NULL, "could not build plan");
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        FAIL("wl_session_create failed");
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    ASSERT(cs->compound_arena != NULL,
+        "compound_arena not allocated by col_session_create");
+
+    /* Exercise one allocation so we know the arena is wired correctly. */
+    uint64_t handle = wl_compound_arena_alloc(cs->compound_arena, 64u);
+    if (handle == WL_COMPOUND_HANDLE_NULL) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("wl_compound_arena_alloc returned WL_COMPOUND_HANDLE_NULL");
+    }
+
+    /* Session seed propagation: low 20 bits of 0x53455353 ('SESS'). */
+    if (wl_compound_handle_session(handle) != (0x53455353u & 0xFFFFFu)) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("handle session seed does not match placeholder constant");
+    }
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    PASS();
+}
+
+/* ======================================================================== */
+/* main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_session_compound_arena_lifecycle (Issue #559)\n");
+    test_session_compound_arena_lifecycle();
+    printf("\n%d run, %d passed, %d failed\n", tests_run, tests_passed,
+        tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -27,6 +27,7 @@
 #include "util/lockfree_queue.h"
 #include "workqueue.h"
 #include "arena/arena.h"
+#include "arena/compound_arena.h"
 #include "wirelog-types.h"
 
 #include "nanoarrow/nanoarrow.h"
@@ -948,6 +949,15 @@ typedef struct wl_col_session_t {
      * always uses the broadcast delta (which may be >= local partition size).
      * False everywhere else, including retraction paths. */
     bool tdd_subpass_active;
+    /* Side-relation compound arena (Issue #559): heap-allocated session-local
+     * compound-term arena.  Owned by the coordinator; created in
+     * col_session_create and freed in col_session_destroy.  Worker sessions
+     * NULL this pointer in col_worker_session_create so the bitwise copy of
+     * the coordinator never participates in worker cleanup; the arena is
+     * single-threaded and frozen across K-Fusion (see compound_arena.h).
+     * The session_seed passed at create time is a placeholder constant; the
+     * remap-aware seed will land in the rotation work tracked by #586+. */
+    wl_compound_arena_t *compound_arena;
     /* Filtered relation cache (Issue #386): caches apply_right_filter results
      * keyed by (relation_name, filter_expr hash + full content). Prevents
      * redundant O(N) filter scans on each fixpoint iteration when

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -685,6 +685,21 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         sess->arr_cache_limit_bytes = arr_limit;
     }
 
+    /* Issue #559: Side-relation compound arena.  Phase 0 gateway field.
+     * Allocated after the simpler malloc/calloc paths so the dedicated
+     * `oom:` label is the only cleanup site that has to free it.
+     * session_seed=0x53455353u ('SESS') is a placeholder; the remap-aware
+     * seed will be plumbed in when handle rotation lands (#586+).
+     * default_gen_cap=4096 mirrors the smoke-test usage in
+     * tests/test_compound_arena.c; max_epochs=0 selects the library
+     * default (WL_COMPOUND_EPOCH_MAX + 1). */
+    sess->compound_arena = wl_compound_arena_create(0x53455353u, 4096u, 0u);
+    if (!sess->compound_arena)
+        goto oom;
+    WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
+        "event=compound_arena_init seed=0x%08x default_gen_cap=%u",
+        0x53455353u, 4096u);
+
     /* Pre-register EDB relations (ncols determined at first insert) */
     for (uint32_t i = 0; i < plan->edb_count; i++) {
         col_rel_t *r = NULL;
@@ -777,6 +792,7 @@ oom:
     free(sess->rels);
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
+    wl_compound_arena_free(sess->compound_arena); /* NULL-safe (Issue #559) */
     free(sess);
     return ENOMEM;
 }
@@ -863,6 +879,13 @@ col_session_destroy(wl_session_t *session)
             col_rel_destroy(sess->filt_cache[i].filtered);
     }
     free(sess->filt_cache);
+    /* Issue #559: free side-relation compound arena (NULL-safe). */
+    WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
+        "event=compound_arena_destroy live_handles=%llu",
+        sess->compound_arena
+            ? (unsigned long long)sess->compound_arena->live_handles
+            : 0ULL);
+    wl_compound_arena_free(sess->compound_arena);
     free(sess);
 }
 
@@ -920,6 +943,9 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->filt_cache = NULL;
     out_worker->filt_cache_count = 0;
     out_worker->filt_cache_cap = 0;
+    /* Issue #559: compound arena is coordinator-owned; workers must not
+     * inherit the bitwise-copied pointer or they would double-free. */
+    out_worker->compound_arena = NULL;
     memset(&out_worker->mat_cache, 0, sizeof(col_mat_cache_t));
     /* Exchange buffers are owned by coordinator; worker inherits borrowed ptr */
     out_worker->exchange_bufs = NULL;

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -31,7 +31,7 @@ wirelog_optimizer_src = files('passes/fusion.c', 'passes/jpp.c', 'passes/sip.c',
 #Arena Allocator Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_arena_src = files('arena/arena.c', )
+wirelog_arena_src = files('arena/arena.c', 'arena/compound_arena.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Thread Backend Module(Issue #88 - Cross-Platform Threading)


### PR DESCRIPTION
## Summary
- Phase 0 gateway for the side-relation tier: every `wl_col_session_t` now owns a heap-allocated `wl_compound_arena_t`. Allocated in `col_session_create` with placeholder seed `0x53455353` (`'SESS'`) and the default 4096-byte generation capacity; freed in `col_session_destroy`. Workers NULL the field after the bitwise copy in `col_worker_session_create` so coordinator ownership is single.
- Logs `event=compound_arena_init` / `event=compound_arena_destroy` at INFO on `WL_LOG_SEC_SESSION`.
- Wires `arena/compound_arena.c` into `wirelog_arena_src`, `tests/arena_src`, and `bench/bench_arena_src` so every consumer of `session.c` resolves the new symbols.

## Stack
Stacked on top of `feat/556-test-framework` (PR #605). CI fires only when the base is `main`, matching the cadence used for #554/#556.

## Test plan
- [x] `meson compile -C build` clean (no new warnings).
- [x] `meson test -C build session_compound_arena_lifecycle` -> PASS.
- [x] `meson test -C build` -> 158 ok, 0 fail, 1 skipped.

Closes #559.