### PR TITLE
feat(#583): trace compound arena lifecycle under COMPOUND section

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2488,6 +2488,26 @@ test('compound_arena_freeze_cycle_stress',
      timeout: 120)
 
 # ============================================================================
+# Compound arena lifecycle observability (Issue #583)
+# WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.
+# ============================================================================
+
+test_compound_arena_trace_exe = executable(
+  'test_compound_arena_trace',
+  files('test_compound_arena_trace.c'),
+  arena_src,
+  thread_src,
+  files(
+    '../wirelog/util/log.c',
+    '../wirelog/util/log_emit.c',
+  ),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep, math_dep],
+)
+
+test('compound_arena_trace', test_compound_arena_trace_exe, suite: 'log')
+
+# ============================================================================
 # K-Fusion deep-copy + inline compound visibility (Issue #532 Task 4)
 # ============================================================================
 

--- a/tests/test_compound_arena_trace.c
+++ b/tests/test_compound_arena_trace.c
@@ -1,0 +1,264 @@
+/*
+ * test_compound_arena_trace.c - Issue #583 lifecycle observability
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives the COMPOUND section of the WL_LOG logger across the
+ * compound-arena lifecycle and asserts that
+ *
+ *   WL_LOG=COMPOUND:5
+ *
+ * yields the lifecycle tags added in session.c (create/destroy) and
+ * compound_arena.c (alloc/freeze/unfreeze).  The events share the
+ * `lifecycle event=<verb>` prefix so a single grep over the COMPOUND
+ * section reconstructs the full timeline.
+ *
+ * This test exercises the arena directly (no session) for the
+ * alloc/freeze/unfreeze events so it stays cheap and avoids pulling
+ * in the full backend.  Session create/destroy traces are exercised by
+ * the existing test_session_compound_arena_lifecycle suite, which
+ * already runs under the standard observability harness; #583 only
+ * needs to verify that the new COMPOUND tags are emitted at the right
+ * level.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/util/log.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#  include <process.h>
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#  define getpid   _getpid
+#else
+#  include <unistd.h>
+#endif
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* ======================================================================== */
+/* tmpfile helpers                                                          */
+/* ======================================================================== */
+
+static char tmp_path_[256];
+
+static const char *
+tmpdir_(void)
+{
+    const char *d = getenv("TMPDIR");
+    if (d && *d) return d;
+#if defined(_WIN32)
+    d = getenv("TEMP");
+    if (d && *d) return d;
+    d = getenv("TMP");
+    if (d && *d) return d;
+    return ".";
+#else
+    return "/tmp";
+#endif
+}
+
+static void
+make_tmpfile_(const char *tag)
+{
+    const char *d = tmpdir_();
+#if defined(_WIN32)
+    const char sep = '\\';
+#else
+    const char sep = '/';
+#endif
+    snprintf(tmp_path_, sizeof(tmp_path_),
+        "%s%cwl_compound_arena_trace_%s_%ld_%ld.log",
+        d, sep, tag, (long)getpid(), (long)time(NULL));
+    (void)remove(tmp_path_);
+}
+
+static size_t
+read_file_(const char *path, char *buf, size_t bufsz)
+{
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    size_t n = fread(buf, 1, bufsz - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    return n;
+}
+
+static void
+clear_env_(void)
+{
+    unsetenv("WL_LOG");
+    unsetenv("WL_LOG_FILE");
+    unsetenv("WL_DEBUG_JOIN");
+    unsetenv("WL_CONSOLIDATION_LOG");
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_arena_lifecycle_emits_compound_traces(void)
+{
+    TEST("WL_LOG=COMPOUND:5 captures alloc/freeze/unfreeze lifecycle events");
+
+    wl_compound_arena_t *arena = NULL;
+
+    clear_env_();
+    make_tmpfile_("lifecycle");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    setenv("WL_LOG", "COMPOUND:5", 1);
+    wl_log_init();
+
+    arena = wl_compound_arena_create(0xCAFEu, 256u, 0u);
+    if (!arena) FAIL("arena create");
+
+    uint64_t handle = wl_compound_arena_alloc(arena, 32u);
+    ASSERT(handle != WL_COMPOUND_HANDLE_NULL, "alloc returned NULL handle");
+
+    wl_compound_arena_freeze(arena);
+    /* Frozen alloc must still emit no spurious COMPOUND alloc trace. */
+    uint64_t denied = wl_compound_arena_alloc(arena, 16u);
+    ASSERT(denied == WL_COMPOUND_HANDLE_NULL, "frozen alloc accepted");
+
+    wl_compound_arena_unfreeze(arena);
+
+    wl_log_shutdown();
+
+    char buf[8192] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n > 0, "log file empty");
+    ASSERT(strstr(buf, "[TRACE][COMPOUND]") != NULL,
+        "missing [TRACE][COMPOUND] prefix");
+    ASSERT(strstr(buf, "lifecycle event=alloc") != NULL,
+        "missing lifecycle event=alloc");
+    ASSERT(strstr(buf, "lifecycle event=freeze") != NULL,
+        "missing lifecycle event=freeze");
+    ASSERT(strstr(buf, "lifecycle event=unfreeze") != NULL,
+        "missing lifecycle event=unfreeze");
+
+    /* Frozen-denied allocations must NOT emit a lifecycle event=alloc. */
+    int alloc_count = 0;
+    const char *p = buf;
+    const char *needle = "lifecycle event=alloc";
+    size_t needle_len = strlen(needle);
+    while ((p = strstr(p, needle)) != NULL) {
+        alloc_count++;
+        p += needle_len;
+    }
+    ASSERT(alloc_count == 1,
+        "alloc trace should fire exactly once (frozen alloc must not emit)");
+
+    PASS();
+cleanup:
+    if (arena)
+        wl_compound_arena_free(arena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+static void
+test_no_compound_traces_when_disabled(void)
+{
+    TEST("WL_LOG unset -> zero COMPOUND lifecycle traces emitted");
+
+    wl_compound_arena_t *arena = NULL;
+
+    clear_env_();
+    make_tmpfile_("disabled");
+    setenv("WL_LOG_FILE", tmp_path_, 1);
+    /* Note: no WL_LOG -> all sections at NONE; lifecycle traces must
+     * not be emitted (this is the "no overhead" acceptance criterion
+     * surfaced as observable behaviour). */
+    wl_log_init();
+
+    arena = wl_compound_arena_create(0xBEEFu, 256u, 0u);
+    if (!arena) FAIL("arena create");
+    (void)wl_compound_arena_alloc(arena, 32u);
+    wl_compound_arena_freeze(arena);
+    wl_compound_arena_unfreeze(arena);
+
+    wl_log_shutdown();
+
+    char buf[4096] = {0};
+    size_t n = read_file_(tmp_path_, buf, sizeof(buf));
+    ASSERT(n == 0, "log file should be empty when WL_LOG is unset");
+
+    PASS();
+cleanup:
+    if (arena)
+        wl_compound_arena_free(arena);
+    (void)remove(tmp_path_);
+    clear_env_();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_compound_arena_trace (Issue #583)\n");
+    printf("======================================\n");
+
+    test_arena_lifecycle_emits_compound_traces();
+    test_no_compound_traces_when_disabled();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -185,6 +185,13 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
     WL_LOG(WL_LOG_SEC_ARENA, WL_LOG_TRACE,
         "handle_alloc(epoch=%u, offset=%u, packed=0x%" PRIx64 ")",
         arena->current_epoch, offset, handle);
+    /* Issue #583: lifecycle audit trail under the COMPOUND section so a
+     * single `WL_LOG=COMPOUND:5` captures end-to-end side-relation
+     * activity without enabling the noisier generic-allocator ARENA
+     * traces above. */
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=alloc handle=0x%" PRIx64 " size=%u epoch=%u",
+        handle, size, arena->current_epoch);
     return handle;
 }
 
@@ -274,15 +281,23 @@ wl_compound_arena_retain(wl_compound_arena_t *arena, uint64_t handle,
 void
 wl_compound_arena_freeze(wl_compound_arena_t *arena)
 {
-    if (arena)
-        arena->frozen = true;
+    if (!arena)
+        return;
+    arena->frozen = true;
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=freeze epoch=%u live_handles=%" PRIu64,
+        arena->current_epoch, arena->live_handles);
 }
 
 void
 wl_compound_arena_unfreeze(wl_compound_arena_t *arena)
 {
-    if (arena)
-        arena->frozen = false;
+    if (!arena)
+        return;
+    arena->frozen = false;
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=unfreeze epoch=%u live_handles=%" PRIu64,
+        arena->current_epoch, arena->live_handles);
 }
 
 uint32_t

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -725,6 +725,13 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
         "event=compound_arena_init seed=0x%08x default_gen_cap=%u",
         0x53455353u, 4096u);
+    /* Issue #583: lifecycle audit trail for the compound side-relation
+     * subsystem.  WL_LOG=COMPOUND:5 captures create/destroy/alloc/
+     * freeze/unfreeze in one section without enabling the noisier
+     * SESSION INFO surface. */
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=session_create seed=0x%08x default_gen_cap=%u",
+        0x53455353u, 4096u);
 
     /* Pre-register EDB relations (ncols determined at first insert) */
     for (uint32_t i = 0; i < plan->edb_count; i++) {
@@ -913,6 +920,12 @@ col_session_destroy(wl_session_t *session)
     /* Issue #559: free side-relation compound arena (NULL-safe). */
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
         "event=compound_arena_destroy live_handles=%llu",
+        sess->compound_arena
+            ? (unsigned long long)sess->compound_arena->live_handles
+            : 0ULL);
+    /* Issue #583: lifecycle audit trail (mirrors session_create). */
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=session_destroy live_handles=%llu",
         sess->compound_arena
             ? (unsigned long long)sess->compound_arena->live_handles
             : 0ULL);


### PR DESCRIPTION
## Summary
- New \`WL_LOG(COMPOUND, TRACE, ...)\` audit lines so \`WL_LOG=COMPOUND:5\` captures the side-relation arena timeline end-to-end (session create/destroy, alloc, freeze, unfreeze).
- Pre-existing \`SESSION INFO\` + \`ARENA TRACE\` surfaces stay in place — no behavioural change for operators who already filter on those sections.
- Frozen-allocation guard still suppresses the alloc trace for denied calls (verified by the \"alloc fired exactly once\" assertion in the new test).

## Stacked on
\`feat/582-arena-rotation-stress\` (PR #614). Merge that first; this PR will rebase onto main automatically.

## Test plan
- [x] \`tests/test_compound_arena_trace.c\` (new): WL_LOG=COMPOUND:5 emits the expected lifecycle tags; WL_LOG unset produces zero output.
- [x] \`meson test -C build\` → 166/166 OK + 1 skipped (suite count 165 → 167)
- [x] uncrustify + pre-commit hook clean

Closes #583.