### PR TITLE
docs(#586): pin remap initial-capacity and arena live-handles bound

### DIFF
--- a/wirelog/arena/compound_arena.h
+++ b/wirelog/arena/compound_arena.h
@@ -298,4 +298,28 @@ wl_compound_arena_unfreeze(wl_compound_arena_t *arena);
 uint32_t
 wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena);
 
+/**
+ * wl_compound_arena_live_handles:
+ * @arena: arena to query (NULL-safe).
+ *
+ * Return the current live-handle population of @arena (the value of
+ * @arena->live_handles), or 0 if @arena is NULL.  Introspection-only
+ * accessor used by the rotation-helper path (Issue #586): the remap
+ * table sizes itself against this number when migrating compound
+ * handles into a fresh session (#562 / #550 Option C).
+ *
+ * Stability: NOT stable across rotations or during live K-Fusion
+ * worker access.  Callers must invoke this either while the arena
+ * is frozen (so coordinator-side mutation is paused) or before any
+ * worker has spawned — see the file-level "Thread safety" note at
+ * the top of this header.  `live_handles` is a plain (non-atomic)
+ * `uint64_t`; this accessor is TSan-clean iff the caller honors
+ * that contract.
+ */
+static inline uint64_t
+wl_compound_arena_live_handles(const wl_compound_arena_t *arena)
+{
+    return arena ? arena->live_handles : (uint64_t)0;
+}
+
 #endif /* WL_COMPOUND_ARENA_H */

--- a/wirelog/columnar/handle_remap_design.md
+++ b/wirelog/columnar/handle_remap_design.md
@@ -1,5 +1,5 @@
 # Handle Remapping Data Structure Design
