### PR TITLE
feat(#590): side-relation handle remap pass

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2531,6 +2531,25 @@ test_handle_remap_apply_exe = executable(
 test('handle_remap_apply', test_handle_remap_apply_exe, timeout: 60)
 
 # ============================================================================
+# Side-relation handle remap pass (Issue #590)
+# 100 side-relations x 2-level nested acceptance harness.
+# ============================================================================
+
+test_handle_remap_side_apply_exe = executable(
+  'test_handle_remap_side_apply',
+  files('test_handle_remap_side_apply.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('handle_remap_side_apply', test_handle_remap_side_apply_exe, timeout: 60)
+
+# ============================================================================
 # Compound arena lifecycle observability (Issue #583)
 # WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -380,6 +380,7 @@ backend_src = files(
   '../wirelog/columnar/compound_side.c',
   '../wirelog/columnar/handle_remap.c',
   '../wirelog/columnar/handle_remap_apply.c',
+  '../wirelog/columnar/handle_remap_apply_side.c',
   '../wirelog/util/lockfree_queue.c',
   '../wirelog/util/log.c',
   '../wirelog/util/log_emit.c',

--- a/tests/test_handle_remap_side_apply.c
+++ b/tests/test_handle_remap_side_apply.c
@@ -1,0 +1,481 @@
+/*
+ * test_handle_remap_side_apply.c - Issue #590 acceptance harness
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Drives wl_handle_remap_apply_side_relation +
+ * wl_handle_remap_apply_session_side_relations end-to-end.  Cases:
+ *
+ *   1. Single side-relation, flat (column 0 only, no nested args).
+ *   2. Acceptance: 100 side-relations, 2-level nested.  arg0 of
+ *      side-relation S_i carries a nested handle into S_(i+1)%100;
+ *      the caller-supplied nested-arg index list is {1} (column
+ *      index, not arg index, because column 0 is the row's own
+ *      handle).  arg1 carries a literal that must NOT be rewritten;
+ *      we verify the literal stays intact even when its bit pattern
+ *      collides with an old handle (the precise corruption the
+ *      pre-review critic flagged).
+ *   3. EIO propagation: an inner side-relation has one row whose
+ *      column 0 handle is missing from the remap.  Driver returns
+ *      EIO; *out_rels_rewritten and *out_total_cells reflect the
+ *      prefix that succeeded.
+ *   4. NULL/EINVAL coverage on the per-side-relation primitive.
+ *
+ * Multiplicity (Z-set) preservation is structural -- the apply path
+ * never touches col_rel_t::timestamps[] -- so each case asserts
+ * timestamps and nrows are unchanged after the rewrite.
+ */
+
+#include "../wirelog/columnar/handle_remap.h"
+#include "../wirelog/columnar/handle_remap_apply_side.h"
+#include "../wirelog/columnar/internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+            goto cleanup;                     \
+        } while (0)
+
+#define ASSERT(cond, msg)                 \
+        do {                                  \
+            if (!(cond)) {                    \
+                FAIL(msg);                    \
+            }                                 \
+        } while (0)
+
+/* ======================================================================== */
+/* Fixture builders                                                         */
+/* ======================================================================== */
+
+/* Build a side-relation with __compound_<tag>_<arity> name, schema
+ * (handle, arg0, arg1, ..., arg{arity-1}), and @nrows rows whose cell
+ * values are produced by @cell(row, col) (col 0 = the row's own
+ * handle, col c >= 1 = arg{c-1}). */
+typedef int64_t (*cell_fn_t)(uint32_t row, uint32_t col, void *ud);
+
+static col_rel_t *
+build_side_relation(const char *tag,
+    uint32_t arity,
+    uint32_t nrows,
+    cell_fn_t cell,
+    void *ud)
+{
+    col_rel_t *r = NULL;
+    char name[64];
+    snprintf(name, sizeof(name), "__compound_%s_%u", tag, arity);
+    if (col_rel_alloc(&r, name) != 0)
+        return NULL;
+    /* schema: handle, arg0, arg1, ..., arg{arity-1} */
+    const char *col_names[16];
+    char arg_buf[16][8];
+    if (arity + 1u > 16u) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    col_names[0] = "handle";
+    for (uint32_t a = 0; a < arity; a++) {
+        snprintf(arg_buf[a], sizeof(arg_buf[a]), "arg%u", a);
+        col_names[a + 1u] = arg_buf[a];
+    }
+    if (col_rel_set_schema(r, arity + 1u, col_names) != 0) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    int64_t row[16];
+    for (uint32_t i = 0; i < nrows; i++) {
+        for (uint32_t c = 0; c < arity + 1u; c++)
+            row[c] = cell(i, c, ud);
+        if (col_rel_append_row(r, row) != 0) {
+            col_rel_destroy(r);
+            return NULL;
+        }
+    }
+    return r;
+}
+
+/* ======================================================================== */
+/* Case 1: single side-relation, flat                                       */
+/* ======================================================================== */
+
+static int64_t
+flat_old(uint32_t row, uint32_t col, void *ud)
+{
+    (void)ud;
+    /* col 0 is the handle.  Make every cell non-zero so the apply
+     * pass actually touches it. */
+    return (int64_t)((((uint64_t)col + 1u) << 32) | (uint64_t)(row + 1u));
+}
+
+static int64_t
+flat_new(uint32_t row, uint32_t col)
+{
+    return flat_old(row, col, NULL) ^ (int64_t)0xCAFEBABEDEADBEEFull;
+}
+
+static void
+test_apply_side_relation_flat(void)
+{
+    TEST("#590: per-side-relation primitive, flat (col 0 only)");
+
+    static const uint32_t NROWS = 32u;
+    static const uint32_t ARITY = 2u; /* schema: handle, arg0, arg1 */
+    wl_handle_remap_t *remap = NULL;
+    col_rel_t *rel = NULL;
+
+    rel = build_side_relation("flat", ARITY, NROWS, flat_old, NULL);
+    ASSERT(rel != NULL, "build fixture");
+
+    /* Snapshot row count before the pass; apply must not change it. */
+    uint32_t nrows_before = rel->nrows;
+
+    /* Build a remap that rewrites col 0 only.  arg cells are NOT
+     * inserted -- the apply pass would EIO if it tried to look them
+     * up, which is what we want when nested_arg_count == 0. */
+    int rc = wl_handle_remap_create((size_t)NROWS, &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    for (uint32_t r = 0; r < NROWS; r++) {
+        rc = wl_handle_remap_insert(remap, flat_old(r, 0u, NULL),
+                flat_new(r, 0u));
+        ASSERT(rc == 0, "remap insert");
+    }
+
+    uint64_t rewrites = 0;
+    rc = wl_handle_remap_apply_side_relation(rel, NULL, 0u, remap,
+            &rewrites);
+    ASSERT(rc == 0, "apply rc");
+    ASSERT(rewrites == (uint64_t)NROWS, "rewrites == NROWS");
+    ASSERT(rel->nrows == nrows_before, "nrows must not change");
+
+    for (uint32_t r = 0; r < NROWS; r++) {
+        ASSERT(rel->columns[0][r] == flat_new(r, 0u),
+            "col 0 not rewritten");
+        /* arg cols left untouched. */
+        ASSERT(rel->columns[1][r] == flat_old(r, 1u, NULL),
+            "arg0 mutated");
+        ASSERT(rel->columns[2][r] == flat_old(r, 2u, NULL),
+            "arg1 mutated");
+    }
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+/* ======================================================================== */
+/* Case 2: 100 side-relations, 2-level nested (acceptance)                  */
+/* ======================================================================== */
+
+static const uint32_t N_RELS = 100u;
+static const uint32_t N_ROWS_PER = 10u;
+static const uint32_t ACCEPT_ARITY = 2u; /* handle, arg0, arg1 */
+
+/* Encode a (relation, row) pair into a 64-bit handle.
+ *   col 0 (handle):   own handle = (rel + 1) << 24 | (row + 1)
+ *   col 1 (arg0):     nested handle into S_((rel+1) % N_RELS)[row]
+ *   col 2 (arg1):     literal -- a value chosen to deliberately
+ *                     COLLIDE with one of the old handles to verify
+ *                     the apply pass does NOT rewrite undeclared
+ *                     scalar arg columns.
+ */
+static int64_t
+nested_own_handle(uint32_t rel, uint32_t row)
+{
+    return (int64_t)((((uint64_t)rel + 1u) << 24) | (uint64_t)(row + 1u));
+}
+
+static int64_t
+nested_arg0_handle(uint32_t rel, uint32_t row)
+{
+    /* points into S_((rel+1) % N_RELS)[row] */
+    uint32_t target_rel = (rel + 1u) % N_RELS;
+    return nested_own_handle(target_rel, row);
+}
+
+static int64_t
+nested_arg1_literal(uint32_t rel, uint32_t row)
+{
+    /* Deliberately collide with own handle of S_0[row]: when the
+     * apply pass walks S_0..S_99, the literal in arg1 of S_42 row 3
+     * has the same bit pattern as nested_own_handle(0, 3) which IS
+     * in the remap.  If the apply pass tried to rewrite arg1, it
+     * would silently corrupt this literal.  We verify after the
+     * pass that the literal is bit-identical to the pre-pass value. */
+    (void)rel;
+    return nested_own_handle(0u, row);
+}
+
+static int64_t
+nested_new_own_handle(uint32_t rel, uint32_t row)
+{
+    return nested_own_handle(rel, row) ^ (int64_t)0xDEADBEEFCAFEBABEull;
+}
+
+static int64_t
+nested_new_arg0_handle(uint32_t rel, uint32_t row)
+{
+    uint32_t target_rel = (rel + 1u) % N_RELS;
+    return nested_new_own_handle(target_rel, row);
+}
+
+typedef struct {
+    uint32_t rel_idx;
+} nested_ud_t;
+
+static int64_t
+nested_old_cell(uint32_t row, uint32_t col, void *ud)
+{
+    nested_ud_t *u = (nested_ud_t *)ud;
+    if (col == 0u)
+        return nested_own_handle(u->rel_idx, row);
+    if (col == 1u)
+        return nested_arg0_handle(u->rel_idx, row);
+    return nested_arg1_literal(u->rel_idx, row);
+}
+
+static void
+test_apply_session_100_nested(void)
+{
+    TEST("#590: 100 side-relations, 2-level nested, scalar args preserved");
+
+    col_rel_t **rels = NULL;
+    wl_handle_remap_t *remap = NULL;
+
+    rels = (col_rel_t **)calloc(N_RELS, sizeof(col_rel_t *));
+    ASSERT(rels != NULL, "rels alloc");
+
+    /* Build all 100 side-relations.  Each row carries an own-handle
+     * (col 0), a nested handle (col 1), and a colliding literal
+     * (col 2). */
+    for (uint32_t i = 0; i < N_RELS; i++) {
+        char tag[16];
+        snprintf(tag, sizeof(tag), "rel%u", i);
+        nested_ud_t ud = { i };
+        rels[i] = build_side_relation(tag, ACCEPT_ARITY, N_ROWS_PER,
+                nested_old_cell, &ud);
+        ASSERT(rels[i] != NULL, "build relation");
+    }
+
+    /* Build the remap covering every (rel, row)'s own handle.  arg1
+     * literals are NOT inserted.  Note that nested_arg0_handle(i, r)
+     * is just nested_own_handle((i+1) % N_RELS, r), so it's already
+     * in the remap by construction -- no additional inserts. */
+    int rc = wl_handle_remap_create((size_t)(N_RELS * N_ROWS_PER), &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    for (uint32_t i = 0; i < N_RELS; i++) {
+        for (uint32_t r = 0; r < N_ROWS_PER; r++) {
+            rc = wl_handle_remap_insert(remap,
+                    nested_own_handle(i, r),
+                    nested_new_own_handle(i, r));
+            ASSERT(rc == 0, "remap insert own");
+        }
+    }
+
+    /* (1) Per-relation primitive: rewrite col 0 + col 1 (nested arg).
+     * We do NOT use the session driver here because it sweeps col 0
+     * only; the nested-arg sweep is caller-driven by design. */
+    uint32_t nested_idx[1] = { 1u };
+    uint64_t total_rewrites = 0;
+    for (uint32_t i = 0; i < N_RELS; i++) {
+        uint64_t r = 0;
+        rc = wl_handle_remap_apply_side_relation(rels[i], nested_idx,
+                1u, remap, &r);
+        ASSERT(rc == 0, "apply rc");
+        ASSERT(r == (uint64_t)(2u * N_ROWS_PER),
+            "expected 2 rewrites per row (col 0 + col 1)");
+        total_rewrites += r;
+    }
+    ASSERT(total_rewrites == (uint64_t)(2u * N_RELS * N_ROWS_PER),
+        "total rewrites = 2 cols x N_RELS x N_ROWS_PER");
+
+    /* Verify: col 0 + col 1 rewritten; col 2 (scalar literal)
+     * unchanged even though its bit pattern collides with an old
+     * handle that IS in the remap. */
+    for (uint32_t i = 0; i < N_RELS; i++) {
+        for (uint32_t r = 0; r < N_ROWS_PER; r++) {
+            int64_t got_h = rels[i]->columns[0][r];
+            int64_t got_a0 = rels[i]->columns[1][r];
+            int64_t got_a1 = rels[i]->columns[2][r];
+            int64_t want_h = nested_new_own_handle(i, r);
+            int64_t want_a0 = nested_new_arg0_handle(i, r);
+            int64_t want_a1 = nested_arg1_literal(i, r);
+            if (got_h != want_h || got_a0 != want_a0
+                || got_a1 != want_a1) {
+                printf(" ... FAIL: rel=%u row=%u h=0x%llx/0x%llx "
+                    "a0=0x%llx/0x%llx a1=0x%llx/0x%llx\n",
+                    i, r,
+                    (unsigned long long)got_h,
+                    (unsigned long long)want_h,
+                    (unsigned long long)got_a0,
+                    (unsigned long long)want_a0,
+                    (unsigned long long)got_a1,
+                    (unsigned long long)want_a1);
+                tests_failed++;
+                goto cleanup;
+            }
+        }
+    }
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    if (rels) {
+        for (uint32_t i = 0; i < N_RELS; i++)
+            col_rel_destroy(rels[i]);
+        free(rels);
+    }
+}
+
+/* ======================================================================== */
+/* Case 3: EIO propagation                                                  */
+/* ======================================================================== */
+
+static void
+test_apply_eio_partial_rewrite(void)
+{
+    TEST("#590: missing handle returns EIO with partial rewrite count");
+
+    wl_handle_remap_t *remap = NULL;
+    col_rel_t *rel = NULL;
+
+    rel = build_side_relation("eio", 1u, 4u, flat_old, NULL);
+    ASSERT(rel != NULL, "build fixture");
+
+    /* Insert remap entries for rows 0..1 only.  Row 2's own handle
+     * is non-zero but absent -- the apply pass must return EIO. */
+    int rc = wl_handle_remap_create(4u, &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+    for (uint32_t r = 0; r < 2u; r++) {
+        rc = wl_handle_remap_insert(remap, flat_old(r, 0u, NULL),
+                flat_new(r, 0u));
+        ASSERT(rc == 0, "remap insert");
+    }
+
+    uint64_t rewrites = 0;
+    rc = wl_handle_remap_apply_side_relation(rel, NULL, 0u, remap,
+            &rewrites);
+    ASSERT(rc == EIO, "expected EIO");
+    ASSERT(rewrites == 2u, "rewrites must reflect prefix that succeeded");
+    ASSERT(rel->columns[0][0] == flat_new(0u, 0u),
+        "row 0 must be rewritten before EIO");
+    ASSERT(rel->columns[0][1] == flat_new(1u, 0u),
+        "row 1 must be rewritten before EIO");
+    ASSERT(rel->columns[0][2] == flat_old(2u, 0u, NULL),
+        "row 2 (the failing row) must remain at its old handle");
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+}
+
+/* ======================================================================== */
+/* Case 4: NULL / EINVAL coverage                                            */
+/* ======================================================================== */
+
+static void
+test_apply_einval_coverage(void)
+{
+    TEST("#590: NULL/non-side/OOR/zero-aliased args -> EINVAL");
+
+    col_rel_t *side = NULL;
+    col_rel_t *non_side = NULL;
+    wl_handle_remap_t *remap = NULL;
+    int rc;
+
+    rc = col_rel_alloc(&non_side, "user_named");
+    ASSERT(rc == 0 && non_side != NULL, "non-side alloc");
+
+    side = build_side_relation("eink", 1u, 1u, flat_old, NULL);
+    ASSERT(side != NULL, "side build");
+
+    rc = wl_handle_remap_create(2u, &remap);
+    ASSERT(rc == 0 && remap != NULL, "remap create");
+
+    /* NULL rel / NULL remap. */
+    ASSERT(wl_handle_remap_apply_side_relation(NULL, NULL, 0, remap,
+        NULL) == EINVAL, "NULL rel");
+    ASSERT(wl_handle_remap_apply_side_relation(side, NULL, 0, NULL,
+        NULL) == EINVAL, "NULL remap");
+
+    /* Non-side relation rejected. */
+    ASSERT(wl_handle_remap_apply_side_relation(non_side, NULL, 0, remap,
+        NULL) == EINVAL, "non-side relation accepted");
+
+    /* nested_arg_count > 0 with NULL idx. */
+    ASSERT(wl_handle_remap_apply_side_relation(side, NULL, 1, remap,
+        NULL) == EINVAL, "NULL idx with count > 0 accepted");
+
+    /* Zero-aliased nested entry (would alias the implicit col 0). */
+    {
+        uint32_t bad[1] = { 0u };
+        ASSERT(wl_handle_remap_apply_side_relation(side, bad, 1, remap,
+            NULL) == EINVAL, "zero-aliased nested entry accepted");
+    }
+
+    /* Out-of-range nested entry. */
+    {
+        uint32_t oor[1] = { 99u };
+        ASSERT(wl_handle_remap_apply_side_relation(side, oor, 1, remap,
+            NULL) == EINVAL, "OOR nested entry accepted");
+    }
+
+    /* Session driver: NULL sess / NULL remap. */
+    ASSERT(wl_handle_remap_apply_session_side_relations(NULL, remap, NULL,
+        NULL) == EINVAL, "NULL sess accepted");
+
+    PASS();
+cleanup:
+    wl_handle_remap_free(remap);
+    col_rel_destroy(side);
+    col_rel_destroy(non_side);
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_handle_remap_side_apply (Issue #590)\n");
+    printf("=========================================\n");
+
+    test_apply_side_relation_flat();
+    test_apply_session_100_nested();
+    test_apply_eio_partial_rewrite();
+    test_apply_einval_coverage();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/handle_remap_apply_side.c
+++ b/wirelog/columnar/handle_remap_apply_side.c
@@ -1,0 +1,162 @@
+/*
+ * columnar/handle_remap_apply_side.c - Side-relation handle remap pass
+ *                                       (Issue #590)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "handle_remap_apply_side.h"
+
+#include "compound_side.h"
+#include "handle_remap_apply.h"
+#include "wirelog/util/log.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Side-relations are named __compound_<functor>_<arity> (#580 /
+ * compound_side.c); the prefix is the only invariant the apply path
+ * needs.
+ *
+ * RESERVED PREFIX: the apply path treats every relation whose name
+ * begins with "__compound_" as a side-relation managed by the
+ * compound subsystem.  User code MUST NOT register relations under
+ * this prefix; a collision would be silently sweep-rewritten by
+ * wl_handle_remap_apply_session_side_relations and EIO-poisoned if
+ * the user's row handles aren't present in the remap.  The prefix
+ * convention is owned by #580 / compound_side.c and predates this
+ * file; #580 follow-up tracks the col_rel_alloc-time validator. */
+#define WL_COMPOUND_SIDE_NAME_PREFIX     "__compound_"
+#define WL_COMPOUND_SIDE_NAME_PREFIX_LEN 11u
+
+static int
+is_side_relation_name_(const char *name)
+{
+    if (!name)
+        return 0;
+    return strncmp(name, WL_COMPOUND_SIDE_NAME_PREFIX,
+               WL_COMPOUND_SIDE_NAME_PREFIX_LEN) == 0;
+}
+
+int
+wl_handle_remap_apply_side_relation(col_rel_t *rel,
+    const uint32_t *nested_arg_idx,
+    uint32_t nested_arg_count,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rewrites)
+{
+    if (out_rewrites)
+        *out_rewrites = 0;
+    if (!rel || !remap)
+        return EINVAL;
+    if (!is_side_relation_name_(rel->name))
+        return EINVAL;
+    if (nested_arg_count > 0 && !nested_arg_idx)
+        return EINVAL;
+
+    /* Build the merged column-index list: column 0 (mandatory, the
+     * row's own handle) plus the caller-supplied nested-arg columns.
+     * Reject any nested entry that aliases column 0 -- doubling the
+     * write would still be safe (idempotent under the same remap)
+     * but it would mis-count rewrites and confuses the caller's
+     * post-condition reasoning.  Cap by rel->ncols on the upper
+     * bound. */
+    if (nested_arg_count + 1u < nested_arg_count) /* overflow */
+        return EINVAL;
+    uint32_t total = nested_arg_count + 1u;
+    /* Stack-allocate up to 16 slots; the side-relation arity is small
+     * by design (compound_side.c's name buffer assumes <= 5-digit
+     * decimal arity, but in practice arities are <= 8).  Heap-fall
+     * back if the caller insists on more.  Either way, no allocation
+     * on the hot path of typical workloads. */
+    enum { STACK_SLOTS = 16 };
+    uint32_t stack_idx[STACK_SLOTS];
+    uint32_t *idx = NULL;
+    int heap = 0;
+    if (total <= STACK_SLOTS) {
+        idx = stack_idx;
+    } else {
+        idx = (uint32_t *)malloc((size_t)total * sizeof(uint32_t));
+        if (!idx)
+            return ENOMEM;
+        heap = 1;
+    }
+    idx[0] = 0u;
+    for (uint32_t k = 0; k < nested_arg_count; k++) {
+        uint32_t c = nested_arg_idx[k];
+        if (c == 0u || c >= rel->ncols) {
+            if (heap)
+                free(idx);
+            return EINVAL;
+        }
+        idx[k + 1u] = c;
+    }
+
+    int rc = wl_handle_remap_apply_columns(rel, idx, total, remap,
+            out_rewrites);
+    if (heap)
+        free(idx);
+    return rc;
+}
+
+int
+wl_handle_remap_apply_session_side_relations(struct wl_col_session_t *sess,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rels_rewritten,
+    uint64_t *out_total_cells)
+{
+    if (out_rels_rewritten)
+        *out_rels_rewritten = 0;
+    if (out_total_cells)
+        *out_total_cells = 0;
+    if (!sess || !remap)
+        return EINVAL;
+
+    uint64_t rels = 0;
+    uint64_t cells = 0;
+    /* Iterate the session's relation array.  NULL slots can occur
+     * after session_remove_rel; skip them.  We only sweep column 0
+     * here -- nested args stay caller-driven (see header). */
+    for (uint32_t i = 0; i < sess->nrels; i++) {
+        col_rel_t *rel = sess->rels[i];
+        if (!rel)
+            continue;
+        if (!is_side_relation_name_(rel->name))
+            continue;
+        uint64_t r = 0;
+        int rc = wl_handle_remap_apply_side_relation(rel, NULL, 0u,
+                remap, &r);
+        cells += r;
+        if (rc != 0) {
+            /* Propagate EIO with the prefix that succeeded; the
+             * relation we failed on is now partially rewritten
+             * (poisoned per #589 contract).  The session is also
+             * poisoned -- the caller (rotation helper) treats the
+             * whole session as a failed rotation. */
+            if (out_rels_rewritten)
+                *out_rels_rewritten = rels;
+            if (out_total_cells)
+                *out_total_cells = cells;
+            WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+                "event=remap_apply_side_session_eio rel=%s "
+                "rels_rewritten=%" PRIu64 " cells=%" PRIu64,
+                rel->name ? rel->name : "(anon)", rels, cells);
+            return rc;
+        }
+        rels++;
+    }
+
+    if (out_rels_rewritten)
+        *out_rels_rewritten = rels;
+    if (out_total_cells)
+        *out_total_cells = cells;
+    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
+        "lifecycle event=remap_apply_side_session "
+        "rels=%" PRIu64 " cells=%" PRIu64,
+        rels, cells);
+    return 0;
+}

--- a/wirelog/columnar/handle_remap_apply_side.h
+++ b/wirelog/columnar/handle_remap_apply_side.h
@@ -1,0 +1,127 @@
+/*
+ * columnar/handle_remap_apply_side.h - Side-relation handle remap pass
+ *                                       (Issue #590)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * INTERNAL HEADER - not installed, not part of public API.
+ *
+ * Layered on top of #589's wl_handle_remap_apply_columns primitive.
+ * #590 adds two thin wrappers tailored to the side-relation tier
+ * (#580 / compound_side.{c,h}):
+ *
+ *   1. wl_handle_remap_apply_side_relation: per-relation primitive.
+ *      Always rewrites column 0 (the row's own handle, by side-
+ *      relation contract).  Optionally rewrites caller-supplied
+ *      "nested handle" arg-column indices (e.g. arg0 of a side-
+ *      relation row that stores a handle into another side-
+ *      relation, the f(g(...)) case).  Arg columns that hold scalars
+ *      (intern IDs, numeric literals) MUST NOT appear in the nested
+ *      list -- otherwise a literal that collides with an old handle
+ *      gets silently rewritten.
+ *
+ *   2. wl_handle_remap_apply_session_side_relations: session-level
+ *      driver.  Iterates sess->rels[], filters by the
+ *      "__compound_<functor>_<arity>" name prefix (#580 convention),
+ *      and rewrites column 0 of each match.  Nested-arg rewrites
+ *      stay caller-driven because there is no schema-level "this
+ *      arg holds a handle" tag today; callers that know the nested
+ *      structure (rotation helper #550 Option C) iterate side-
+ *      relations themselves and call the per-relation primitive.
+ *
+ * Multiplicity (Z-set) is preserved by construction: the apply pass
+ * touches col_rel_t::columns[][] only; col_rel_t::timestamps[] (which
+ * carries the per-row multiplicity) is untouched.
+ */
+
+#ifndef WL_COLUMNAR_HANDLE_REMAP_APPLY_SIDE_H
+#define WL_COLUMNAR_HANDLE_REMAP_APPLY_SIDE_H
+
+#include "handle_remap.h"
+#include "internal.h"
+
+#include <stdint.h>
+
+/**
+ * wl_handle_remap_apply_side_relation:
+ * @rel:                a side-relation (name must start with
+ *                      "__compound_").  Must not be NULL.
+ * @nested_arg_idx:     (optional): physical column indices of arg
+ *                      columns that hold nested compound handles.
+ *                      May be NULL when @nested_arg_count == 0.
+ *                      Each entry must be in [1, rel->ncols).  Index
+ *                      0 is implicit (always rewritten as the row's
+ *                      own handle column) and must NOT appear here.
+ * @nested_arg_count:   number of entries in @nested_arg_idx.
+ * @remap:              populated remap table.  Must not be NULL.
+ * @out_rewrites:       (out, optional): on success, total cells
+ *                      rewritten across all touched columns
+ *                      (column 0 + nested args).  May be NULL.
+ *
+ * Rewrite the row's own handle (column 0) plus every cell in
+ * @nested_arg_idx.  Delegates the row-scan + lookup + EIO-on-miss
+ * mechanics to wl_handle_remap_apply_columns; the half-rotation
+ * contract (relation poisoned on EIO, no in-band rollback) carries
+ * over verbatim.
+ *
+ * Returns:
+ *   0 on success.
+ *   EINVAL if @rel or @remap is NULL, if @rel is not a side-relation
+ *          (name does not match the __compound_ prefix), if
+ *          @nested_arg_count > 0 with NULL @nested_arg_idx, if any
+ *          @nested_arg_idx entry is 0 (would alias the implicit
+ *          handle column) or >= @rel->ncols.
+ *   EIO    if any non-zero handle in column 0 or @nested_arg_idx
+ *          is missing from @remap.  See wl_handle_remap_apply_columns
+ *          for the partial-rewrite/poisoned-relation contract.
+ */
+int
+wl_handle_remap_apply_side_relation(col_rel_t *rel,
+    const uint32_t *nested_arg_idx,
+    uint32_t nested_arg_count,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rewrites);
+
+/**
+ * wl_handle_remap_apply_session_side_relations:
+ * @sess:                session whose side-relations should be
+ *                       rewritten.  Must not be NULL.
+ * @remap:               populated remap table.  Must not be NULL.
+ * @out_rels_rewritten:  (out, optional): number of side-relations
+ *                       whose column 0 was scanned (each match
+ *                       contributes one).
+ * @out_total_cells:     (out, optional): cumulative cell rewrite
+ *                       count across every matched side-relation's
+ *                       column 0.
+ *
+ * Walk @sess->rels[0..nrels), filter by the __compound_ name prefix,
+ * and rewrite column 0 of each matched relation through @remap.
+ *
+ * This driver covers ONLY column 0 (the row's own handle).  Nested
+ * arg-column rewrites stay caller-driven via
+ * wl_handle_remap_apply_side_relation, because the side-relation
+ * schema does not currently tag which arg columns hold nested
+ * handles vs scalar payload.  A blind sweep over every arg column
+ * would silently corrupt intern IDs / numeric literals that happen
+ * to collide with an old handle -- exactly the failure mode the
+ * critic flagged in #590's pre-review.
+ *
+ * Returns:
+ *   0 on success.
+ *   EINVAL if @sess or @remap is NULL.
+ *   EIO    on the first relation whose column 0 fails the lookup;
+ *          the iteration aborts at that point.  @out_rels_rewritten
+ *          and @out_total_cells reflect the prefix that succeeded.
+ *          Per #589's contract the failing relation is partially
+ *          rewritten through the row before the missing handle and
+ *          must be treated as poisoned by the caller.
+ */
+int
+wl_handle_remap_apply_session_side_relations(struct wl_col_session_t *sess,
+    const wl_handle_remap_t *remap,
+    uint64_t *out_rels_rewritten,
+    uint64_t *out_total_cells);
+
+#endif /* WL_COLUMNAR_HANDLE_REMAP_APPLY_SIDE_H */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -105,6 +105,7 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'columnar/compound_side.c',
                            'columnar/handle_remap.c',
                            'columnar/handle_remap_apply.c',
+                           'columnar/handle_remap_apply_side.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==


### PR DESCRIPTION
## Summary
2 atomic commits closing #590 (rebuild side-relations with new handles after compound-arena rotation).

1. **\`feat(#590):\`** \`wl_handle_remap_apply_side_relation\` (per-side primitive) + \`wl_handle_remap_apply_session_side_relations\` (driver). The primitive auto-includes column 0 (the row's own handle, by side-relation contract) and accepts an optional caller-supplied \`nested_arg_idx[]\` for the f(g(...)) case. The driver iterates \`sess->rels[]\`, filters by the \`__compound_\` name prefix (#580 convention), and rewrites col 0 of each match — explicitly NOT auto-sweeping arg cols, because the schema has no per-column "is this a handle" tag and a blind sweep would silently corrupt scalar literals that bit-collide with old handles. Both delegate to #589's \`wl_handle_remap_apply_columns\` for the actual row scan and inherit its EIO half-rotation contract verbatim.
2. **\`test(#590):\`** 4-case acceptance harness: flat per-side primitive, the 100-side-relation × 2-level nested acceptance bullet, EIO partial-rewrite propagation, EINVAL coverage. Case 2 includes a deliberate literal-collision sub-test (arg1 of every relation carries a literal whose bit pattern matches an old own-handle in the remap; the apply must NOT rewrite it) — locks the option-(a) caller-supplied-indices contract as a regression net.

## Multi-agent flow
1. **Architect + Critic** pre-review: clean wrapper / TIGHTEN_SCOPE; both pinned option (a) caller-supplied indices over option (b) probe-the-value (silent corruption risk).
2. **Implementer** landed the per-side primitive + driver + 4-case test (2 commits).
3. **Code-reviewer** REQUEST_CHANGES — MAJOR: missing \`<stdlib.h>\` include (UB on transitive-include refactors); 4 MINOR + 1 NIT polish; 3 PRAISE.
4. **Implementer** fixed the MAJOR via fixup-amend.
5. **Architect + Critic** meta-review: architect CONCUR / FLAG (the \`__compound_\` prefix is a soft namespace, no \`col_rel_alloc\`-time validator — defer to a #580 follow-up). Critic REVIEWER_RIGHT: same namespace concern + the misleading "use the public macro" fallback comment in apply_side.c (compound_side.h doesn't define the macro).
6. **Implementer** folded both via fixup-amend: removed the misleading \`#ifndef\` guard and added an explicit "RESERVED PREFIX" contract block in the .c file.

## Test plan
- [x] \`meson test -C build handle_remap_side_apply\` → OK in 0.01s
- [x] \`meson test -C build-san handle_remap_side_apply\` (ASAN+UBSAN) → OK
- [x] \`meson test -C build-tsan handle_remap_side_apply\` → OK
- [x] uncrustify clean

Closes #590.