### PR TITLE
feat(#600): rotation strategy vtable (STANDARD + MVCC stub)

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -45,6 +45,8 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/diff_bridge.c',
   subdir_wirelog / 'columnar/partition.c',
   subdir_wirelog / 'columnar/progress.c',
+  subdir_wirelog / 'columnar/rotation_standard.c',
+  subdir_wirelog / 'columnar/rotation_mvcc.c',
   subdir_wirelog / 'util/lockfree_queue.c',
   subdir_wirelog / 'util/log.c',
   subdir_wirelog / 'util/log_emit.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1815,6 +1815,27 @@ test_session_exe = executable(
 test('session', test_session_exe)
 
 # ============================================================================
+# Rotation Strategy Vtable (Issue #600)
+# ============================================================================
+
+test_rotation_strategy_exe = executable(
+  'test_rotation_strategy',
+  files('test_rotation_strategy.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('rotation_strategy', test_rotation_strategy_exe)
+
+# ============================================================================
 # Session Compound Arena Lifecycle (Issue #559) - Phase 0 gateway
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -375,6 +375,8 @@ backend_src = files(
   '../wirelog/columnar/diff_bridge.c',
   '../wirelog/columnar/partition.c',
   '../wirelog/columnar/progress.c',
+  '../wirelog/columnar/rotation_standard.c',
+  '../wirelog/columnar/rotation_mvcc.c',
   '../wirelog/util/lockfree_queue.c',
   '../wirelog/util/log.c',
   '../wirelog/util/log_emit.c',

--- a/tests/test_arrangement.c
+++ b/tests/test_arrangement.c
@@ -108,6 +108,7 @@ typedef struct {
  * Memory layout (x86-64):
  *   wl_session_t   base          (sizeof(wl_session_t) bytes, offset 0)
  *   const void    *frontier_ops  (8 bytes, Issue #261)
+ *   const void    *rotation_ops  (8 bytes, Issue #600)
  *   const void    *plan          (8 bytes)
  *   void          *intern        (8 bytes, Issue #143)
  *   col_rel_t    **rels          (8 bytes)
@@ -117,6 +118,7 @@ typedef struct {
 typedef struct {
     wl_session_t base;
     const void *frontier_ops;
+    const void *rotation_ops;      /* col_rotation_ops_t *, added Issue #600 */
     const void *plan;
     const void *intern;            /* wl_intern_t *, added Issue #143 */
     test_col_rel_mirror_t **rels;

--- a/tests/test_rotation_strategy.c
+++ b/tests/test_rotation_strategy.c
@@ -1,0 +1,242 @@
+/*
+ * tests/test_rotation_strategy.c - Rotation strategy vtable selection (#600).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives col_session_create's rotation_ops selection path:
+ *   test_rotation_default_is_standard   -- WIRELOG_ROTATION unset -> STANDARD
+ *   test_rotation_env_override_mvcc     -- WIRELOG_ROTATION=mvcc -> MVCC
+ *   test_rotation_dispatch_no_crash     -- vtable dispatch is callable on
+ *                                          a live session and does not crash
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "../wirelog/backend.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#  include <process.h>
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#else
+#  include <unistd.h>
+#endif
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+#define ASSERT(cond, msg)   \
+        do {                    \
+            if (!(cond)) {      \
+                FAIL(msg);      \
+                return;         \
+            }                   \
+        } while (0)
+
+/* ======================================================================== */
+/* Plan helper                                                              */
+/* ======================================================================== */
+
+static wl_plan_t *
+build_minimal_plan(void)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(
+        ".decl a(x: int32)\n"
+        ".decl r(x: int32)\n"
+        "r(x) :- a(x).\n",
+        &err);
+    if (!prog)
+        return NULL;
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0)
+        return NULL;
+    return plan;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_rotation_default_is_standard(void)
+{
+    TEST("rotation: default selects STANDARD when WIRELOG_ROTATION unset");
+
+    /* Defensive: ensure the env var is not leaking from another test. */
+    unsetenv("WIRELOG_ROTATION");
+
+    wl_plan_t *plan = build_minimal_plan();
+    ASSERT(plan != NULL, "could not build plan");
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || session == NULL) {
+        wl_plan_free(plan);
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    if (cs->rotation_ops != &col_rotation_standard_ops) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("rotation_ops != &col_rotation_standard_ops");
+        return;
+    }
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    PASS();
+}
+
+static void
+test_rotation_env_override_mvcc(void)
+{
+    TEST("rotation: WIRELOG_ROTATION=mvcc selects MVCC vtable");
+
+    if (setenv("WIRELOG_ROTATION", "mvcc", 1) != 0) {
+        FAIL("setenv WIRELOG_ROTATION=mvcc failed");
+        return;
+    }
+
+    wl_plan_t *plan = build_minimal_plan();
+    if (plan == NULL) {
+        unsetenv("WIRELOG_ROTATION");
+        FAIL("could not build plan");
+        return;
+    }
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || session == NULL) {
+        wl_plan_free(plan);
+        unsetenv("WIRELOG_ROTATION");
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    bool ok = (cs->rotation_ops == &col_rotation_mvcc_ops);
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    unsetenv("WIRELOG_ROTATION");
+
+    if (!ok) {
+        FAIL(
+            "rotation_ops != &col_rotation_mvcc_ops under WIRELOG_ROTATION=mvcc");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_rotation_dispatch_no_crash(void)
+{
+    TEST("rotation: vtable dispatch on live session does not crash");
+
+    unsetenv("WIRELOG_ROTATION");
+
+    wl_plan_t *plan = build_minimal_plan();
+    ASSERT(plan != NULL, "could not build plan");
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || session == NULL) {
+        wl_plan_free(plan);
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    if (cs->rotation_ops == NULL
+        || cs->rotation_ops->rotate_eval_arena == NULL
+        || cs->rotation_ops->gc_epoch_boundary == NULL) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("rotation_ops or required slots are NULL");
+        return;
+    }
+
+    /* Direct dispatch through the vtable; rotate_eval_arena is a NULL-safe
+     * wrapper around wl_arena_reset, gc_epoch_boundary around the compound
+     * arena GC. Either failing here would manifest as a crash/UBSAN abort. */
+    cs->rotation_ops->rotate_eval_arena(cs);
+    cs->rotation_ops->gc_epoch_boundary(cs);
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    PASS();
+}
+
+/* ======================================================================== */
+/* main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("Rotation strategy vtable tests (#600):\n");
+
+    test_rotation_default_is_standard();
+    test_rotation_env_override_mvcc();
+    test_rotation_dispatch_no_crash();
+
+    printf("\nResults: %d run, %d passed, %d failed\n",
+        tests_run, tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -418,7 +418,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
         }
         col_mat_cache_clear(&sess->mat_cache);
         delta_pool_reset(sess->delta_pool);
-        wl_arena_reset(sess->eval_arena);
+        sess->rotation_ops->rotate_eval_arena(sess);
 
         /* Non-recursive stratum frontier: record convergence epoch and iteration.
         * Non-recursive strata always converge at iteration UINT32_MAX (no loop),
@@ -889,7 +889,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
             }
 
             delta_pool_reset(sess->delta_pool);
-            wl_arena_reset(sess->eval_arena);
+            sess->rotation_ops->rotate_eval_arena(sess);
             /* Issue #176: Per-sub-pass cache eviction for recursive strata.
              * Use configurable eviction threshold (cache_evict_threshold):
              * - If 0: clear entire cache each sub-pass (backward compatible)
@@ -974,7 +974,7 @@ stride_error:
     free(snap);
     free(delta_rels);
     delta_pool_reset(sess->delta_pool);
-    wl_arena_reset(sess->eval_arena);
+    sess->rotation_ops->rotate_eval_arena(sess);
     col_mat_cache_clear(&sess->mat_cache);
 
     return 0;
@@ -2145,7 +2145,7 @@ tdd_worker_subpass_fn(void *arg)
 
     /* Reset per-sub-pass allocators and cache (eval.c:716-727) */
     delta_pool_reset(sess->delta_pool);
-    wl_arena_reset(sess->eval_arena);
+    sess->rotation_ops->rotate_eval_arena(sess);
     if (sess->cache_evict_threshold == 0) {
         col_mat_cache_clear(&sess->mat_cache);
     } else {

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -655,6 +655,38 @@ extern const col_frontier_ops_t col_frontier_epoch_ops;
 extern const col_frontier_ops_t col_frontier_diff_ops;
 
 /* ======================================================================== */
+/* Rotation Strategy Vtable (Issue #600)                                    */
+/* ======================================================================== */
+
+/*
+ * col_rotation_ops_t: vtable interface for arena/handle rotation strategy.
+ *
+ * Abstracts the per-iteration `wl_arena_reset` and per-epoch
+ * `wl_compound_arena_gc_epoch_boundary` callsites behind function pointers
+ * so alternative rotation models (e.g. MVCC) can be swapped in without
+ * touching eval.c or session.c. The default STANDARD strategy passes
+ * through to the existing arena APIs.
+ *
+ * The init/destroy hooks are optional (NULL-safe at the callsite).
+ * init returns 0 on success, non-zero on failure (treated as ENOMEM by
+ * col_session_create's `oom:` cleanup path).
+ */
+struct wl_col_session_t; /* forward decl: full type defined below */
+
+typedef struct col_rotation_ops {
+    void (*rotate_eval_arena)(struct wl_col_session_t *sess);
+    void (*gc_epoch_boundary)(struct wl_col_session_t *sess);
+    int (*init)(struct wl_col_session_t *sess);      /* optional, return 0 on success */
+    void (*destroy)(struct wl_col_session_t *sess);  /* optional */
+} col_rotation_ops_t;
+
+/* Default STANDARD rotation strategy (defined in rotation_standard.c). */
+extern const col_rotation_ops_t col_rotation_standard_ops;
+
+/* MVCC placeholder rotation strategy (defined in rotation_mvcc.c). */
+extern const col_rotation_ops_t col_rotation_mvcc_ops;
+
+/* ======================================================================== */
 /* Session                                                                  */
 /* ======================================================================== */
 
@@ -709,6 +741,7 @@ typedef struct col_filt_arr_entry {
 typedef struct wl_col_session_t {
     wl_session_t base;         /* MUST be first field (vtable dispatch)  */
     const col_frontier_ops_t *frontier_ops; /* frontier vtable (#261)   */
+    const col_rotation_ops_t *rotation_ops; /* rotation vtable (#600)   */
     const wl_plan_t *plan;     /* borrowed, lifetime: caller             */
     wl_intern_t *intern;       /* borrowed, lifetime: caller (prog)      */
     col_rel_t **rels;          /* owned array of owned col_rel_t*        */

--- a/wirelog/columnar/rotation_mvcc.c
+++ b/wirelog/columnar/rotation_mvcc.c
@@ -1,0 +1,69 @@
+/*
+ * columnar/rotation_mvcc.c - MVCC placeholder rotation strategy (Issue #600)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * MVCC rotation strategy: PLACEHOLDER. Behavior is currently identical to
+ * the STANDARD strategy (direct wl_arena_reset / compound-arena GC). When
+ * an MVCC-aware rotation model lands (per-version retention, snapshot
+ * isolation), this file becomes the implementation site; for now it
+ * exists to make the vtable selection path real and testable.
+ *
+ * The init hook emits one WL_LOG INFO line on the SESSION section when a
+ * session first selects MVCC, so callers see that the placeholder is in
+ * effect rather than the future MVCC implementation.
+ */
+
+#include "columnar/internal.h"
+
+#include "arena/arena.h"
+#include "arena/compound_arena.h"
+#include "wirelog/util/log.h"
+
+static void
+mvcc_rotate_eval_arena(struct wl_col_session_t *sess)
+{
+    /* Placeholder: behave like STANDARD. */
+    if (sess && sess->eval_arena)
+        wl_arena_reset(sess->eval_arena);
+}
+
+static void
+mvcc_gc_epoch_boundary(struct wl_col_session_t *sess)
+{
+    /* Placeholder: behave like STANDARD. */
+    if (sess && sess->compound_arena)
+        wl_compound_arena_gc_epoch_boundary(sess->compound_arena);
+}
+
+static int
+mvcc_init(struct wl_col_session_t *sess)
+{
+    (void)sess;
+    /* Log once per process so the placeholder status is visible without
+     * spamming every session_create call. Not thread-safe in the strict
+     * sense, but a duplicate log line is benign. */
+    static bool warned = false;
+    if (!warned) {
+        warned = true;
+        WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
+            "event=rotation_mvcc_placeholder note=\"MVCC strategy is a "
+            "placeholder; behavior matches STANDARD\"");
+    }
+    return 0;
+}
+
+static void
+mvcc_destroy(struct wl_col_session_t *sess)
+{
+    (void)sess;
+}
+
+const col_rotation_ops_t col_rotation_mvcc_ops = {
+    .rotate_eval_arena = mvcc_rotate_eval_arena,
+    .gc_epoch_boundary = mvcc_gc_epoch_boundary,
+    .init = mvcc_init,
+    .destroy = mvcc_destroy,
+};

--- a/wirelog/columnar/rotation_standard.c
+++ b/wirelog/columnar/rotation_standard.c
@@ -1,0 +1,52 @@
+/*
+ * columnar/rotation_standard.c - STANDARD rotation strategy (Issue #600)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Default rotation strategy. Pure passthrough to the existing arena APIs:
+ *   rotate_eval_arena -> wl_arena_reset(sess->eval_arena)
+ *   gc_epoch_boundary -> wl_compound_arena_gc_epoch_boundary(sess->compound_arena)
+ *
+ * init/destroy are no-ops; the strategy holds no per-session state.
+ */
+
+#include "columnar/internal.h"
+
+#include "arena/arena.h"
+#include "arena/compound_arena.h"
+
+static void
+standard_rotate_eval_arena(struct wl_col_session_t *sess)
+{
+    if (sess && sess->eval_arena)
+        wl_arena_reset(sess->eval_arena);
+}
+
+static void
+standard_gc_epoch_boundary(struct wl_col_session_t *sess)
+{
+    if (sess && sess->compound_arena)
+        wl_compound_arena_gc_epoch_boundary(sess->compound_arena);
+}
+
+static int
+standard_init(struct wl_col_session_t *sess)
+{
+    (void)sess;
+    return 0;
+}
+
+static void
+standard_destroy(struct wl_col_session_t *sess)
+{
+    (void)sess;
+}
+
+const col_rotation_ops_t col_rotation_standard_ops = {
+    .rotate_eval_arena = standard_rotate_eval_arena,
+    .gc_epoch_boundary = standard_gc_epoch_boundary,
+    .init = standard_init,
+    .destroy = standard_destroy,
+};

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -426,6 +426,32 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         return ENOMEM;
 
     sess->frontier_ops = &col_frontier_epoch_ops;
+
+    /* Issue #600: select rotation strategy via WIRELOG_ROTATION env var.
+     * Default is STANDARD; "mvcc" selects the MVCC placeholder. Run init()
+     * if the chosen vtable provides one; on failure, treat as ENOMEM and
+     * fall through the oom path (init must not have allocated anything
+     * else, otherwise it must clean up before returning). */
+    {
+        const col_rotation_ops_t *chosen = &col_rotation_standard_ops;
+        const char *rot_env = getenv("WIRELOG_ROTATION");
+        const char *strategy_name = "standard";
+        if (rot_env && strcmp(rot_env, "mvcc") == 0) {
+            chosen = &col_rotation_mvcc_ops;
+            strategy_name = "mvcc";
+        }
+        sess->rotation_ops = chosen;
+        WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
+            "event=rotation_ops_select strategy=%s", strategy_name);
+        if (chosen->init) {
+            int rc = chosen->init(sess);
+            if (rc != 0) {
+                free(sess);
+                return ENOMEM;
+            }
+        }
+    }
+
     sess->plan = plan;
     sess->intern = plan->intern;
     sess->num_workers = num_workers > 0 ? num_workers : 1;
@@ -812,6 +838,11 @@ col_session_destroy(wl_session_t *session)
     if (!session)
         return;
     wl_col_session_t *sess = COL_SESSION(session);
+    /* Issue #600: tear down rotation strategy first so the destroy hook
+     * still sees a fully-populated session (eval_arena, compound_arena,
+     * etc.) before any of the other teardown frees them. NULL-safe. */
+    if (sess->rotation_ops && sess->rotation_ops->destroy)
+        sess->rotation_ops->destroy(sess);
     for (uint32_t i = 0; i < sess->nrels; i++) {
         col_rel_free_contents(sess->rels[i]);
         free(sess->rels[i]);

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -101,6 +101,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'columnar/partition.c',
                            'columnar/progress.c',
                            'columnar/rotation_standard.c',
+                           'columnar/rotation_mvcc.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -100,6 +100,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'columnar/diff_bridge.c',
                            'columnar/partition.c',
                            'columnar/progress.c',
+                           'columnar/rotation_standard.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==


### PR DESCRIPTION
## Summary

Implements the body of #600: a `col_rotation_ops_t` vtable that abstracts the per-iteration `wl_arena_reset` and per-epoch `wl_compound_arena_gc_epoch_boundary` callsites behind function pointers, with two concrete strategies (STANDARD default, MVCC placeholder) selected by the `WIRELOG_ROTATION` env var at `col_session_create` time.

## Atomic commits

- **C1** `66f7798` `feat(#600): define col_rotation_ops_t vtable + STANDARD stub` — typedef + extern decls in `columnar/internal.h`, `rotation_ops` field on `wl_col_session_t` (after `frontier_ops`), `columnar/rotation_standard.c` with passthrough impl, wire into `wirelog/meson.build` `wirelog_backend_src`, sync `tests/test_arrangement.c` private mirror struct.
- **C2** `34bb7c5` `feat(#600): MVCC stub rotation strategy` — `columnar/rotation_mvcc.c` (currently mirrors STANDARD; init() emits a one-shot `WL_LOG_INFO` "rotation_mvcc_placeholder" line), wire into `wirelog_backend_src`.
- **C3** `d1a43aa` `feat(#600): wire rotation_ops into session lifecycle` — `col_session_create` reads `WIRELOG_ROTATION` (`mvcc` -> MVCC, else STANDARD), records selection, runs optional `init()`. `col_session_destroy` calls optional `destroy()` first. Also extends `tests/meson.build`'s `backend_src` and `bench/meson.build`'s `bench_backend_src` so test/bench executables that compile `session.c` resolve the new vtable symbols.
- **C4** `0cd48ff` `feat(#600): replace direct rotation calls with vtable dispatch` — swap the four `wl_arena_reset(sess->eval_arena)` callsites in `eval.c` (lines 421, 892, 977, 2148) for `sess->rotation_ops->rotate_eval_arena(sess)`. No other `wl_compound_arena_gc_epoch_boundary` callsite exists in tree today, so the gc_epoch_boundary slot is wired but unused outside the strategy implementations.
- **C5** `e6bc50a` `test(#600): rotation strategy vtable selection and pluggability` — `tests/test_rotation_strategy.c` with three cases (default-is-standard, env-override-mvcc, dispatch-no-crash); wired into `tests/meson.build`.

Each commit compiles and passes `meson test -C build` standalone.

## Closes

Closes #600.

## Test plan

- [x] `meson compile -C build` clean on every commit
- [x] `meson test -C build` -> `Ok: 160, Fail: 0, Skipped: 1` (the 1 skipped is pre-existing; rotation_strategy adds the +1 vs prior 159)
- [x] `./tests/test_rotation_strategy` -> `3 run, 3 passed, 0 failed`
- [x] STANDARD path is functionally identical to pre-vtable behavior (covered by full existing test battery, all GREEN)
- [x] `WIRELOG_ROTATION=mvcc` selects MVCC vtable (covered by `test_rotation_env_override_mvcc`)