-## Issue #557 — Open-Addressing Hash Table for Compound-Handle Remap
+## Issues #557 (initial freeze) / #586 (rotation-evacuation tightening) — Open-Addressing Hash Table for Compound-Handle Remap
 
 **Status**: Design (Phase 3C)
 **Audience**: Implementers (#562, #563), reviewers, architects
@@ -167,6 +167,76 @@ of two so the modulo operation reduces to `index & (capacity - 1)`.
 The minimum capacity is 16 (small enough not to matter; large enough
 that the rounding doesn't dominate). This is an implementation detail
 and not exposed through the API.
+
+### 2.8 Initial capacity for rotation evacuation (Issue #586)
+
+When the table is created on the rotation-helper path
+(`wl_session_rotate`, #550 Option C / blocked by #562), the caller
+already knows the live-handle population it is about to migrate:
+`wl_compound_arena_t.live_handles`.  The contract is one-sided to
+avoid double-counting the load-factor headroom against §4.1:
+
+  - Caller passes the raw `live_handles` value to
+    `wl_handle_remap_create(capacity, &out)`.  Do NOT pre-divide by
+    0.75 — the constructor (§4.1) already applies the load-factor
+    headroom by rounding `capacity / 0.75` up to the next power of
+    two.  Passing `live_handles / 0.75` would double-count and
+    over-allocate by ~2×.
+  - The resulting table starts at the smallest power of two ≥
+    `ceil(live_handles / 0.75)`, which is the smallest size that
+    holds the population without crossing the 0.75 load threshold.
+  - For the issue's quoted "256K initial" point: a population of
+    ~190K handles passes `live_handles = 190000`; the constructor
+    computes `ceil(190000 / 0.75) = 253334` and rounds up to
+    `2^18 = 262144` slots.  That ~256K figure is therefore not a
+    hard-coded constant but the natural consequence of (a) the
+    live-count input and (b) §2.7 rounding.
+
+Default-on-zero stays at 16 (§2.7), which keeps unit tests and tiny
+fixtures cheap.  The 256K figure is the bound for the *production
+rotation* call site, not a global default.
+
+### 2.9 Capacity upper bound (Issue #586)
+
+The remap table sizes itself against `arena->live_handles` (the
+caller-visible "generation size"), not against per-epoch
+`entry_count` or total payload bytes.  The upper bound is the
+arena's saturation point:
+
+  - Pre-rotation: `live_handles ≤ Σ_e entry_count[e]` over all live
+    epochs `e`.  This is bounded by the 12-bit epoch field × the
+    32-bit per-generation offset, i.e. `2^44` in theory; in practice
+    bounded by RAM × the per-handle payload size.
+  - Caller responsibility (#562 implementer): the SOA layout (§3.2)
+    holds `keys` and `values` as two separate `int64_t` arrays of
+    `capacity` entries each.  `ceil_pow2(live_handles * 4/3)` can
+    almost double again (the next power of two is at most 2× the
+    input), so the worst-case post-rounded `capacity` is
+    `live_handles * 8/3 ≈ 2.67×`.  Total bytes allocated for the
+    table is therefore up to:
+
+        capacity * sizeof(int64_t) * 2  ≈  live_handles * 128/3
+                                        ≈  live_handles * 42.67
+
+    Before calling `wl_handle_remap_create(live_handles, &out)`,
+    the caller must validate that this post-rounded allocation
+    does not overflow `size_t` on 32-bit targets (MSVC i386 still
+    in CI):
+
+        live_handles ≤ SIZE_MAX / 64           (safe, with headroom)
+        live_handles ≤ SIZE_MAX / 42.67        (tight)
+
+    On 32-bit `size_t` the tight bound is ~100M handles before the
+    table allocation overflows; the safe bound is ~67M.  On 64-bit
+    `size_t` either bound vastly exceeds the arena's `2^44`
+    saturation cap, so the check is a no-op there but stays free.
+    The constructor itself is also free to re-validate after
+    rounding and return ENOMEM if the bound is exceeded; doing
+    both belt-and-suspenders is encouraged.
+
+These two bullets close the "max bounded by generation size"
+clause in #586 with a single unambiguous formula and one explicit
+overflow check the implementer must enforce.
 
 ---
 


### PR DESCRIPTION
## Summary
Single docs+header delta on top of the already-frozen #557 remap design.

The core open-addressing/linear-probing/0.75-load-factor/SplitMix64 design shipped under #557 (\`wirelog/columnar/handle_remap.{h,_design.md}\`). Issue #586 asks to *tighten* that design with two specific clauses:

1. **§2.8 — Initial capacity for rotation evacuation.** The caller passes raw \`live_handles\` (NOT pre-divided by 0.75 — the constructor §4.1 already applies the load-factor headroom). The "256K initial" figure quoted by the issue is the natural consequence of a ~190K handle population rounded to \`2^18 = 262144\` slots, not a hard-coded constant.

2. **§2.9 — Capacity upper bound.** The table sizes against \`arena->live_handles\`, not per-epoch \`entry_count\` or payload bytes. The post-rounded allocation is up to \`live_handles * 128/3 ≈ 42.67×\` bytes; #562 must validate \`live_handles ≤ SIZE_MAX / 64\` (safe headroom) before calling \`wl_handle_remap_create\` so the allocation cannot overflow \`size_t\` on 32-bit targets (MSVC i386 still in CI).

Add a new inline accessor \`wl_compound_arena_live_handles()\` in \`compound_arena.h\` so #562 / #600 can read the bound through the API instead of struct-poking. NULL-safe; documents single-mutator visibility contract.

## Stacked on
\`feat/584-gc-freeze-verification\` (PR #616, currently in CI). Will rebase onto main once that merges.

## Multi-agent flow
1. **Architect + Critic** pre-review found the existing #557 frozen design and recommended a delta-only approach.
2. **Implementer** landed §2.8 + §2.9 + accessor in one commit.
3. **Code-reviewer** REQUEST_CHANGES with one MAJOR (§2.8 vs §4.1 double-divide) + 3 MINOR + 2 NIT.
4. **Implementer** amended: rewrote §2.8 to a one-sided contract, fixed cite anchor, used \`(uint64_t)0\` literal.
5. **Architect + Critic** meta-review: CONCUR / REVIEWER_RIGHT, both spotted §2.9's divisor was understated (21.3 → 42.67) and a tautological 32/64-bit clause. Folded in.

## Test plan
- [x] \`meson test -C build\` → 167/167 OK + 1 skipped (no behavioural change)
- [x] \`uncrustify --check\` clean

Closes #586.