### PR TITLE
feat(#589): EDB handle remap apply pass + missing #562 implementation

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -378,6 +378,7 @@ backend_src = files(
   '../wirelog/columnar/rotation_standard.c',
   '../wirelog/columnar/rotation_mvcc.c',
   '../wirelog/columnar/compound_side.c',
+  '../wirelog/columnar/handle_remap.c',
   '../wirelog/util/lockfree_queue.c',
   '../wirelog/util/log.c',
   '../wirelog/util/log_emit.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2511,6 +2511,25 @@ test_gc_freeze_alloc_race_exe = executable(
 test('gc_freeze_alloc_race', test_gc_freeze_alloc_race_exe, timeout: 60)
 
 # ============================================================================
+# Handle remap EDB apply pass (Issue #589)
+# 10K rows x 3 compound columns acceptance harness, plus negative paths.
+# ============================================================================
+
+test_handle_remap_apply_exe = executable(
+  'test_handle_remap_apply',
+  files('test_handle_remap_apply.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('handle_remap_apply', test_handle_remap_apply_exe, timeout: 60)
+
+# ============================================================================
 # Compound arena lifecycle observability (Issue #583)
 # WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -379,6 +379,7 @@ backend_src = files(
   '../wirelog/columnar/rotation_mvcc.c',
   '../wirelog/columnar/compound_side.c',
   '../wirelog/columnar/handle_remap.c',
+  '../wirelog/columnar/handle_remap_apply.c',
   '../wirelog/util/lockfree_queue.c',
   '../wirelog/util/log.c',
   '../wirelog/util/log_emit.c',

--- a/tests/test_handle_remap_apply.c
+++ b/tests/test_handle_remap_apply.c
@@ -1,0 +1,349 @@
+/*
+ * test_handle_remap_apply.c - Issue #589 acceptance harness
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives wl_handle_remap_apply_columns end-to-end against a 10K-row x
+ * 3-compound-column fixture, the size #589 pins as the acceptance
+ * test.  The fixture builds the remap table by hand (the rotation
+ * helper that would normally populate it is #550 Option C, not yet
+ * implemented), so this is unit-style coverage of the apply pass +
+ * the underlying SplitMix64 / open-addressing table together.
+ *
+ * Acceptance bullets the test pins:
+ *   - All EDB compound handles remapped (every cell rewritten)
+ *   - Handle lookup always succeeds (no EIO miss path)
+ *   - 10K rows, 3 compound columns
+ *   - TSan clean on hash lookup
+ *   - ASAN clean
+ *
+ * The test is single-threaded; the project's TSan suite runs the
+ * binary under instrumentation but no concurrent thread is involved
+ * here -- the W=2 alloc-vs-gc race is covered by #584's harness.
+ * What this test verifies under TSan is the *absence* of any
+ * concurrent state inside wl_handle_remap_apply_columns itself
+ * (e.g. accidental thread-local globals).  The default sanitizer
+ * build also catches out-of-bounds, use-after-free, and signed
+ * overflow inside the row scan.
+ */
+
+#include "../wirelog/columnar/handle_remap.h"
+#include "../wirelog/columnar/handle_remap_apply.h"
+#include "../wirelog/columnar/internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+            goto cleanup;                     \
+        } while (0)
+
+#define ASSERT(cond, msg)                 \
+        do {                                  \
+            if (!(cond)) {                    \
+                FAIL(msg);                    \
+            }                                 \
+        } while (0)
+
+/* ======================================================================== */
+/* Fixture builder                                                          */
+/* ======================================================================== */
+
+/* Synthesise a deterministic old handle per (row, column) pair.  We
+ * spread bits across all 64 so the SplitMix64 finalizer in
+ * wl_handle_remap_hash actually sees varied input. */
+static int64_t
+mk_old_handle(uint32_t row, uint32_t col)
+{
+    /* +1 to keep handles non-zero; high bits encode column to spread
+     * across the keyspace; low bits encode row monotonically. */
+    return (int64_t)(((uint64_t)(col + 1u) << 40) ^ ((uint64_t)row + 1u));
+}
+
+/* Deterministic post-rotation handle.  The remap is mk_old_handle(r,c)
+ * -> mk_new_handle(r,c).  Choosing a different transform from
+ * mk_old_handle makes round-trip mistakes obvious. */
+static int64_t
+mk_new_handle(uint32_t row, uint32_t col)
+{
+    return (int64_t)(((uint64_t)(col + 1u) << 40)
+           ^ ((uint64_t)row + 1u)
+           ^ 0xDEADBEEFCAFEBABEull);
+}
+
+static col_rel_t *
+build_relation(uint32_t nrows, uint32_t ncompound_cols)
+{
+    col_rel_t *r = NULL;
+    if (col_rel_alloc(&r, "edb_remap_fixture") != 0)
+        return NULL;
+    /* Build a flat 3-column schema; col_rel_set_schema also sizes the
+     * physical columns array. */
+    const char *names[3] = { "h0", "h1", "h2" };
+    if (ncompound_cols > 3u) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    if (col_rel_set_schema(r, ncompound_cols, names) != 0) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    /* Populate row-by-row using append_row -- this matches how the
+     * EDB ingest path fills relations (one row at a time, growing
+     * capacity as needed) so the apply pass exercises the same
+     * column-major buffer the production path does. */
+    int64_t row[3];
+    for (uint32_t i = 0; i < nrows; i++) {
+        for (uint32_t c = 0; c < ncompound_cols; c++)
+            row[c] = mk_old_handle(i, c);
+        if (col_rel_append_row(r, row) != 0) {
+            col_rel_destroy(r);
+            return NULL;
+        }
+    }
+    return r;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_apply_10k_x_3_columns(void)
+{
+    TEST("#589: 10K rows x 3 compound columns -- all handles remapped");
+
+    static const uint32_t NROWS = 10000u;
+    static const uint32_t NCOLS = 3u;
+
+    wl_handle_remap_t *remap = NULL;
+    col_rel_t *rel = NULL;
+
+    /* (1) Build the fixture relation.  Every cell carries a
+     * deterministic non-zero old handle. */
+    rel = build_relation(NROWS, NCOLS);
+    ASSERT(rel != NULL, "build_relation");
+
+    /* (2) Build the remap table sized for the full population.  The
+     * caller passes the raw expected count; the constructor applies
+     * the load-factor headroom (per #586 §2.8 / handle_remap.c). */
+    int rc = wl_handle_remap_create((size_t)(NROWS * NCOLS), &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    for (uint32_t r = 0; r < NROWS; r++) {
+        for (uint32_t c = 0; c < NCOLS; c++) {
+            rc = wl_handle_remap_insert(remap,
+                    mk_old_handle(r, c),
+                    mk_new_handle(r, c));
+            if (rc != 0)
+                FAIL("remap insert mid-build");
+        }
+    }
+
+    /* (3) Apply the pass.  Acceptance: every cell rewritten. */
+    uint32_t handle_cols[3] = { 0u, 1u, 2u };
+    uint64_t rewrites = 0u;
+    rc = wl_handle_remap_apply_columns(rel, handle_cols, NCOLS, remap,
+            &rewrites);
+    ASSERT(rc == 0, "apply_columns returned non-zero");
+    ASSERT(rewrites == (uint64_t)NROWS * (uint64_t)NCOLS,
+        "rewrites count must equal nrows * ncols");
+
+    /* (4) Spot-check a stratified sample: first row, last row, and a
+     * mid sample.  Verifying every cell would just re-implement the
+     * apply loop; stratified sampling catches off-by-one and
+     * cross-column corruption.  Probe values are bare literals (not
+     * NROWS - 1) because MSVC's default C dialect rejects
+     * static-storage initializers that reference `static const`
+     * locals (C2099). */
+    static const uint32_t probe_rows[] = {
+        0u, 1u, 4999u, 5000u, 5001u, 9999u
+    };
+    for (size_t i = 0; i < sizeof(probe_rows) / sizeof(probe_rows[0]);
+        i++) {
+        uint32_t pr = probe_rows[i];
+        for (uint32_t c = 0; c < NCOLS; c++) {
+            int64_t got = rel->columns[c][pr];
+            int64_t want = mk_new_handle(pr, c);
+            if (got != want) {
+                printf(" ... FAIL: row=%u col=%u got=0x%llx want=0x%llx\n",
+                    pr, c, (unsigned long long)got,
+                    (unsigned long long)want);
+                tests_failed++;
+                goto cleanup;
+            }
+        }
+    }
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+static void
+test_apply_zero_handles_unchanged(void)
+{
+    TEST("#589: zero (NULL) handles are skipped, not flagged as miss");
+
+    wl_handle_remap_t *remap = NULL;
+    col_rel_t *rel = NULL;
+
+    rel = build_relation(8u, 1u);
+    ASSERT(rel != NULL, "build_relation");
+
+    /* Zero out every other cell so the apply pass walks past genuine
+     * NULL handles without entering the EIO miss path. */
+    for (uint32_t r = 0; r < rel->nrows; r += 2u)
+        rel->columns[0][r] = 0;
+
+    int rc = wl_handle_remap_create(8u, &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    for (uint32_t r = 1u; r < rel->nrows; r += 2u) {
+        rc = wl_handle_remap_insert(remap,
+                mk_old_handle(r, 0u),
+                mk_new_handle(r, 0u));
+        ASSERT(rc == 0, "remap insert");
+    }
+
+    uint32_t handle_cols[1] = { 0u };
+    uint64_t rewrites = 0u;
+    rc = wl_handle_remap_apply_columns(rel, handle_cols, 1u, remap,
+            &rewrites);
+    ASSERT(rc == 0, "apply_columns rc != 0");
+    ASSERT(rewrites == 4u, "exactly half of 8 cells should rewrite");
+    /* The zero cells stayed zero; the rewritten cells got new handles. */
+    for (uint32_t r = 0; r < rel->nrows; r++) {
+        if (r % 2u == 0u) {
+            if (rel->columns[0][r] != 0)
+                FAIL("zero cell mutated");
+        } else {
+            if (rel->columns[0][r] != mk_new_handle(r, 0u))
+                FAIL("non-zero cell not rewritten");
+        }
+    }
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+static void
+test_apply_missing_handle_returns_eio(void)
+{
+    TEST("#589: a non-zero handle missing from remap returns EIO");
+
+    wl_handle_remap_t *remap = NULL;
+    col_rel_t *rel = NULL;
+
+    rel = build_relation(4u, 1u);
+    ASSERT(rel != NULL, "build_relation");
+
+    int rc = wl_handle_remap_create(4u, &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    /* Only insert the FIRST row's handle.  The second row's handle is
+     * non-zero but absent -- the apply pass must return EIO. */
+    rc = wl_handle_remap_insert(remap,
+            mk_old_handle(0u, 0u),
+            mk_new_handle(0u, 0u));
+    ASSERT(rc == 0, "remap insert");
+
+    uint32_t handle_cols[1] = { 0u };
+    uint64_t rewrites = 0u;
+    rc = wl_handle_remap_apply_columns(rel, handle_cols, 1u, remap,
+            &rewrites);
+    ASSERT(rc == EIO, "apply must return EIO on missing handle");
+    /* Only the first row should have been rewritten before the miss. */
+    ASSERT(rewrites == 1u, "rewrites must reflect prefix that succeeded");
+    ASSERT(rel->columns[0][0] == mk_new_handle(0u, 0u),
+        "first row should have been rewritten");
+    ASSERT(rel->columns[0][1] == mk_old_handle(1u, 0u),
+        "row that triggered EIO must remain at its old handle");
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+static void
+test_apply_invalid_args_einval(void)
+{
+    TEST("#589: NULL/OOR arguments are rejected with EINVAL");
+
+    col_rel_t *rel = build_relation(4u, 1u);
+    ASSERT(rel != NULL, "build_relation");
+    wl_handle_remap_t *remap = NULL;
+    int rc = wl_handle_remap_create(4u, &remap);
+    ASSERT(rc == 0, "remap create");
+
+    uint32_t cols_ok[1] = { 0u };
+    uint32_t cols_oor[1] = { 99u };
+    uint64_t out = 0;
+
+    ASSERT(wl_handle_remap_apply_columns(NULL, cols_ok, 1u, remap, &out)
+        == EINVAL, "NULL rel not rejected");
+    ASSERT(wl_handle_remap_apply_columns(rel, cols_ok, 1u, NULL, &out)
+        == EINVAL, "NULL remap not rejected");
+    ASSERT(wl_handle_remap_apply_columns(rel, NULL, 1u, remap, &out)
+        == EINVAL, "NULL idx with count > 0 not rejected");
+    ASSERT(wl_handle_remap_apply_columns(rel, cols_oor, 1u, remap, &out)
+        == EINVAL, "out-of-range column index not rejected");
+    /* count == 0 with NULL idx is a no-op success. */
+    ASSERT(wl_handle_remap_apply_columns(rel, NULL, 0u, remap, &out)
+        == 0, "count=0 should be a no-op success");
+    ASSERT(out == 0, "no-op must report zero rewrites");
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_handle_remap_apply (Issue #589)\n");
+    printf("====================================\n");
+
+    test_apply_10k_x_3_columns();
+    test_apply_zero_handles_unchanged();
+    test_apply_missing_handle_returns_eio();
+    test_apply_invalid_args_einval();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/handle_remap.c
+++ b/wirelog/columnar/handle_remap.c
@@ -1,0 +1,247 @@
+/*
+ * columnar/handle_remap.c - Compound-handle Remap Table (Issues #557 / #586 /
+ *                          #589 — implementation of the public surface frozen
+ *                          in handle_remap.h)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Open-addressing hash table with linear probing and SplitMix64 hashing,
+ * struct-of-arrays layout, no per-entry deletion.  See
+ * `handle_remap_design.md` for the rationale; this file is the
+ * mechanical realisation of that design.
+ */
+
+#include "handle_remap.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Smallest viable initial capacity (power of two).  Below this the
+ * rounding/mod arithmetic costs dominate the table; above this is fine.
+ * Matches handle_remap_design.md §2.7. */
+#define WL_HANDLE_REMAP_MIN_CAP 16u
+
+struct wl_handle_remap {
+    int64_t *keys;       /* capacity entries; 0 = empty                  */
+    int64_t *values;     /* capacity entries; valid iff keys[i] != 0     */
+    size_t capacity;     /* power of two; index mask = capacity - 1      */
+    size_t count;        /* live entries (excluding empties)             */
+    size_t rehash_at;    /* count threshold that triggers grow           */
+};
+
+/* SplitMix64 finalizer (handle_remap_design.md §3.3).  Branchless,
+ * well-mixed, identical to xxhash's internal finalizer and Java's
+ * SplittableRandom.  Used unconditionally for all keys. */
+static inline uint64_t
+wl_handle_remap_hash_(int64_t key)
+{
+    uint64_t x = (uint64_t)key;
+    x ^= x >> 30;
+    x *= 0xbf58476d1ce4e5b9ull;
+    x ^= x >> 27;
+    x *= 0x94d049bb133111ebull;
+    x ^= x >> 31;
+    return x;
+}
+
+/* Round @x up to the next power of two.  @x == 0 yields the minimum
+* capacity (caller decides what that is).  Returns 0 on overflow. */
+static size_t
+next_pow2_(size_t x)
+{
+    if (x == 0)
+        return 0;
+    /* If already a power of two, return as-is. */
+    if ((x & (x - 1)) == 0)
+        return x;
+    size_t p = 1u;
+    while (p && p < x)
+        p <<= 1;
+    return p; /* zero on overflow */
+}
+
+/* Compute the rehash threshold (75% of capacity) — same formula the
+ * design doc fixes at §2.4 and §4.1. */
+static inline size_t
+rehash_threshold_(size_t capacity)
+{
+    /* capacity * 3 / 4 -- exact for power-of-two capacity, no FP. */
+    return capacity - (capacity >> 2);
+}
+
+int
+wl_handle_remap_create(size_t capacity, wl_handle_remap_t **out)
+{
+    if (!out)
+        return WL_ERROR_INVALID_ARGS;
+    *out = NULL;
+
+    /* Pre-addition overflow gate (#589 meta-review): the load-factor
+     * headroom calc below adds capacity/3 + 1 to capacity; reject any
+     * input that would wrap size_t before the post-rounded check at
+     * the next gate.  capacity > SIZE_MAX/2 is a comfortable bound
+     * (the actual wrap is at ~3*SIZE_MAX/4) and keeps the constructor
+     * memory-safe regardless of caller discipline. */
+    if (capacity > SIZE_MAX / 2u)
+        return WL_ERROR_OOM;
+
+    /* Apply the load-factor headroom up front so the caller passes the
+     * raw expected entry count (per design §4.1 / §2.8). */
+    size_t target = capacity == 0
+        ? WL_HANDLE_REMAP_MIN_CAP
+        : capacity + (capacity / 3u) + 1u; /* ceil(capacity / 0.75) */
+    if (target < WL_HANDLE_REMAP_MIN_CAP)
+        target = WL_HANDLE_REMAP_MIN_CAP;
+
+    size_t cap = next_pow2_(target);
+    if (cap == 0)
+        return WL_ERROR_OOM; /* size_t overflow on ceil */
+
+    /* Belt-and-suspenders 32-bit overflow check (design §2.9): the SOA
+     * layout costs `capacity * sizeof(int64_t) * 2` bytes total. */
+    if (cap > SIZE_MAX / (sizeof(int64_t) * 2u))
+        return WL_ERROR_OOM;
+
+    wl_handle_remap_t *m
+        = (wl_handle_remap_t *)calloc(1, sizeof(*m));
+    if (!m)
+        return WL_ERROR_OOM;
+    m->keys = (int64_t *)calloc(cap, sizeof(int64_t));
+    m->values = (int64_t *)calloc(cap, sizeof(int64_t));
+    if (!m->keys || !m->values) {
+        free(m->keys);
+        free(m->values);
+        free(m);
+        return WL_ERROR_OOM;
+    }
+    m->capacity = cap;
+    m->count = 0;
+    m->rehash_at = rehash_threshold_(cap);
+    *out = m;
+    return 0;
+}
+
+void
+wl_handle_remap_free(wl_handle_remap_t *remap)
+{
+    if (!remap)
+        return;
+    free(remap->keys);
+    free(remap->values);
+    free(remap);
+}
+
+/* Probe-then-insert.  Returns 0 on success, WL_ERROR_OOM never (the
+ * caller is responsible for ensuring there is at least one empty slot
+ * — see grow logic in wl_handle_remap_insert).  Always finds either
+ * the matching key (overwrite) or an empty slot (insert) because the
+ * caller maintains count < capacity.
+ *
+ * Defense-in-depth (#589 meta-review): the linear-probe loop is
+ * unconditional `for(;;)`, so a bad invariant turns a future-bug into
+ * an infinite loop.  Trip-wire `if` converts that to a debuggable
+ * abort instead of a hang. */
+static void
+remap_put_unchecked_(wl_handle_remap_t *m,
+    int64_t key, int64_t value)
+{
+    if (m->count >= m->capacity)
+        abort(); /* invariant break: caller failed to grow */
+    size_t mask = m->capacity - 1u;
+    size_t i = (size_t)wl_handle_remap_hash_(key) & mask;
+    for (;;) {
+        int64_t k = m->keys[i];
+        if (k == 0) {
+            /* Empty slot: insert. */
+            m->keys[i] = key;
+            m->values[i] = value;
+            m->count++;
+            return;
+        }
+        if (k == key) {
+            /* Existing key: overwrite (per design §4.2 contract). */
+            m->values[i] = value;
+            return;
+        }
+        i = (i + 1u) & mask;
+    }
+}
+
+static int
+remap_grow_(wl_handle_remap_t *m)
+{
+    size_t new_cap = m->capacity * 2u;
+    if (new_cap < m->capacity) /* overflow */
+        return WL_ERROR_OOM;
+    if (new_cap > SIZE_MAX / (sizeof(int64_t) * 2u))
+        return WL_ERROR_OOM;
+
+    int64_t *nk = (int64_t *)calloc(new_cap, sizeof(int64_t));
+    int64_t *nv = (int64_t *)calloc(new_cap, sizeof(int64_t));
+    if (!nk || !nv) {
+        free(nk);
+        free(nv);
+        return WL_ERROR_OOM;
+    }
+
+    /* Swap in the new arrays before reinserting so the unchecked-put
+     * helper sees the new capacity/mask. */
+    int64_t *old_k = m->keys;
+    int64_t *old_v = m->values;
+    size_t old_cap = m->capacity;
+    m->keys = nk;
+    m->values = nv;
+    m->capacity = new_cap;
+    m->count = 0;
+    m->rehash_at = rehash_threshold_(new_cap);
+
+    for (size_t i = 0; i < old_cap; i++) {
+        if (old_k[i] != 0)
+            remap_put_unchecked_(m, old_k[i], old_v[i]);
+    }
+    free(old_k);
+    free(old_v);
+    return 0;
+}
+
+int
+wl_handle_remap_insert(wl_handle_remap_t *m,
+    int64_t old_handle, int64_t new_handle)
+{
+    if (!m || old_handle == 0)
+        return WL_ERROR_INVALID_ARGS;
+
+    /* Grow before insertion if the resulting count would cross the
+     * rehash threshold.  An overwrite of an existing key does not
+     * change count, but we cannot tell that without first probing —
+     * so check the worst case here.  This matches the design's §4.2
+     * "rehash to double capacity" rule and keeps probe length under
+     * the 0.75-load-factor bound. */
+    if (m->count + 1u > m->rehash_at) {
+        int rc = remap_grow_(m);
+        if (rc != 0)
+            return rc;
+    }
+    remap_put_unchecked_(m, old_handle, new_handle);
+    return 0;
+}
+
+int64_t
+wl_handle_remap_lookup(const wl_handle_remap_t *m, int64_t old_handle)
+{
+    if (!m || old_handle == 0)
+        return 0;
+
+    size_t mask = m->capacity - 1u;
+    size_t i = (size_t)wl_handle_remap_hash_(old_handle) & mask;
+    for (;;) {
+        int64_t k = m->keys[i];
+        if (k == 0)
+            return 0; /* empty -> miss */
+        if (k == old_handle)
+            return m->values[i];
+        i = (i + 1u) & mask;
+    }
+}

--- a/wirelog/columnar/handle_remap_apply.c
+++ b/wirelog/columnar/handle_remap_apply.c
@@ -1,0 +1,80 @@
+/*
+ * columnar/handle_remap_apply.c - EDB handle-remap apply pass (Issue #589)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "handle_remap_apply.h"
+
+#include "wirelog/util/log.h"
+
+#include <errno.h>
+#include <inttypes.h>
+
+int
+wl_handle_remap_apply_columns(col_rel_t *rel,
+    const uint32_t *handle_col_idx,
+    uint32_t handle_col_count,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rewrites)
+{
+    if (out_rewrites)
+        *out_rewrites = 0;
+    if (!rel || !remap)
+        return EINVAL;
+    if (handle_col_count > 0 && !handle_col_idx)
+        return EINVAL;
+    /* Validate each requested column index up front so we never write
+     * past the relation's column array on the row-scan loop below. */
+    for (uint32_t k = 0; k < handle_col_count; k++) {
+        if (handle_col_idx[k] >= rel->ncols)
+            return EINVAL;
+    }
+    if (handle_col_count == 0 || rel->nrows == 0)
+        return 0;
+
+    uint64_t rewrites = 0;
+    /* Outer loop is by column so the linear-probe cache footprint
+     * (keys[]/values[]) stays warm across rows for the same column.
+     * compound_arena_design.md §2 sized the table for the working set;
+     * each lookup is O(1) amortised. */
+    for (uint32_t k = 0; k < handle_col_count; k++) {
+        uint32_t c = handle_col_idx[k];
+        int64_t *col = rel->columns[c];
+        for (uint32_t r = 0; r < rel->nrows; r++) {
+            int64_t old_h = col[r];
+            if (old_h == 0)
+                continue; /* no compound in this row -- by design */
+            int64_t new_h
+                = wl_handle_remap_lookup(remap, old_h);
+            if (new_h == 0) {
+                /* Miss: any non-zero EDB handle must be present in the
+                 * remap.  This is a corruption signal; surface it so
+                 * the rotation helper can abort. */
+                WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+                    "event=remap_apply_miss rel=%s col=%u row=%u "
+                    "handle=0x%" PRIx64,
+                    rel->name ? rel->name : "(anon)", c, r,
+                    (uint64_t)old_h);
+                if (out_rewrites)
+                    *out_rewrites = rewrites;
+                return EIO;
+            }
+            col[r] = new_h;
+            rewrites++;
+        }
+    }
+    if (out_rewrites)
+        *out_rewrites = rewrites;
+    /* Issue #583 lifecycle audit (COMPOUND section): one summary line
+     * per relation makes the pass observable without flooding when the
+     * caller iterates many EDB relations. */
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=remap_apply rel=%s cols=%u rows=%u rewrites=%"
+        PRIu64,
+        rel->name ? rel->name : "(anon)", handle_col_count, rel->nrows,
+        rewrites);
+    return 0;
+}

--- a/wirelog/columnar/handle_remap_apply.h
+++ b/wirelog/columnar/handle_remap_apply.h
@@ -1,0 +1,86 @@
+/*
+ * columnar/handle_remap_apply.h - EDB handle-remap apply pass (Issue #589)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * INTERNAL HEADER - not installed, not part of public API.
+ *
+ * Row-scan helpers that rewrite compound handles in a col_rel_t's
+ * column buffers using a build-then-query wl_handle_remap_t.
+ *
+ * Used by the rotation helper (#550 Option C) to repoint EDB rows
+ * from the old session's compound arena to the new session's arena
+ * after a handle-renumbering pass.  The pass is single-threaded and
+ * runs while the compound arena is frozen (#561 / #584 freeze
+ * contract), so the table itself does not need internal
+ * synchronisation.
+ *
+ * Algorithm
+ * ---------
+ *
+ * For each row r of the relation, for each handle-bearing column c
+ * in @handle_col_idx:
+ *   - read the current handle value h = rel->columns[c][r];
+ *   - if h == 0 (WL_COMPOUND_HANDLE_NULL) leave the cell unchanged
+ *     (no compound there);
+ *   - look h up in the remap table -- on hit, write the new handle
+ *     back to the cell; on miss, treat as a corruption signal and
+ *     return EIO so the rotation helper can abort cleanly.
+ *
+ * Total complexity: O(nrows * handle_col_count).  No allocations.
+ */
+
+#ifndef WL_COLUMNAR_HANDLE_REMAP_APPLY_H
+#define WL_COLUMNAR_HANDLE_REMAP_APPLY_H
+
+#include "handle_remap.h"
+#include "internal.h"
+
+#include <stdint.h>
+
+/**
+ * wl_handle_remap_apply_columns:
+ * @rel:               relation whose handle columns should be rewritten.
+ *                     Must not be NULL.
+ * @handle_col_idx:    array of physical column indices that hold
+ *                     compound handles.  Must not be NULL when
+ *                     @handle_col_count > 0.  Each entry must be
+ *                     strictly less than @rel->ncols.
+ * @handle_col_count:  number of entries in @handle_col_idx.  Zero is
+ *                     a no-op.
+ * @remap:             populated remap table from a prior arena
+ *                     compaction pass.  Must not be NULL.
+ * @out_rewrites:      (out, optional): on success, receives the total
+ *                     number of cells rewritten across all columns.
+ *                     May be NULL.
+ *
+ * Walk every (row, column) cell in @handle_col_idx and rewrite the
+ * stored handle through @remap.  See file header for the full
+ * algorithm.
+ *
+ * Returns:
+ *   0 on success.
+ *   EINVAL if @rel, @remap, or (handle_col_count > 0 && handle_col_idx
+ *          == NULL) is invalid, or if any entry in @handle_col_idx
+ *          exceeds @rel->ncols.
+ *   EIO   if any non-zero handle in a target cell does not appear in
+ *         the remap table.  The rewrite is partial in this case:
+ *         columns [0..k-1] of @handle_col_idx are fully rewritten
+ *         and column k is rewritten through row r-1, where (r, k) is
+ *         the failing cell; (r, k) and beyond are unchanged.
+ *         @out_rewrites reflects exactly that prefix.  The relation
+ *         is in a half-rotated state — the caller (rotation helper,
+ *         #550 Option C) MUST treat it as poisoned: discard, restore
+ *         from a snapshot, or abort the rotation.  There is no
+ *         in-band roll-back primitive.
+ */
+int
+wl_handle_remap_apply_columns(col_rel_t *rel,
+    const uint32_t *handle_col_idx,
+    uint32_t handle_col_count,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rewrites);
+
+#endif /* WL_COLUMNAR_HANDLE_REMAP_APPLY_H */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -104,6 +104,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'columnar/rotation_mvcc.c',
                            'columnar/compound_side.c',
                            'columnar/handle_remap.c',
+                           'columnar/handle_remap_apply.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -103,6 +103,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'columnar/rotation_standard.c',
                            'columnar/rotation_mvcc.c',
                            'columnar/compound_side.c',
+                           'columnar/handle_remap.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==


### PR DESCRIPTION
## Summary
Critical-path stack closing #589 (EDB handle remap consumer) and **incidentally landing the missing #562 implementation** that #589 needed to link.

4 atomic commits:

1. \`feat(#562):\` implement \`wl_handle_remap_t\` open-addressing table — realises the #557/#586-frozen design verbatim (SplitMix64 finalizer, linear probing, SOA, 0.75 load factor, no delete, power-of-two capacity, §2.9 overflow gate).
2. \`feat(#589):\` \`wl_handle_remap_apply_columns\` rewrites EDB handles — O(N×K) row scan with caller-supplied \`handle_col_idx[]\` (SIDE-tier metadata is insufficient for self-discovery; rotation helper #550-C already walks the logical schema).
3. \`test(#589):\` 10K rows × 3 compound columns acceptance harness — pins all 5 acceptance bullets (rewrites, no EIO, dimensions, TSan-clean, ASAN-clean) plus 3 negative-path tests.
4. \`fix(#589):\` meta-review fold-ins — constructor pre-addition overflow gate, defense-in-depth abort in the unconditional probe loop, tightened EIO half-rotation contract in the header doc.

## Closes
- **Closes #589** (this is the EDB consumer it asks for).
- **Closes #563** (verbatim duplicate of #589, was open).
- **Closes #562** (the implementation #562 nominally owned was missing on main; this PR lands it).

## Multi-agent flow
1. **Architect + Critic** pre-review: BLOCKED — \`handle_remap.c\` missing, #589 duplicates closed #563. Architect supplied API plan.
2. **Implementer** landed the missing .c + apply pass + 10K×3 test as 3 atomic commits.
3. **Code-reviewer** APPROVE — 1 MAJOR (defense-in-depth assert) + 4 MINOR + 2 NIT + 3 PRAISE.
4. **Architect + Critic** meta-review: architect CONCUR/DIVERGE — fold the assert AND constructor overflow gate (one-liners closing real holes). Critic REVIEWER_OVERLOOKED — half-rotation EIO contract under-documented; PR body must cite #563 + #562.
5. **Implementer** landed the 4th fold-in commit.

## Test plan
- [x] \`meson test -C build\` → 167+1 OK + 1 skipped (suite grows by 1 with the new test)
- [x] \`meson test -C build-san handle_remap_apply\` (ASAN+UBSAN) → OK
- [x] \`meson test -C build-tsan handle_remap_apply\` → OK in 0.05s
- [x] uncrustify clean on all new files