### PR TITLE
feat(#560): integrate gc_epoch_boundary into eval and K-Fusion paths

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1858,6 +1858,27 @@ test('session_compound_arena_lifecycle',
      test_session_compound_arena_lifecycle_exe)
 
 # ============================================================================
+# GC Epoch Boundary Integration (Issue #560)
+# ============================================================================
+
+test_gc_epoch_boundary_exe = executable(
+  'test_gc_epoch_boundary',
+  files('test_gc_epoch_boundary.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('gc_epoch_boundary', test_gc_epoch_boundary_exe)
+
+# ============================================================================
 # Recursive Aggregation Plan Tests - DISABLED in Phase 2C
 # ============================================================================
 #

--- a/tests/test_gc_epoch_boundary.c
+++ b/tests/test_gc_epoch_boundary.c
@@ -1,0 +1,234 @@
+/*
+ * test_gc_epoch_boundary.c - Issue #560 integration tests
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Verifies that the rotation-strategy gc_epoch_boundary slot fires at
+ * the integration points added by #560:
+ *
+ *   1. After each recursive sub-pass iteration in col_eval_stratum:
+ *      a recursive transitive-closure evaluation that runs >= 2
+ *      sub-pass iterations advances sess->compound_arena->current_epoch.
+ *
+ *   2. The dispatch is NULL-safe with respect to sess->compound_arena:
+ *      if a session is mutated to drop its arena before evaluation,
+ *      the eval path must not crash on the slot dispatch.
+ */
+
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/backend.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+            return;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)     \
+        do {                      \
+            if (!(cond)) {        \
+                FAIL(msg);        \
+            }                     \
+        } while (0)
+
+/* ======================================================================== */
+/* Helper: build a minimal columnar plan                                    */
+/* ======================================================================== */
+
+static wl_plan_t *
+build_plan(const char *src)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0)
+        return NULL;
+    return plan;
+}
+
+/* ======================================================================== */
+/* Test 1: gc_epoch_boundary fires per recursive sub-pass iteration         */
+/* ======================================================================== */
+
+static void
+test_gc_epoch_advances_per_iteration(void)
+{
+    TEST("gc_epoch_boundary: advances current_epoch across recursive eval");
+
+    /* Transitive-closure program: forces the recursive sub-pass loop to
+     * run multiple iterations until fixed-point. */
+    wl_plan_t *plan
+        = build_plan(".decl edge(x: int32, y: int32)\n"
+            ".decl tc(x: int32, y: int32)\n"
+            "tc(X, Y) :- edge(X, Y).\n"
+            "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n");
+    ASSERT(plan != NULL, "could not build TC plan");
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        FAIL("wl_session_create failed");
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    ASSERT(cs->compound_arena != NULL,
+        "compound_arena not allocated by col_session_create");
+
+    /* Snapshot the epoch counter before evaluation. */
+    uint32_t epoch_before = cs->compound_arena->current_epoch;
+
+    /* Build a chain edge(1,2), edge(2,3), edge(3,4), edge(4,5) so the
+     * recursive sub-pass loop has to iterate several times to derive
+     * the full closure (the per-iteration GC dispatch fires once per
+     * sub-pass). */
+    int64_t edges[][2] = {
+        { 1, 2 },
+        { 2, 3 },
+        { 3, 4 },
+        { 4, 5 },
+    };
+    for (size_t i = 0; i < sizeof(edges) / sizeof(edges[0]); i++) {
+        wl_session_insert(session, "edge", edges[i], 1, 2);
+    }
+
+    rc = wl_session_step(session);
+    if (rc != 0) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("wl_session_step failed");
+    }
+
+    uint32_t epoch_after = cs->compound_arena->current_epoch;
+
+    if (epoch_after <= epoch_before) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("compound_arena current_epoch did not advance after eval");
+    }
+
+    /* TC over a 4-edge chain takes >= 2 recursive sub-passes (and the
+     * #560 dispatch fires once per sub-pass), so we expect strictly
+     * more than one epoch advance.  Use >= 2 as the lower bound to
+     * keep the assertion robust against future eval optimisations
+     * that might collapse trivial sub-passes. */
+    if (epoch_after - epoch_before < 2u) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("expected at least 2 epoch advances across recursive eval");
+    }
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Test 2: dispatch is NULL-safe when sess->compound_arena is NULL          */
+/* ======================================================================== */
+
+static void
+test_gc_epoch_compound_arena_null_safe(void)
+{
+    TEST("gc_epoch_boundary: NULL compound_arena does not crash eval");
+
+    /* Same recursive program as test 1 so the dispatch site fires. */
+    wl_plan_t *plan
+        = build_plan(".decl edge(x: int32, y: int32)\n"
+            ".decl tc(x: int32, y: int32)\n"
+            "tc(X, Y) :- edge(X, Y).\n"
+            "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n");
+    ASSERT(plan != NULL, "could not build TC plan");
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        FAIL("wl_session_create failed");
+    }
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    ASSERT(cs->compound_arena != NULL,
+        "compound_arena not allocated by col_session_create");
+
+    /* Free and detach the compound arena so the per-iteration
+     * dispatch site has to take the NULL-guarded skip branch. */
+    wl_compound_arena_free(cs->compound_arena);
+    cs->compound_arena = NULL;
+
+    int64_t edge_12[] = { 1, 2 };
+    int64_t edge_23[] = { 2, 3 };
+    wl_session_insert(session, "edge", edge_12, 1, 2);
+    wl_session_insert(session, "edge", edge_23, 1, 2);
+
+    rc = wl_session_step(session);
+    if (rc != 0) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        FAIL("wl_session_step failed with NULL compound_arena");
+    }
+
+    /* If we reached here without segfaulting, the NULL guards held. */
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    PASS();
+}
+
+/* ======================================================================== */
+/* main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_gc_epoch_boundary (Issue #560)\n");
+    test_gc_epoch_advances_per_iteration();
+    test_gc_epoch_compound_arena_null_safe();
+    printf("\n%d run, %d passed, %d failed\n", tests_run, tests_passed,
+        tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -890,6 +890,16 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
 
             delta_pool_reset(sess->delta_pool);
             sess->rotation_ops->rotate_eval_arena(sess);
+            /* Issue #560: Advance the compound-arena epoch frontier at the
+            * end of each recursive sub-pass iteration so the
+            * epoch-frontier GC can reclaim handles whose multiplicity
+            * dropped to zero in this iteration.  NULL-guard each link in
+            * the dispatch chain because tests and early lifecycle paths
+            * may operate without a compound arena or rotation strategy. */
+            if (sess->compound_arena && sess->rotation_ops
+                && sess->rotation_ops->gc_epoch_boundary) {
+                sess->rotation_ops->gc_epoch_boundary(sess);
+            }
             /* Issue #176: Per-sub-pass cache eviction for recursive strata.
              * Use configurable eviction threshold (cache_evict_threshold):
              * - If 0: clear entire cache each sub-pass (backward compatible)

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -4834,6 +4834,19 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
 
     int rc = 0;
 
+    /* Issue #560: Advance the compound-arena epoch frontier before
+     * spawning K-Fusion workers so each worker's view of the arena
+     * starts at a freshly-retired generation.  This bounds the set
+     * of compound handles workers can observe and lets the
+     * epoch-frontier GC reclaim handles whose multiplicity already
+     * dropped to zero in the parent.  Each link is NULL-guarded so
+     * sessions without a compound arena or rotation strategy still
+     * spawn workers unchanged. */
+    if (sess->compound_arena && sess->rotation_ops
+        && sess->rotation_ops->gc_epoch_boundary) {
+        sess->rotation_ops->gc_epoch_boundary(sess);
+    }
+
     /* Issue #196: Workers start with zeroed mat_cache (no shared entries).
      * All worker cache entries are worker-owned; cleanup frees all of them
      * starting from index 0, so no base_count snapshot is needed. */


