### PR TITLE
feat(#594): parameterizable stress harness + nightly CI gate

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -147,3 +147,62 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo '</details>' >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # ==========================================================================
+  # Stress nightly (Issue #594): runs the W=4 / R=500 freeze-cycle and
+  # W=4 / R=5000 apply-roundtrip workloads under TSan instrumentation on
+  # Linux GCC.  Independent of the perf gate above (different build flags
+  # and different test suite) so a stress regression doesn't mask a perf
+  # regression and vice-versa.  See docs/STRESS_BASELINE.md for the
+  # release-tier (W=8) invocation and the flake-baseline protocol.
+  # ==========================================================================
+  stress:
+    name: Stress / ubuntu-latest / gcc / TSan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build
+
+      - name: Configure debug + TSan
+        run: >
+          meson setup build-stress-tsan
+          -Db_sanitize=thread
+          -Db_lundef=false
+          -Dthreads=posix
+          -Dtests=true
+          --buildtype=debug
+        env:
+          CC: gcc
+
+      - name: Build
+        run: meson compile -C build-stress-tsan
+
+      - name: Run stress-nightly suite under TSan
+        env:
+          TSAN_OPTIONS: 'halt_on_error=1:second_deadlock_stack=1'
+        run: |
+          meson test -C build-stress-tsan --suite stress-nightly \
+            --print-errorlogs --num-processes 1
+
+      - name: Publish results
+        if: always()
+        shell: bash
+        run: |
+          STATUS="${{ job.status }}"
+          echo "## Stress Nightly: ubuntu-latest / gcc / TSan" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo "Status: **${STATUS}**" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f build-stress-tsan/meson-logs/testlog.txt ]; then
+            echo '<details><summary>Stress-nightly testlog</summary>' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -A 30 'stress_harness' build-stress-tsan/meson-logs/testlog.txt 2>/dev/null \
+              | head -200 >> "$GITHUB_STEP_SUMMARY" || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo '</details>' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/STRESS_BASELINE.md
+++ b/docs/STRESS_BASELINE.md
@@ -1,0 +1,165 @@
+# Stress Harness Baseline Protocol (Issue #594)
+
+This document covers the K-Fusion arena stress harness that
+ships in `tests/test_stress_harness.c`: how it is wired into CI,
+how to run the release-tier (W=8) variant locally, and the flake-
+baseline protocol the repo uses to triage intermittent failures.
+
+## CI tier topology
+
+The same `test_stress_harness` binary is registered six times in
+`tests/meson.build` with different `env:` blocks and meson `suite:`
+tags so a single configurable harness backs three CI tiers
+without duplicating code.
+
+| Test name | Suite | Workload | W | R | Where it runs |
+|---|---|---|---|---|---|
+| `stress_harness_w2` | (default) | freeze-cycle | 2 | 200 | every PR (`ci-pr.yml` -> `meson test`) |
+| `stress_harness_apply_roundtrip_pr` | (default) | apply-roundtrip | 2 | 500 | every PR |
+| `stress_harness_w4` | `stress-nightly` | freeze-cycle | 4 | 500 | nightly (`perf-nightly.yml`, 04:00 UTC) |
+| `stress_harness_apply_roundtrip_nightly` | `stress-nightly` | apply-roundtrip | 4 | 5000 | nightly |
+| `stress_harness_w8` | `stress-release` | freeze-cycle | 8 | 1000 | release-tier (manual, see below) |
+| `stress_harness_apply_roundtrip_release` | `stress-release` | apply-roundtrip | 8 | 50000 | release-tier (manual) |
+
+The PR tier runs in the default suite, picked up by every
+`meson test -C build` invocation in `ci-pr.yml`/`ci-main.yml`. The
+nightly tier runs under TSan in `perf-nightly.yml`'s `stress` job.
+The release tier has no GitHub workflow today; release engineers
+invoke it manually before tagging.
+
+## Workloads
+
+### `freeze-cycle`
+
+Verbatim lift of #582's freeze-cycle stress. Each cycle:
+
+1. coordinator alloc()s a sentinel handle on `coord->compound_arena`,
+2. coordinator freeze()s the arena,
+3. submit `W` workers via `wl_workqueue_submit`; each worker does
+   `wl_compound_arena_lookup` (must succeed) plus
+   `wl_compound_arena_alloc` (must refuse while frozen),
+4. wait_all,
+5. coordinator unfreeze + `gc_epoch_boundary` advances the epoch.
+
+`R` is the cycle count and is bounded by the arena's 4096 epoch cap;
+the harness rejects `WL_STRESS_R >= max_epochs` with a hard FAIL.
+
+### `apply-roundtrip`
+
+Pre-rotation handles must remain valid post-apply (#594 acceptance
+bullet). Sequence:
+
+1. allocate `R` rows, each carrying a non-zero handle in column 0,
+2. build a deterministic remap: `new_handle = old_handle XOR
+   0xDEADBEEFCAFEBABE`,
+3. call `wl_handle_remap_apply_columns` (#589) to rewrite the
+   column in place,
+4. assert every cell carries the expected post-apply handle.
+
+`W` is accepted but ignored: `wl_handle_remap_apply_columns` is
+single-mutator by contract; concurrent appliers would corrupt each
+other's prefix. The W parameter stays in the harness signature for
+CI-tier wiring uniformity. `R` is row count, only bounded by
+available memory; release-tier exercises 50000 rows.
+
+## Running release-tier locally
+
+There is no `release.yml` workflow yet (deferred follow-up). To
+gate a release manually:
+
+```bash
+meson setup build-stress-tsan -Db_sanitize=thread -Db_lundef=false \
+    -Dthreads=posix -Dtests=true --buildtype=debug
+meson compile -C build-stress-tsan
+TSAN_OPTIONS='halt_on_error=1' \
+    meson test -C build-stress-tsan --suite stress-release \
+    --print-errorlogs --num-processes 1
+```
+
+Both `stress_harness_w8` (freeze-cycle, 1000 cycles) and
+`stress_harness_apply_roundtrip_release` (apply-roundtrip, 50000
+rows) must pass. Wall time is sub-minute on a typical x86_64
+laptop under TSan; the test() entries set `timeout: 300` as
+headroom.
+
+## Flake baseline protocol
+
+A "flake" is a TSan-clean test that fails non-deterministically
+under stress instrumentation. The baseline distinguishes flakes
+from real regressions.
+
+### Capturing a baseline
+
+After a stress test lands or its parameters change, capture a
+baseline pass-rate over many runs to learn the natural failure
+floor. From a clean working tree:
+
+```bash
+# 100-run baseline for the PR tier (cheap, sub-minute total).
+N=100
+fails=0
+for i in $(seq 1 "$N"); do
+    meson test -C build stress_harness_w2 \
+        stress_harness_apply_roundtrip_pr >/dev/null 2>&1 \
+        || fails=$((fails + 1))
+done
+echo "PR-tier baseline: $((N - fails)) / $N pass"
+```
+
+Replace the test-name list with `--suite stress-nightly` or
+`--suite stress-release` for the heavier tiers.
+
+A 100-run pass rate of:
+
+- **100 / 100** -> healthy. Any single failure in CI is a real
+  regression, not a flake.
+- **99 / 100 - 95 / 100** -> the test has a tolerable flake floor.
+  Document the rate inline at the top of the workload function in
+  `test_stress_harness.c` and treat single CI failures as flakes
+  for retry, but trigger investigation if two consecutive nightly
+  runs fail.
+- **< 95 / 100** -> the test is too flaky to gate on. Either
+  reduce R (lower confidence) or fix the underlying race before
+  re-enabling the gate.
+
+### Triaging a CI failure against the baseline
+
+When a CI run reports `stress_harness_*` FAIL:
+
+1. Re-run the failed job once. Pass on retry + healthy baseline =
+   flake; close-as-flaky.
+2. Persistent failure across two consecutive runs OR a healthy
+   baseline (100/100) PROVES it's a regression. Open a P1 issue
+   referencing the SHA, attach `meson-logs/testlog.txt` and the
+   relevant TSan/ASAN diagnostic, and bisect.
+
+### Re-baselining
+
+Re-run the baseline capture whenever:
+
+- The harness's `R` defaults change.
+- A new workload is added.
+- A worker_fn or apply pass implementation changes (the upstream
+  primitives in `wl_handle_remap_apply_columns`,
+  `wl_compound_arena_lookup`, etc.).
+- TSan / sanitizer toolchain version changes in CI image.
+
+Record the new baseline pass-rate in the file header docstring of
+`test_stress_harness.c` so future on-callers do not have to
+re-derive it.
+
+## Out of scope (#594 follow-up tracking)
+
+- **Release-tier CI workflow**: no `release.yml` exists yet. The
+  W=8 invocation runs manually per the script above. Adding an
+  automated release pipeline is a separate (follow-up) issue.
+- **Cross-arena rotation workload**: this harness exercises the
+  *in-place* apply pass (#589 / #590). Cross-arena rotation needs
+  the #550 Option C `wl_session_rotate` helper, which has not
+  landed; a sibling workload will be added when #550-C ships.
+- **Existing hardcoded canaries**: `test_compound_arena_freeze_
+  cycle_stress.c` (#582), `test_gc_freeze_alloc_race.c` (#584),
+  and `test_worker_borrow_w2_tsan.c` (#592) are intentionally
+  retained un-refactored. They serve as fixed-W canaries; the
+  parameterizable harness is in addition to, not in place of,
+  them.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2596,6 +2596,66 @@ test_worker_borrow_w2_tsan_exe = executable(
 test('worker_borrow_w2_tsan', test_worker_borrow_w2_tsan_exe, timeout: 60)
 
 # ============================================================================
+# Parameterizable freeze-cycle stress harness (Issue #594)
+# Same binary registered three times with WL_STRESS_W / WL_STRESS_R env
+# overrides; suite tags route W=4 to nightly and W=8 to release.
+# ============================================================================
+
+test_stress_harness_exe = executable(
+  'test_stress_harness',
+  files('test_stress_harness.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+# Freeze-cycle workload (default).
+# PR tier (default suite -> picked up by ci-pr.yml's meson test).
+test('stress_harness_w2', test_stress_harness_exe,
+     timeout: 60,
+     env: {'WL_STRESS_W': '2', 'WL_STRESS_R': '200',
+           'WL_STRESS_WORKLOAD': 'freeze-cycle'})
+
+# Nightly tier (suite: stress-nightly).  Wired into perf-nightly.yml.
+test('stress_harness_w4', test_stress_harness_exe,
+     suite: 'stress-nightly',
+     timeout: 120,
+     env: {'WL_STRESS_W': '4', 'WL_STRESS_R': '500',
+           'WL_STRESS_WORKLOAD': 'freeze-cycle'})
+
+# Release tier (suite: stress-release).  Run manually per
+# docs/STRESS_BASELINE.md; no release.yml workflow exists yet.
+test('stress_harness_w8', test_stress_harness_exe,
+     suite: 'stress-release',
+     timeout: 300,
+     env: {'WL_STRESS_W': '8', 'WL_STRESS_R': '1000',
+           'WL_STRESS_WORKLOAD': 'freeze-cycle'})
+
+# Apply-roundtrip workload (#594 acceptance: pre-rotation handles
+# valid post-apply).  Single-mutator by contract -- W is accepted
+# but ignored by the workload; PR/nightly/release tiers vary R.
+test('stress_harness_apply_roundtrip_pr', test_stress_harness_exe,
+     timeout: 60,
+     env: {'WL_STRESS_W': '2', 'WL_STRESS_R': '500',
+           'WL_STRESS_WORKLOAD': 'apply-roundtrip'})
+
+test('stress_harness_apply_roundtrip_nightly', test_stress_harness_exe,
+     suite: 'stress-nightly',
+     timeout: 120,
+     env: {'WL_STRESS_W': '4', 'WL_STRESS_R': '5000',
+           'WL_STRESS_WORKLOAD': 'apply-roundtrip'})
+
+test('stress_harness_apply_roundtrip_release', test_stress_harness_exe,
+     suite: 'stress-release',
+     timeout: 300,
+     env: {'WL_STRESS_W': '8', 'WL_STRESS_R': '50000',
+           'WL_STRESS_WORKLOAD': 'apply-roundtrip'})
+
+# ============================================================================
 # Compound arena lifecycle observability (Issue #583)
 # WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.
 # ============================================================================

--- a/tests/test_stress_harness.c
+++ b/tests/test_stress_harness.c
@@ -1,0 +1,393 @@
+/*
+ * test_stress_harness.c - Issue #594 parameterizable stress harness
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Single test binary that drives one of two K-Fusion arena workloads
+ * with parameters supplied via environment variables.  The same
+ * binary is registered under multiple meson tests with different
+ * `env:` blocks so a single configurable harness backs the three CI
+ * tiers #594 calls out:
+ *
+ *   - stress_harness_w2 (default suite, PR CI):  W=2,  R=200
+ *   - stress_harness_w4 (suite: stress-nightly): W=4,  R=500
+ *   - stress_harness_w8 (suite: stress-release): W=8,  R=1000
+ *
+ * Workloads (selected by WL_STRESS_WORKLOAD):
+ *
+ *   "freeze-cycle" (default):
+ *       Verbatim lift of #582's freeze-cycle stress (worker_fn does
+ *       lookup() + denied-alloc on the borrowed arena while frozen).
+ *       Each cycle: alloc sentinel → freeze → submit W workers →
+ *       wait_all → unfreeze → gc_epoch_boundary.
+ *
+ *   "apply-roundtrip":
+ *       Pre-rotation handles must remain valid post-apply (#594
+ *       acceptance bullet).  Sequence: allocate R handles, build a
+ *       deterministic remap (old → old XOR magic) covering them all,
+ *       call wl_handle_remap_apply_columns (#589) to rewrite the
+ *       column in place, then verify every cell carries its expected
+ *       new value.  This workload does NOT use W workers --
+ *       wl_handle_remap_apply_columns is single-mutator by contract;
+ *       W is accepted as input but ignored, with a one-line note
+ *       printed to keep CI tier wiring uniform across workloads.
+ *       (No #550 Option C rotation helper required: the apply pass
+ *       rewrites the same arena in place; cross-arena swap is a
+ *       separate concern that needs its own sibling test.)
+ *
+ * The pre-implementation review explicitly scoped this NOT to:
+ *   - touch the already-merged #582/#584/#592 hardcoded tests
+ *     (refactor-risk for zero feature value),
+ *   - add a release.yml workflow (out of scope; the W=8 invocation
+ *     is documented in docs/STRESS_BASELINE.md instead).
+ *
+ * Environment variables:
+ *
+ *   WL_STRESS_W         unsigned int [1, 64]         (default 2)
+ *   WL_STRESS_R         unsigned int [1, 1_000_000]  (default 200)
+ *   WL_STRESS_WORKLOAD  one of:                      (default "freeze-cycle")
+ *                       "freeze-cycle"
+ *                       "apply-roundtrip"
+ *
+ * The harness-level R cap (1M) is a sanity bound; each workload
+ * applies its own tighter validation against domain-specific limits
+ * (freeze-cycle requires R < arena->max_epochs because each cycle
+ * advances current_epoch; apply-roundtrip is row-count and only
+ * bounded by available memory).  Out-of-range / non-numeric W or
+ * R, or unknown WORKLOAD, triggers a hard FAIL with a clear
+ * diagnostic so a misconfigured CI tier surfaces loudly instead of
+ * masquerading as a "passed at default".
+ */
+
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/columnar/handle_remap.h"
+#include "../wirelog/columnar/handle_remap_apply.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/workqueue.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* ======================================================================== */
+/* Env-var parsing                                                          */
+/* ======================================================================== */
+
+/* Parse a positive integer from @env_name, clamp to [1, max], FAIL with a
+ * diagnostic if the value is missing-and-no-default, non-numeric, zero,
+ * or above @max.  @default_value is used iff the env var is unset. */
+static int
+parse_env_uint(const char *env_name, uint32_t default_value,
+    uint32_t max_value, uint32_t *out)
+{
+    const char *raw = getenv(env_name);
+    if (!raw || raw[0] == '\0') {
+        *out = default_value;
+        return 0;
+    }
+    char *end = NULL;
+    errno = 0;
+    unsigned long long v = strtoull(raw, &end, 10);
+    if (errno != 0 || end == raw || *end != '\0' || v == 0
+        || v > (unsigned long long)max_value) {
+        fprintf(stderr,
+            "FAIL: %s='%s' is not a positive integer <= %u\n",
+            env_name, raw, max_value);
+        return -1;
+    }
+    *out = (uint32_t)v;
+    return 0;
+}
+
+/* ======================================================================== */
+/* Freeze-cycle workload                                                    */
+/* ======================================================================== */
+
+typedef struct {
+    wl_compound_arena_t *arena;
+    uint64_t sentinel_handle;
+    uint32_t expected_payload_size;
+    int lookup_ok;
+    int alloc_blocked;
+} worker_task_t;
+
+static void
+worker_fn(void *ctx)
+{
+    worker_task_t *t = (worker_task_t *)ctx;
+    uint32_t out_size = 0;
+    const void *payload = wl_compound_arena_lookup(t->arena,
+            t->sentinel_handle, &out_size);
+    t->lookup_ok = (payload != NULL && out_size == t->expected_payload_size);
+
+    /* Frozen alloc must refuse; verifies the freeze guard composes
+     * correctly with concurrent worker access. */
+    uint64_t denied = wl_compound_arena_alloc(t->arena, 16u);
+    t->alloc_blocked = (denied == WL_COMPOUND_HANDLE_NULL);
+}
+
+static int
+run_freeze_cycle_workload(uint32_t num_workers, uint32_t cycles)
+{
+    printf("  [freeze-cycle W=%u R=%u] ", num_workers, cycles);
+    fflush(stdout);
+
+    wl_compound_arena_t *arena = wl_compound_arena_create(0xCAFEu, 4096u, 0u);
+    if (!arena) {
+        printf("FAIL: arena create\n");
+        return 1;
+    }
+
+    /* Bound check: each cycle advances current_epoch by one
+     * (gc_epoch_boundary at the cycle tail), so cycles must fit
+     * the arena's epoch cap.  Mirrors #582's bound assertion. */
+    if (cycles >= arena->max_epochs) {
+        printf("FAIL: WL_STRESS_R=%u exceeds max_epochs=%u\n",
+            cycles, arena->max_epochs);
+        wl_compound_arena_free(arena);
+        return 1;
+    }
+
+    wl_work_queue_t *wq = wl_workqueue_create(num_workers);
+    if (!wq) {
+        printf("FAIL: workqueue create (W=%u)\n", num_workers);
+        wl_compound_arena_free(arena);
+        return 1;
+    }
+
+    worker_task_t *tasks
+        = (worker_task_t *)calloc(num_workers, sizeof(worker_task_t));
+    if (!tasks) {
+        printf("FAIL: tasks alloc\n");
+        wl_workqueue_destroy(wq);
+        wl_compound_arena_free(arena);
+        return 1;
+    }
+
+    int verdict = 0;
+    /* clock() is portable across MSVC/glibc/musl; the diagnostic
+     * timing is informational only, not a gate. */
+    clock_t t0 = clock();
+
+    for (uint32_t r = 0; r < cycles; r++) {
+        uint64_t handle = wl_compound_arena_alloc(arena, 24u);
+        if (handle == WL_COMPOUND_HANDLE_NULL) {
+            printf("FAIL: cycle %u sentinel alloc returned NULL\n", r);
+            verdict = 1;
+            break;
+        }
+        wl_compound_arena_freeze(arena);
+        for (uint32_t k = 0; k < num_workers; k++) {
+            tasks[k].arena = arena;
+            tasks[k].sentinel_handle = handle;
+            tasks[k].expected_payload_size = 24u;
+            tasks[k].lookup_ok = 0;
+            tasks[k].alloc_blocked = 0;
+            if (wl_workqueue_submit(wq, worker_fn, &tasks[k]) != 0) {
+                printf("FAIL: submit cycle %u worker %u\n", r, k);
+                verdict = 1;
+                break;
+            }
+        }
+        if (verdict)
+            break;
+        if (wl_workqueue_wait_all(wq) != 0) {
+            printf("FAIL: wait_all cycle %u\n", r);
+            verdict = 1;
+            break;
+        }
+        for (uint32_t k = 0; k < num_workers; k++) {
+            if (!tasks[k].lookup_ok) {
+                printf("FAIL: cycle %u worker %u lookup failed\n", r, k);
+                verdict = 1;
+                break;
+            }
+            if (!tasks[k].alloc_blocked) {
+                printf("FAIL: cycle %u worker %u frozen alloc accepted\n",
+                    r, k);
+                verdict = 1;
+                break;
+            }
+        }
+        if (verdict)
+            break;
+        wl_compound_arena_unfreeze(arena);
+        (void)wl_compound_arena_gc_epoch_boundary(arena);
+    }
+
+    clock_t t1 = clock();
+    double secs = (double)(t1 - t0) / (double)CLOCKS_PER_SEC;
+
+    free(tasks);
+    wl_workqueue_destroy(wq);
+    wl_compound_arena_free(arena);
+
+    if (verdict == 0)
+        printf("PASS (%.3fs)\n", secs);
+    return verdict;
+}
+
+/* ======================================================================== */
+/* Apply-roundtrip workload                                                 */
+/* ======================================================================== */
+
+/* Deterministic remap transform: keeps a handle non-zero after the
+ * rewrite (XOR with a non-zero magic guarantees that), avoids
+ * collisions with WL_COMPOUND_HANDLE_NULL, and is invertible by the
+ * verification step. */
+#define WL_STRESS_NEW_HANDLE_XOR ((int64_t)0xDEADBEEFCAFEBABEull)
+
+static int
+run_apply_roundtrip_workload(uint32_t num_workers, uint32_t rows)
+{
+    /* W is accepted for CI-tier uniformity but ignored: the apply
+     * pass is single-mutator by contract (handle_remap_apply.c
+     * touches columns[][] under the freeze invariant; concurrent
+     * appliers would corrupt each other's prefix). */
+    (void)num_workers;
+    printf("  [apply-roundtrip W=%u (ignored, single-mutator) R=%u] ",
+        num_workers, rows);
+    fflush(stdout);
+
+    /* Mirrors the test_handle_remap_apply.c (#589) shape but with
+     * a configurable row count.  We use a synthetic col_rel_t
+     * directly instead of a session, to keep the harness
+     * dependency-light and focused on the apply contract. */
+    col_rel_t *rel = NULL;
+    if (col_rel_alloc(&rel, "stress_apply_roundtrip") != 0) {
+        printf("FAIL: col_rel_alloc\n");
+        return 1;
+    }
+    const char *names[1] = { "h0" };
+    if (col_rel_set_schema(rel, 1u, names) != 0) {
+        printf("FAIL: set_schema\n");
+        col_rel_destroy(rel);
+        return 1;
+    }
+    /* Populate rows: row i carries handle (i + 1), guaranteed
+    * non-zero so the apply pass actually scans every cell. */
+    int64_t row[1];
+    for (uint32_t i = 0; i < rows; i++) {
+        row[0] = (int64_t)(i + 1u);
+        if (col_rel_append_row(rel, row) != 0) {
+            printf("FAIL: append_row at i=%u\n", i);
+            col_rel_destroy(rel);
+            return 1;
+        }
+    }
+
+    wl_handle_remap_t *remap = NULL;
+    int rc = wl_handle_remap_create((size_t)rows, &remap);
+    if (rc != 0 || !remap) {
+        printf("FAIL: remap create\n");
+        col_rel_destroy(rel);
+        return 1;
+    }
+    for (uint32_t i = 0; i < rows; i++) {
+        int64_t old_h = (int64_t)(i + 1u);
+        int64_t new_h = old_h ^ WL_STRESS_NEW_HANDLE_XOR;
+        if (wl_handle_remap_insert(remap, old_h, new_h) != 0) {
+            printf("FAIL: remap_insert i=%u\n", i);
+            wl_handle_remap_free(remap);
+            col_rel_destroy(rel);
+            return 1;
+        }
+    }
+
+    clock_t t0 = clock();
+
+    uint32_t handle_cols[1] = { 0u };
+    uint64_t rewrites = 0;
+    rc = wl_handle_remap_apply_columns(rel, handle_cols, 1u, remap,
+            &rewrites);
+    if (rc != 0) {
+        printf("FAIL: apply_columns rc=%d\n", rc);
+        wl_handle_remap_free(remap);
+        col_rel_destroy(rel);
+        return 1;
+    }
+    if (rewrites != (uint64_t)rows) {
+        printf("FAIL: rewrites=%" PRIu64 " expected=%u\n",
+            rewrites, rows);
+        wl_handle_remap_free(remap);
+        col_rel_destroy(rel);
+        return 1;
+    }
+
+    /* Verification: every cell carries the expected post-apply
+     * handle.  Stratified sampling caught no off-by-ones in #589's
+     * 10K x 3 acceptance test; full sweep here keeps the
+     * configurable harness honest at any R. */
+    int verdict = 0;
+    for (uint32_t i = 0; i < rows; i++) {
+        int64_t got = rel->columns[0][i];
+        int64_t want = (int64_t)(i + 1u) ^ WL_STRESS_NEW_HANDLE_XOR;
+        if (got != want) {
+            printf("FAIL: row %u got=0x%llx want=0x%llx\n",
+                i, (unsigned long long)got,
+                (unsigned long long)want);
+            verdict = 1;
+            break;
+        }
+    }
+
+    clock_t t1 = clock();
+    double secs = (double)(t1 - t0) / (double)CLOCKS_PER_SEC;
+
+    wl_handle_remap_free(remap);
+    col_rel_destroy(rel);
+
+    if (verdict == 0)
+        printf("PASS (%.3fs)\n", secs);
+    return verdict;
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("test_stress_harness (Issue #594)\n");
+    printf("================================\n");
+
+    uint32_t W = 0;
+    uint32_t R = 0;
+    if (parse_env_uint("WL_STRESS_W", 2u, 64u, &W) != 0)
+        return 1;
+    if (parse_env_uint("WL_STRESS_R", 200u, 1000000u, &R) != 0)
+        return 1;
+
+    const char *workload = getenv("WL_STRESS_WORKLOAD");
+    if (!workload || workload[0] == '\0')
+        workload = "freeze-cycle";
+
+    printf("Configuration: W=%u R=%u workload=%s "
+        "(env-driven; defaults W=2 R=200 workload=freeze-cycle)\n",
+        W, R, workload);
+
+    int rc;
+    if (strcmp(workload, "freeze-cycle") == 0) {
+        rc = run_freeze_cycle_workload(W, R);
+    } else if (strcmp(workload, "apply-roundtrip") == 0) {
+        rc = run_apply_roundtrip_workload(W, R);
+    } else {
+        fprintf(stderr,
+            "FAIL: WL_STRESS_WORKLOAD='%s' is not one of "
+            "'freeze-cycle', 'apply-roundtrip'\n", workload);
+        return 1;
+    }
+
+    if (rc == 0)
+        printf("\nWorkload '%s' passed.\n", workload);
+    else
+        printf("\nFAILURE: workload '%s' failed.\n", workload);
+    return rc == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
2 atomic commits closing #594 (configurable K-Fusion stress harness with PR/nightly/release CI tiers).

1. **\`test(#594):\`** \`tests/test_stress_harness.c\` — single binary, env-driven (\`WL_STRESS_W\` / \`WL_STRESS_R\` / \`WL_STRESS_WORKLOAD\`). Two workloads:
   - **\`freeze-cycle\`**: lift of #582's structure (alloc → freeze → W workers lookup+denied-alloc → wait_all → unfreeze → gc).
   - **\`apply-roundtrip\`**: pre-rotation handles must remain valid post-apply (#594 acceptance bullet). In-place rewrite via \`wl_handle_remap_apply_columns\` (#589); does NOT need #550-C cross-arena rotation. Pre-implementation critic incorrectly punted this; user caught the mistake; implementer added it back.

   Six \`test()\` entries × 3 CI tiers (default/stress-nightly/stress-release) × 2 workloads.

2. **\`docs(#594):\`** \`docs/STRESS_BASELINE.md\` — tier topology, workload contracts, manual release-tier invocation (no \`release.yml\` workflow yet), flake-baseline protocol (100/100, 95-99/100, <95/100 thresholds + triage flow). Plus \`.github/workflows/perf-nightly.yml\` adds a sibling \`stress\` job (Linux GCC + TSan + suite \`stress-nightly\`) that runs daily at 04:00 UTC.

## Multi-agent flow
1. **Architect + Critic** pre-review: clean / TIGHTEN_SCOPE. Architect approved env-var harness; critic warned about YAGNI and (incorrectly) punted apply-roundtrip to #550-C.
2. **Implementer** landed harness (commit 1) + docs/CI (commit 2). User caught the apply-roundtrip punt error; implementer added it as a 2nd workload. R cap initially 4094 (epoch limit) broke nightly/release apply-roundtrip; raised to 1M with per-workload self-validation.
3. **Code-reviewer** APPROVE — 0 blocking, 4 MINOR / 2 NIT polish, 3 PRAISE.
4. **Architect + Critic** meta-review: architect CONCUR ship-as-is. Critic REVIEWER_OVERLOOKED on his own earlier punt — explicitly retracts (\"My earlier punt was wrong; user catch was correct\") and concurs SHIP.

## Test plan
- [x] \`meson test -C build stress_harness_w2 stress_harness_apply_roundtrip_pr\` → 2/2 OK
- [x] \`meson test -C build --suite stress-nightly --suite stress-release\` → 4/4 OK
- [x] \`meson test -C build-san --suite stress-nightly --suite stress-release\` (ASAN+UBSAN) → 4/4 OK
- [x] \`meson test -C build-tsan --suite stress-nightly --suite stress-release\` → 4/4 OK
- [x] uncrustify clean

Closes #594.