### PR DESCRIPTION
## Summary

Adds the missing call sites for the rotation-strategy `gc_epoch_boundary` slot introduced in #600, so the compound-arena epoch frontier actually advances at runtime.

Two integration points:

1. **After each recursive stratum sub-pass iteration** (`wirelog/columnar/eval.c`, in `col_eval_stratum`'s sub-pass loop, immediately after the existing `rotate_eval_arena` call). Lets the epoch-frontier GC reclaim handles whose multiplicity dropped to zero in the iteration that just finished.
2. **Before K-Fusion worker spawn** (`wirelog/columnar/ops.c`, in `col_op_k_fusion`, immediately before the per-worker initialisation loop). Workers therefore start against a freshly-retired generation rather than inheriting an in-flight parent epoch.

Each dispatch is NULL-guarded on `sess->compound_arena`, `sess->rotation_ops`, and the `gc_epoch_boundary` slot itself, so sessions and tests that operate without a compound arena or rotation strategy are unaffected. The STANDARD strategy wraps `wl_compound_arena_gc_epoch_boundary`; the MVCC stub remains a no-op.

## Commits
- `b469de6` feat(#560): call gc_epoch_boundary after stratum iteration
- `61995ef` feat(#560): call gc_epoch_boundary before K-Fusion worker spawn
- `b0f1bf2` test(#560): gc_epoch_boundary fires at iteration boundaries

## Test plan
- [x] `meson compile -C build` — clean
- [x] `meson test -C build` — 161 passed, 0 failed, 1 skipped (perf gate)
- [x] New `tests/test_gc_epoch_boundary.c`:
  - `test_gc_epoch_advances_per_iteration`: TC over 4-edge chain advances `compound_arena->current_epoch` by >= 2
  - `test_gc_epoch_compound_arena_null_safe`: detaches `sess->compound_arena` before `wl_session_step`, asserts no crash

Closes #560.