### PR TITLE
test(#598): RSS-bounded per-rotation gate + ledger/deep_copy canaries

### DIFF
--- a/docs/STRESS_BASELINE.md
+++ b/docs/STRESS_BASELINE.md
@@ -349,6 +349,98 @@ Record the new baseline pass-rate in the file header docstring of
 `test_stress_harness.c` so future on-callers do not have to
 re-derive it.
 
+## Per-rotation RSS-bounded gate (Issue #598)
+
+`tests/test_rss_bounded.c` is the residual-scope companion to #597's
+end-of-run daemon-soak gate. It exercises three signals NOT covered
+by the daemon-soak workload:
+
+1. **Per-rotation sampling granularity**, not just end-of-run. The
+   sampler is `test_current_rss_kb()` (Linux `/proc/self/status:VmRSS`,
+   macOS `task_info` `resident_size`, Windows
+   `PROCESS_MEMORY_COUNTERS.WorkingSetSize`), which returns the
+   CURRENT working-set size. The companion `test_peak_rss_kb()` (used
+   by daemon-soak) returns the monotonic VmHWM peak and is unfit for
+   per-rotation deltas because `VmHWM(N+1) - VmHWM(N) >= 0` always,
+   independent of memory pressure. Per-rotation gates require VmRSS;
+   end-of-run gates use VmHWM.
+2. **Cumulative cap with no 4 MB floor.** The PR-tier gate is
+   `rss_after <= rss_warmup + max(rss_warmup / 10, 1024 KB)` -- 10
+   percent growth or a 1 MB absolute floor (whichever larger),
+   strictly tighter than daemon-soak's `max(10 percent, 4 MB)`. The
+   wider 4 MB floor is appropriate for an end-of-run signal at small
+   baselines (~2 MB) where 10 percent would be too tight; the
+   per-rotation gate is the canary for incremental drift and benefits
+   from the tighter floor.
+3. **Per-rotation `mem_ledger.current_bytes` snapshot.** Production
+   rotation hooks (`rotation_standard.c`) only call
+   `wl_arena_reset`; they do NOT mutate `wl_mem_ledger`. The gate
+   asserts `ledger.current_bytes` is EXACTLY equal before and after
+   each rotation -- production rotation does not allocate via the
+   ledger; any change is a regression. Today the assertion is
+   tautological (catches future regressions that introduce ledger
+   churn into the rotation hot path).
+
+The strict per-rotation delta gate
+`rss_after - rss_prev <= rss_prev / 10` (skip when delta < 256 KB
+page-size noise floor) is opt-in via `WL_RSS_BOUNDED_STRICT=1` and
+runs only in the nightly/release tiers. Localhost machines that fail
+the warmup CoV self-check (>0.05) exit 77 (meson SKIP); the pattern
+mirrors `test_log_perf_gate.c`.
+
+The workload uses a saturation-driven arena recycle pattern
+(max_epochs=32, epoch_buffer=8) so the working set plateaus at the
+arena ceiling, mirroring daemon-soak. Without recycle, R=1000 with
+K=64 handles per epoch would accumulate legitimate per-epoch
+generation overhead and trip the cumulative gate.
+
+### CI tier topology
+
+| Test name | Suite | R | Strict | Where it runs |
+|---|---|---|---|---|
+| `rss_bounded_pr` | (default) | 100 | off | every PR |
+| `rss_bounded_nightly` | `stress-nightly` | 500 | on | nightly |
+| `rss_bounded_release` | `stress-release` | 1000 | on | release-tier (manual) |
+| `rss_bounded_asan` | `asan` | 100 | off | every PR (build-san) |
+
+ASan tier compile-time skips the RSS portion (ASan instrumentation
+confounds VmRSS the same way it confounds VmHWM -- redzones, shadow
+memory, and quarantine prevent reclaim). Ledger and rotation
+assertions still run to surface UAF/heap-overflow on the rotation
+hot path via ASan's own reporting.
+
+### Baseline pass rate
+
+100/100 PR-tier `rss_bounded_pr` runs pass on the baseline machine.
+Healthy floor: any single CI failure is a real regression, not a
+flake.
+
+## deep_copy ledger-charge canary (Issue #598)
+
+`tests/test_deep_copy_ledger_canary.c` is the destroy-side companion
+to `test_col_rel_deep_copy.c::test_deep_copy_mem_ledger_null`
+(Issue #554). The existing test already pins:
+
+1. `dst->mem_ledger == NULL` after `col_rel_deep_copy`.
+2. Source ledger counters are unchanged by the deep copy itself.
+
+The canary adds the residual #598 acceptance bullet:
+
+- `col_rel_destroy(dst)` does NOT double-charge the source session's
+  ledger. Because `dst->mem_ledger` is NULL,
+  `col_rel_free_contents` must not accidentally consult
+  `src->mem_ledger` when it walks dst's columns.
+
+**Vacuous in production today**: `col_rel_deep_copy` has NO
+production callers in rotation paths today (verified by grep across
+`wirelog/`). Only `tests/test_col_rel_deep_copy.c` and
+`tests/col_rel_deep_copy_fixture.c` invoke it. The canary becomes
+load-bearing when #550-C `wl_session_rotate` ships: the cross-arena
+rotation helper will deep-copy live relations into the new arena,
+and any ledger churn would corrupt per-session memory accounting.
+
+Registered in the default suite as `deep_copy_ledger_canary`.
+
 ## Out of scope (#594 follow-up tracking)
 
 - **Release-tier CI workflow**: no `release.yml` exists yet. The

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2793,6 +2793,26 @@ test_rss_bounded_exe = executable(
 
 test('rss_bounded_pr', test_rss_bounded_exe, timeout: 60)
 
+# ----------------------------------------------------------------------------
+# deep_copy ledger-charge canary (Issue #598)
+# Vacuous today (col_rel_deep_copy has no production rotation callers);
+# regression canary for #550-C wl_session_rotate.
+# ----------------------------------------------------------------------------
+
+test_deep_copy_ledger_canary_exe = executable(
+  'test_deep_copy_ledger_canary',
+  files('test_deep_copy_ledger_canary.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('deep_copy_ledger_canary', test_deep_copy_ledger_canary_exe)
+
 # ============================================================================
 # Compound arena lifecycle observability (Issue #583)
 # WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2771,6 +2771,29 @@ test('stress_harness_daemon_release_mvcc', test_stress_harness_exe,
            'WIRELOG_ROTATION': 'mvcc'})
 
 # ============================================================================
+# Per-rotation RSS-bounded + ledger-stability gates (Issue #598)
+# ============================================================================
+# Residual scope on top of #597's daemon-soak end-of-run gate:
+#   - per-rotation VmRSS sampling (not monotonic VmHWM peak)
+#   - cumulative cap with no 4 MB floor (10% or 1 MB, whichever larger)
+#   - ledger.current_bytes stability across each rotation
+# Strict per-rotation delta gate is opt-in via WL_RSS_BOUNDED_STRICT=1.
+
+test_rss_bounded_exe = executable(
+  'test_rss_bounded',
+  files('test_rss_bounded.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('rss_bounded_pr', test_rss_bounded_exe, timeout: 60)
+
+# ============================================================================
 # Compound arena lifecycle observability (Issue #583)
 # WL_LOG=COMPOUND:5 must emit alloc/freeze/unfreeze tags.
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2793,6 +2793,26 @@ test_rss_bounded_exe = executable(
 
 test('rss_bounded_pr', test_rss_bounded_exe, timeout: 60)
 
+# Nightly tier: strict per-rotation delta gate at R=500.  Skipped via
+# meson exit-77 if warmup CoV exceeds 0.05 on a noisy localhost.
+test('rss_bounded_nightly', test_rss_bounded_exe,
+     suite: 'stress-nightly',
+     timeout: 600,
+     env: {'WL_RSS_BOUNDED_STRICT': '1', 'WL_RSS_BOUNDED_R': '500'})
+
+# Release tier: strict per-rotation delta gate at R=1000.
+test('rss_bounded_release', test_rss_bounded_exe,
+     suite: 'stress-release',
+     timeout: 1200,
+     env: {'WL_RSS_BOUNDED_STRICT': '1', 'WL_RSS_BOUNDED_R': '1000'})
+
+# ASan tier: RSS portion is compile-time skipped (ASan instrumentation
+# confounds VmRSS/VmHWM signal).  Ledger and rotation assertions still
+# run under ASan to surface UAF/heap-overflow on the rotation hot path.
+test('rss_bounded_asan', test_rss_bounded_exe,
+     suite: 'asan',
+     timeout: 240)
+
 # ----------------------------------------------------------------------------
 # deep_copy ledger-charge canary (Issue #598)
 # Vacuous today (col_rel_deep_copy has no production rotation callers);

--- a/tests/test_deep_copy_ledger_canary.c
+++ b/tests/test_deep_copy_ledger_canary.c
@@ -1,0 +1,185 @@
+/*
+ * test_deep_copy_ledger_canary.c - Issue #598 deep_copy ledger-charge canary
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Regression canary for the col_rel_deep_copy ledger contract.  Per
+ * relation.c:1101-1107, deep copies are TRANSIENT relations: dst->mem_ledger
+ * is unconditionally NULL even when src is wired to a real ledger, and
+ * deep_copy itself does NOT report any allocations against src's ledger.
+ *
+ * The existing test_col_rel_deep_copy.c::test_deep_copy_mem_ledger_null
+ * (Issue #554) already pins:
+ *   1. dst->mem_ledger == NULL after deep_copy.
+ *   2. src ledger counters are unchanged by the deep_copy itself.
+ *
+ * This canary adds the destroy-side half of the contract that #598 calls
+ * out specifically:
+ *
+ *   - destroy(dst) does NOT double-charge the source session's ledger.
+ *     Because dst->mem_ledger is NULL, col_rel_free_contents must not
+ *     accidentally consult src->mem_ledger when it walks dst's columns.
+ *
+ * Vacuous in production today (col_rel_deep_copy has NO production
+ * callers in rotation paths -- verified by grep across wirelog/).  Only
+ * tests/test_col_rel_deep_copy.c and tests/col_rel_deep_copy_fixture.c
+ * invoke it.  Becomes load-bearing when #550-C wl_session_rotate ships:
+ * the cross-arena rotation helper will deep-copy the live relations into
+ * the new arena, and any ledger churn would corrupt the per-session
+ * memory accounting.
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/columnar/mem_ledger.h"
+#include "../wirelog/wirelog-types.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                              \
+        do {                                        \
+            tests_run++;                            \
+            printf("  [%d] %s", tests_run, name);   \
+        } while (0)
+
+#define PASS()                                  \
+        do {                                        \
+            tests_passed++;                         \
+            printf(" ... PASS\n");                  \
+        } while (0)
+
+#define FAIL(msg)                               \
+        do {                                        \
+            tests_failed++;                         \
+            printf(" ... FAIL: %s\n", (msg));       \
+            goto cleanup;                           \
+        } while (0)
+
+#define ASSERT(cond, msg)                       \
+        do {                                        \
+            if (!(cond)) {                          \
+                FAIL(msg);                          \
+            }                                       \
+        } while (0)
+
+/* Build a small populated relation: 3 columns, 4 rows, deterministic
+ * content.  Mirrors test_col_rel_deep_copy.c's build_populated helper. */
+static col_rel_t *
+build_populated(const char *name, uint32_t nrows)
+{
+    col_rel_t *r = NULL;
+    if (col_rel_alloc(&r, name) != 0)
+        return NULL;
+    const char *names[3] = { "alpha", "beta", "gamma" };
+    if (col_rel_set_schema(r, 3u, names) != 0) {
+        col_rel_destroy(r);
+        return NULL;
+    }
+    for (uint32_t i = 0; i < nrows; i++) {
+        int64_t row[3] = {
+            (int64_t)i,
+            (int64_t)(i * 10),
+            (int64_t)(i * 100),
+        };
+        if (col_rel_append_row(r, row) != 0) {
+            col_rel_destroy(r);
+            return NULL;
+        }
+    }
+    return r;
+}
+
+static void
+test_deep_copy_no_ledger_charge(void)
+{
+    /* Acceptance contract (Issue #598):
+     *   - Snapshot ledger.current_bytes before deep_copy.
+     *   - Call col_rel_deep_copy(src, &dst).
+     *   - Assert ledger.current_bytes == snapshot (deep_copy does not
+     *     charge the source ledger -- relation.c:1101-1107).
+     *   - Destroy dst.
+     *   - Snapshot ledger.current_bytes again.
+     *   - Assert ledger.current_bytes == snapshot (destroy did not
+     *     accidentally double-charge through the NULL dst->mem_ledger). */
+    TEST("col_rel_deep_copy + destroy do not charge src ledger");
+    col_rel_t *src = build_populated("ledger_canary_src", 4u);
+    col_rel_t *dst = NULL;
+    ASSERT(src != NULL, "build_populated failed");
+
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 0u /* unlimited */);
+
+    /* Stamp a baseline allocation that mimics what the surrounding
+     * pipeline would have charged for src's data buffer.  Mirrors
+     * test_deep_copy_mem_ledger_null in test_col_rel_deep_copy.c. */
+    const uint64_t baseline_bytes = 4096u;
+    wl_mem_ledger_alloc(&ledger, WL_MEM_SUBSYS_RELATION, baseline_bytes);
+    src->mem_ledger = &ledger;
+
+    /* Snapshot pre-copy. */
+    uint64_t before_copy = atomic_load_explicit(&ledger.current_bytes,
+            memory_order_relaxed);
+    ASSERT(before_copy == baseline_bytes,
+        "ledger baseline not at expected stamp");
+
+    /* Call deep_copy. */
+    int rc = col_rel_deep_copy(src, &dst, NULL);
+    ASSERT(rc == 0 && dst != NULL, "col_rel_deep_copy failed");
+    ASSERT(dst->mem_ledger == NULL,
+        "dst->mem_ledger must be NULL per #554/#598 transient contract");
+
+    /* Snapshot post-copy: must be unchanged. */
+    uint64_t after_copy = atomic_load_explicit(&ledger.current_bytes,
+            memory_order_relaxed);
+    ASSERT(after_copy == before_copy,
+        "deep_copy charged src ledger (must be a no-op)");
+
+    /* Destroy dst.  Because dst->mem_ledger is NULL,
+     * col_rel_free_contents must not double-charge through src's
+     * ledger -- the canary asserts the destroy path is ledger-clean. */
+    col_rel_destroy(dst);
+    dst = NULL;
+
+    uint64_t after_destroy = atomic_load_explicit(&ledger.current_bytes,
+            memory_order_relaxed);
+    if (after_destroy != before_copy) {
+        printf(" ... FAIL: destroy(dst) drifted ledger from %" PRIu64
+            " to %" PRIu64 "\n", before_copy, after_destroy);
+        tests_failed++;
+        goto cleanup;
+    }
+
+    /* Detach src's ledger before destroy so col_rel_free_contents does
+     * not unwind the synthetic baseline against our local stack ledger
+     * (mirrors test_deep_copy_mem_ledger_null's cleanup pattern). */
+    src->mem_ledger = NULL;
+
+    PASS();
+cleanup:
+    if (src)
+        src->mem_ledger = NULL;
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+}
+
+int
+main(void)
+{
+    printf("test_deep_copy_ledger_canary (Issue #598)\n");
+    printf("=========================================\n");
+
+    test_deep_copy_no_ledger_charge();
+
+    printf("\nResults: %d/%d passed, %d failed\n",
+        tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/tests/test_rss_bounded.c
+++ b/tests/test_rss_bounded.c
@@ -1,0 +1,343 @@
+/*
+ * test_rss_bounded.c - Issue #598 per-rotation RSS + ledger stability gates
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Per-rotation residual-scope test on top of #597's daemon-soak end-of-run
+ * gate.  This test adds three independent signals that are NOT covered by
+ * the daemon-soak workload:
+ *
+ *   1. Per-rotation sampling granularity at R=100 (not just end-of-run).
+ *      Uses test_current_rss_kb() (VmRSS / resident_size / WorkingSetSize)
+ *      because the monotonic peak sampler is unfit for per-rotation deltas.
+ *
+ *   2. Cumulative cap with NO 4 MB floor.  The PR-tier gate is 10% growth
+ *      or a 1 MB absolute floor (whichever larger), strictly tighter than
+ *      #597's max(10%, 4 MB).  Daemon-soak's wider floor is for an end-
+ *      of-run signal at small baselines (~2 MB) where 10% would be too
+ *      tight; #598's per-rotation gate is the canary for incremental drift
+ *      and benefits from the tighter floor.
+ *
+ *   3. Per-rotation mem_ledger.current_bytes snapshot.  Production rotation
+ *      hooks (rotation_standard.c) only call wl_arena_reset; they do NOT
+ *      mutate wl_mem_ledger.  This gate asserts ledger.current_bytes is
+ *      EXACTLY equal before and after each rotation -- any future change
+ *      that introduces ledger churn into the rotation hot path will trip
+ *      this canary.  Today the assertion is tautological; it becomes load-
+ *      bearing when a ledger-touching rotation strategy lands.
+ *
+ * Strict per-rotation delta gate (Def#1) is opt-in via WL_RSS_BOUNDED_STRICT=1
+ * and runs only in the nightly/release tiers; localhost machines that fail
+ * the CoV self-check exit 77 (meson SKIP).
+ *
+ * The mock-session pattern mirrors test_stress_harness.c's daemon-soak
+ * helper (which the architect identified as the canonical pattern for
+ * exercising the rotation vtable).  Going through the full
+ * parser/optimizer/plan -> wl_session_create() pipeline would only add
+ * cost: rotation_ops touches eval_arena and compound_arena, neither
+ * of which depends on plan/parser state.  We DO embed a real
+ * wl_mem_ledger so the ledger snapshot is meaningful.
+ */
+
+#include "../wirelog/arena/arena.h"
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/columnar/mem_ledger.h"
+#include "test_rss_util.h"
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Clang exposes __has_feature; GCC does not.  Polyfill so the
+ * conditional below tokenizes cleanly under both compilers (mirrors
+ * test_stress_harness.c's daemon-soak skip). */
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+
+/* Test parameters -- match the daemon-soak workload's surface so a
+ * future divergence in one does not silently churn the other. */
+#define WL_RSS_BOUNDED_K_HANDLES   64u
+#define WL_RSS_BOUNDED_PAYLOAD_SZ  24u
+#define WL_RSS_BOUNDED_WARMUP      5u
+#define WL_RSS_BOUNDED_DEFAULT_R   100u
+#define WL_RSS_BOUNDED_MAX_EPOCHS  4096u
+#define WL_RSS_BOUNDED_EVAL_ARENA  (256u * 1024u)
+#define WL_RSS_BOUNDED_COV_CEILING 0.05
+#define WL_RSS_BOUNDED_NOISE_FLOOR_KB 256
+
+#define SKIP_EXIT 77
+
+/* Strict per-rotation delta gate threshold (Def#1): rss_after - rss_prev
+ * <= rss_prev / 10.  Skipped when delta < WL_RSS_BOUNDED_NOISE_FLOOR_KB
+ * to absorb page-size noise. */
+#define WL_RSS_BOUNDED_STRICT_PCT 10
+
+static int
+parse_env_uint(const char *name, uint32_t default_val, uint32_t max_val,
+    uint32_t *out)
+{
+    const char *s = getenv(name);
+    if (!s || s[0] == '\0') {
+        *out = default_val;
+        return 0;
+    }
+    char *endp = NULL;
+    unsigned long v = strtoul(s, &endp, 10);
+    if (endp == s || *endp != '\0' || v == 0 || v > max_val) {
+        printf("FAIL: %s='%s' is not a positive integer in [1, %u]\n",
+            name, s, max_val);
+        return -1;
+    }
+    *out = (uint32_t)v;
+    return 0;
+}
+
+static int
+env_flag_enabled(const char *name)
+{
+    const char *s = getenv(name);
+    return (s != NULL && s[0] == '1' && s[1] == '\0') ? 1 : 0;
+}
+
+static wl_col_session_t *
+make_session(wl_compound_arena_t *arena)
+{
+    wl_col_session_t *s = (wl_col_session_t *)calloc(1, sizeof(*s));
+    if (!s)
+        return NULL;
+    s->compound_arena = arena;
+    s->eval_arena = wl_arena_create(WL_RSS_BOUNDED_EVAL_ARENA);
+    if (!s->eval_arena) {
+        free(s);
+        return NULL;
+    }
+    s->rotation_ops = &col_rotation_standard_ops;
+    /* Embed a real ledger so the per-rotation snapshot is meaningful.
+     * The session owns the ledger lifetime (see internal.h:910). */
+    wl_mem_ledger_init(&s->mem_ledger, 0u /* unlimited */);
+    return s;
+}
+
+static void
+free_session(wl_col_session_t *s)
+{
+    if (!s)
+        return;
+    if (s->eval_arena)
+        wl_arena_free(s->eval_arena);
+    free(s);
+}
+
+/* CoV self-check: skip-on-noise pattern from tests/test_log_perf_gate.c.
+ * Computes the coefficient of variation across @n warmup samples; if
+ * stdev/mean exceeds the ceiling the run is too noisy to draw a
+ * per-rotation conclusion and the test SKIPs. */
+static double
+compute_cov(const int64_t *samples, size_t n)
+{
+    if (n == 0)
+        return 0.0;
+    double sum = 0.0;
+    for (size_t i = 0; i < n; i++)
+        sum += (double)samples[i];
+    double mean = sum / (double)n;
+    if (mean <= 0.0)
+        return 0.0;
+    double sumsq = 0.0;
+    for (size_t i = 0; i < n; i++) {
+        double d = (double)samples[i] - mean;
+        sumsq += d * d;
+    }
+    double stdev = sqrt(sumsq / (double)n);
+    return stdev / mean;
+}
+
+int
+main(void)
+{
+    printf("test_rss_bounded (Issue #598)\n");
+    printf("=============================\n");
+
+    /* WL_RSS_BOUNDED_R is the post-warmup rotation count.  Default 100
+     * matches the brief; the nightly/release tiers override to 500/1000. */
+    uint32_t R = 0;
+    if (parse_env_uint("WL_RSS_BOUNDED_R", WL_RSS_BOUNDED_DEFAULT_R,
+        100000u, &R) != 0)
+        return 1;
+    int strict = env_flag_enabled("WL_RSS_BOUNDED_STRICT");
+
+    printf("  [R=%u strict=%d K=%u]\n", R, strict, WL_RSS_BOUNDED_K_HANDLES);
+
+    /* Build the mock session + a real wl_mem_ledger embedded in the
+     * session.  See file docstring for why we don't go through
+     * wl_session_create. */
+    wl_compound_arena_t *arena = wl_compound_arena_create(0xBEEFu, 4096u,
+            WL_RSS_BOUNDED_MAX_EPOCHS);
+    if (!arena) {
+        printf("FAIL: arena create\n");
+        return 1;
+    }
+    wl_col_session_t *sess = make_session(arena);
+    if (!sess) {
+        printf("FAIL: session create\n");
+        wl_compound_arena_free(arena);
+        return 1;
+    }
+
+    int verdict = 0;
+
+    /* ASan compile-time skip of the RSS portion (mirror daemon-soak's
+    * pattern from test_stress_harness.c).  Ledger and rotation
+    * assertions still run under ASan -- the ledger contract is not
+    * confounded by ASan instrumentation, only the VmRSS signal is. */
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
+    int rss_skipped = 1;
+    printf("  [rss-bounded skipped: AddressSanitizer instrumentation "
+        "confounds VmRSS signal]\n");
+#else
+    int rss_skipped = 0;
+#endif
+
+    /* ------------------------------------------------------------------
+     * Warmup phase: 5 rotations to let the working set stabilize.
+     * Sample VmRSS after each warmup rotation; computed CoV gates the
+     * subsequent strict-mode delta assertions.
+     * ------------------------------------------------------------------ */
+    int64_t warmup_rss[WL_RSS_BOUNDED_WARMUP];
+    for (uint32_t i = 0; i < WL_RSS_BOUNDED_WARMUP; i++) {
+        for (uint32_t k = 0; k < WL_RSS_BOUNDED_K_HANDLES; k++) {
+            uint64_t h = wl_compound_arena_alloc(arena,
+                    WL_RSS_BOUNDED_PAYLOAD_SZ);
+            if (h == WL_COMPOUND_HANDLE_NULL) {
+                printf("FAIL: warmup %u handle %u alloc returned NULL\n",
+                    i, k);
+                verdict = 1;
+                goto cleanup;
+            }
+        }
+        sess->rotation_ops->rotate_eval_arena(sess);
+        sess->rotation_ops->gc_epoch_boundary(sess);
+        warmup_rss[i] = test_current_rss_kb();
+    }
+
+    int64_t rss_warmup_kb = warmup_rss[WL_RSS_BOUNDED_WARMUP - 1u];
+    uint64_t ledger_warmup_bytes = atomic_load_explicit(
+        &sess->mem_ledger.current_bytes, memory_order_relaxed);
+
+    /* CoV self-check.  rss_skipped covers the platform-unavailable and
+     * ASan paths -- in both, warmup_rss[i] is -1 and CoV is meaningless. */
+    if (!rss_skipped && rss_warmup_kb > 0) {
+        double cov = compute_cov(warmup_rss, WL_RSS_BOUNDED_WARMUP);
+        if (cov > WL_RSS_BOUNDED_COV_CEILING) {
+            printf("[rss-bounded skipped: warmup CoV=%.3f exceeds %.3f "
+                "ceiling]\n", cov, WL_RSS_BOUNDED_COV_CEILING);
+            free_session(sess);
+            wl_compound_arena_free(arena);
+            return SKIP_EXIT;
+        }
+    }
+    if (!rss_skipped && rss_warmup_kb < 0) {
+        printf("  [rss-bounded skipped: platform sampler unavailable]\n");
+        rss_skipped = 1;
+    }
+
+    /* ------------------------------------------------------------------
+     * Per-rotation gate loop: R rotations post-warmup.
+     * ------------------------------------------------------------------ */
+    int64_t rss_prev_kb = rss_warmup_kb;
+    for (uint32_t r = 0; r < R; r++) {
+        for (uint32_t k = 0; k < WL_RSS_BOUNDED_K_HANDLES; k++) {
+            uint64_t h = wl_compound_arena_alloc(arena,
+                    WL_RSS_BOUNDED_PAYLOAD_SZ);
+            if (h == WL_COMPOUND_HANDLE_NULL) {
+                /* Out of epochs is a normal end-of-soak condition for
+                 * very large R; surface as a clean PASS only after we
+                 * confirm the ledger gate held.  For now, treat as FAIL
+                 * to surface premature exhaustion. */
+                printf("FAIL: rotation %u handle %u alloc returned NULL "
+                    "(current_epoch=%u max_epochs=%u)\n",
+                    r, k, arena->current_epoch, arena->max_epochs);
+                verdict = 1;
+                goto cleanup;
+            }
+        }
+        sess->rotation_ops->rotate_eval_arena(sess);
+        sess->rotation_ops->gc_epoch_boundary(sess);
+
+        int64_t rss_after = rss_skipped ? -1 : test_current_rss_kb();
+        uint64_t ledger_after = atomic_load_explicit(
+            &sess->mem_ledger.current_bytes, memory_order_relaxed);
+
+        /* Ledger stability gate: production rotation does not allocate
+         * via the ledger; any change is a regression. */
+        if (ledger_after != ledger_warmup_bytes) {
+            printf("FAIL: rotation %u ledger drift: warmup=%" PRIu64
+                " after=%" PRIu64 " (delta=%" PRId64 ")\n",
+                r, ledger_warmup_bytes, ledger_after,
+                (int64_t)ledger_after - (int64_t)ledger_warmup_bytes);
+            verdict = 1;
+            goto cleanup;
+        }
+
+        if (!rss_skipped && rss_after > 0) {
+            /* PR-tier cumulative gate (Def#2): 10% growth or 1 MB floor. */
+            int64_t allowance_pct = rss_warmup_kb / 10;
+            int64_t allowance_floor = 1024; /* KB */
+            int64_t allowance = (allowance_pct > allowance_floor)
+                ? allowance_pct : allowance_floor;
+            int64_t budget = rss_warmup_kb + allowance;
+            if (rss_after > budget) {
+                printf("FAIL: rotation %u rss-cumulative warmup=%" PRId64
+                    " kb after=%" PRId64 " kb delta=%" PRId64
+                    " kb gate=%" PRId64 " kb\n",
+                    r, rss_warmup_kb, rss_after,
+                    rss_after - rss_warmup_kb, budget);
+                verdict = 1;
+                goto cleanup;
+            }
+
+            /* Strict per-rotation delta gate (Def#1, nightly-only).
+            * Skip when delta is below the page-size noise floor. */
+            if (strict && rss_prev_kb > 0) {
+                int64_t delta = rss_after - rss_prev_kb;
+                if (delta >= WL_RSS_BOUNDED_NOISE_FLOOR_KB) {
+                    int64_t strict_budget
+                        = rss_prev_kb / WL_RSS_BOUNDED_STRICT_PCT;
+                    if (delta > strict_budget) {
+                        printf("FAIL: rotation %u rss-strict prev=%"
+                            PRId64 " kb after=%" PRId64
+                            " kb delta=%" PRId64 " kb budget=%" PRId64
+                            " kb\n",
+                            r, rss_prev_kb, rss_after, delta,
+                            strict_budget);
+                        verdict = 1;
+                        goto cleanup;
+                    }
+                }
+            }
+
+            rss_prev_kb = rss_after;
+        }
+    }
+
+    if (rss_skipped) {
+        printf("PASS (R=%u, ledger stable @ %" PRIu64 " bytes, rss skipped)\n",
+            R, ledger_warmup_bytes);
+    } else {
+        printf("PASS (R=%u, ledger stable @ %" PRIu64
+            " bytes, rss warmup=%" PRId64 " kb final=%" PRId64 " kb)\n",
+            R, ledger_warmup_bytes, rss_warmup_kb, rss_prev_kb);
+    }
+
+cleanup:
+    free_session(sess);
+    wl_compound_arena_free(arena);
+    return verdict;
+}

--- a/tests/test_rss_bounded.c
+++ b/tests/test_rss_bounded.c
@@ -62,12 +62,21 @@
 #endif
 
 /* Test parameters -- match the daemon-soak workload's surface so a
- * future divergence in one does not silently churn the other. */
+ * future divergence in one does not silently churn the other.
+ * WL_RSS_BOUNDED_MAX_EPOCHS=32 with WL_RSS_BOUNDED_EPOCH_BUFFER=8
+ * mirrors the daemon-soak pattern: the saturation predicate fires
+ * every ~24 steps so the working set plateaus at the arena's ceiling
+ * regardless of R, which is exactly the bounded-RSS contract the
+ * cumulative gate asserts.  Without saturation-recycle, R=1000 with
+ * K=64 handles per epoch would accumulate ~1.5 MB of legitimate
+ * allocator pressure (64 * 24 bytes * 1000 epochs + per-epoch
+ * generation overhead) and trip the 10%/1 MB cumulative gate. */
 #define WL_RSS_BOUNDED_K_HANDLES   64u
 #define WL_RSS_BOUNDED_PAYLOAD_SZ  24u
 #define WL_RSS_BOUNDED_WARMUP      5u
 #define WL_RSS_BOUNDED_DEFAULT_R   100u
-#define WL_RSS_BOUNDED_MAX_EPOCHS  4096u
+#define WL_RSS_BOUNDED_MAX_EPOCHS  32u
+#define WL_RSS_BOUNDED_EPOCH_BUFFER 8u
 #define WL_RSS_BOUNDED_EVAL_ARENA  (256u * 1024u)
 #define WL_RSS_BOUNDED_COV_CEILING 0.05
 #define WL_RSS_BOUNDED_NOISE_FLOOR_KB 256
@@ -133,6 +142,43 @@ free_session(wl_col_session_t *s)
     if (s->eval_arena)
         wl_arena_free(s->eval_arena);
     free(s);
+}
+
+/* Saturation predicate: when current_epoch + EPOCH_BUFFER >= max_epochs,
+ * advance via gc_epoch_boundary to keep allocations flowing.  If the
+ * advance pushes (or has already pushed) current_epoch to the saturation
+ * sentinel (== max_epochs, see compound_arena.c:351), destroy and
+ * recreate the arena so the working set plateaus.  Mirrors the pattern
+ * in test_stress_harness.c's daemon-soak workload.
+ *
+ * Returns the (possibly newly recreated) arena via *arena_io.  Updates
+ * sess->compound_arena to match.  Returns 0 on success, non-zero on
+ * arena recreate failure. */
+static int
+maybe_recycle_arena(wl_col_session_t *sess, wl_compound_arena_t **arena_io)
+{
+    wl_compound_arena_t *arena = *arena_io;
+    if (arena->current_epoch + WL_RSS_BOUNDED_EPOCH_BUFFER
+        < arena->max_epochs) {
+        return 0;
+    }
+    /* Advance the epoch ahead of allocations -- but only if we're not
+     * already at the saturation sentinel (gc_epoch_boundary indexes
+     * gens[current_epoch] unconditionally; current_epoch == max_epochs
+     * is out of bounds). */
+    if (arena->current_epoch < arena->max_epochs)
+        sess->rotation_ops->gc_epoch_boundary(sess);
+    if (arena->current_epoch == arena->max_epochs) {
+        /* Tear down and recreate. */
+        wl_compound_arena_free(arena);
+        arena = wl_compound_arena_create(0xBEEFu, 4096u,
+                WL_RSS_BOUNDED_MAX_EPOCHS);
+        if (!arena)
+            return -1;
+        sess->compound_arena = arena;
+        *arena_io = arena;
+    }
+    return 0;
 }
 
 /* CoV self-check: skip-on-noise pattern from tests/test_log_perf_gate.c.
@@ -212,6 +258,11 @@ main(void)
      * ------------------------------------------------------------------ */
     int64_t warmup_rss[WL_RSS_BOUNDED_WARMUP];
     for (uint32_t i = 0; i < WL_RSS_BOUNDED_WARMUP; i++) {
+        if (maybe_recycle_arena(sess, &arena) != 0) {
+            printf("FAIL: warmup %u arena recycle failed\n", i);
+            verdict = 1;
+            goto cleanup;
+        }
         for (uint32_t k = 0; k < WL_RSS_BOUNDED_K_HANDLES; k++) {
             uint64_t h = wl_compound_arena_alloc(arena,
                     WL_RSS_BOUNDED_PAYLOAD_SZ);
@@ -253,14 +304,15 @@ main(void)
      * ------------------------------------------------------------------ */
     int64_t rss_prev_kb = rss_warmup_kb;
     for (uint32_t r = 0; r < R; r++) {
+        if (maybe_recycle_arena(sess, &arena) != 0) {
+            printf("FAIL: rotation %u arena recycle failed\n", r);
+            verdict = 1;
+            goto cleanup;
+        }
         for (uint32_t k = 0; k < WL_RSS_BOUNDED_K_HANDLES; k++) {
             uint64_t h = wl_compound_arena_alloc(arena,
                     WL_RSS_BOUNDED_PAYLOAD_SZ);
             if (h == WL_COMPOUND_HANDLE_NULL) {
-                /* Out of epochs is a normal end-of-soak condition for
-                 * very large R; surface as a clean PASS only after we
-                 * confirm the ledger gate held.  For now, treat as FAIL
-                 * to surface premature exhaustion. */
                 printf("FAIL: rotation %u handle %u alloc returned NULL "
                     "(current_epoch=%u max_epochs=%u)\n",
                     r, k, arena->current_epoch, arena->max_epochs);

--- a/tests/test_rss_util.h
+++ b/tests/test_rss_util.h
@@ -1,5 +1,5 @@
 /*
- * test_rss_util.h - Cross-platform peak-RSS sampler for stress tests
+ * test_rss_util.h - Cross-platform peak/current-RSS samplers for stress tests
  *
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
@@ -19,6 +19,22 @@
  * macOS, which is a known foot-gun.  This helper uses platform-native
  * APIs (Linux /proc/self/status VmHWM, macOS task_info, Windows
  * GetProcessMemoryInfo) so callers always get KB.
+ *
+ * Issue #598: extends this header with test_current_rss_kb(), which
+ * samples the CURRENT working-set size (not the monotonic peak).  The
+ * peak sampler test_peak_rss_kb() is appropriate for end-of-run gates
+ * that care about the high-water mark over a soak.  test_current_rss_kb()
+ * is appropriate for per-rotation sampling where the gate must observe
+ * heap growth between two points in time -- VmHWM only ever rises, so
+ * a per-rotation strict gate against VmHWM is mathematically broken
+ * (VmHWM(N+1) - VmHWM(N) >= 0 always).  Callers that need a delta
+ * between two rotations must use test_current_rss_kb().
+ *
+ * Platform notes for current_rss_kb:
+ *   - Linux:   /proc/self/status VmRSS field.
+ *   - macOS:   task_info MACH_TASK_BASIC_INFO resident_size.
+ *   - Windows: PROCESS_MEMORY_COUNTERS.WorkingSetSize.
+ *   - Else:    -1 (platform unavailable).
  */
 
 #ifndef WL_TEST_RSS_UTIL_H
@@ -41,6 +57,18 @@ test_peak_rss_kb(void)
     return (int64_t)(info.resident_size_max / 1024);
 }
 
+static inline int64_t
+test_current_rss_kb(void)
+{
+    struct mach_task_basic_info info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    kern_return_t kr = task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+            (task_info_t)&info, &count);
+    if (kr != KERN_SUCCESS)
+        return -1;
+    return (int64_t)(info.resident_size / 1024);
+}
+
 #elif defined(_WIN32)
 #include <psapi.h>
 #include <windows.h>
@@ -54,34 +82,65 @@ test_peak_rss_kb(void)
     return (int64_t)(pmc.PeakWorkingSetSize / 1024);
 }
 
+static inline int64_t
+test_current_rss_kb(void)
+{
+    PROCESS_MEMORY_COUNTERS pmc;
+    if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+        return -1;
+    return (int64_t)(pmc.WorkingSetSize / 1024);
+}
+
 #elif defined(__linux__)
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+/* Internal helper: parse a /proc/self/status field by tag (e.g. "VmHWM:"
+ * or "VmRSS:") and return its value in KB.  Both fields share the same
+ * "Tag:    1234 kB" line format, so the I/O logic is shared.  Returns -1
+ * on failure (file missing, tag absent). */
 static inline int64_t
-test_peak_rss_kb(void)
+test_proc_self_status_kb(const char *tag)
 {
     FILE *f = fopen("/proc/self/status", "r");
     if (!f)
         return -1;
-    int64_t rss = -1;
+    int64_t kb = -1;
     char line[256];
+    size_t taglen = strlen(tag);
     while (fgets(line, sizeof(line), f)) {
-        if (strncmp(line, "VmHWM:", 6) == 0) {
-            /* Format: "VmHWM:    1234 kB" */
-            rss = strtol(line + 6, NULL, 10);
+        if (strncmp(line, tag, taglen) == 0) {
+            kb = strtol(line + taglen, NULL, 10);
             break;
         }
     }
     fclose(f);
-    return rss;
+    return kb;
+}
+
+static inline int64_t
+test_peak_rss_kb(void)
+{
+    return test_proc_self_status_kb("VmHWM:");
+}
+
+static inline int64_t
+test_current_rss_kb(void)
+{
+    return test_proc_self_status_kb("VmRSS:");
 }
 
 #else
 
 static inline int64_t
 test_peak_rss_kb(void)
+{
+    return -1; /* unsupported platform */
+}
+
+static inline int64_t
+test_current_rss_kb(void)
 {
     return -1; /* unsupported platform */
 }


### PR DESCRIPTION
## Summary

Closes #598. Stacks on PR #626 (#597).

Adds `tests/test_rss_bounded.c` and `tests/test_deep_copy_ledger_canary.c` — narrow per-rotation memory-stability gates that complement #597's end-of-run RSS gate.

## Scope (post-rewrite-scope from architect+critic pre-review)

#598's literal text had three dead bullets that pre-review identified:

1. **VmHWM is monotonic** (Linux `/proc/self/status:VmHWM`). #597's `test_peak_rss_kb()` returns VmHWM, fine for end-of-run gates but mathematically broken for per-rotation deltas (`VmHWM(N+1) - VmHWM(N) >= 0` always). **Fix:** new `test_current_rss_kb()` reads `VmRSS` (live working set).
2. **`col_rel_deep_copy` has zero production callers in rotation paths** today (verified by grep across `wirelog/`). The "deep_copy temporary on rotation commit" bullet is vacuous today — becomes load-bearing only when #550-C `wl_session_rotate` ships.
3. **Production rotation hooks don't touch `wl_mem_ledger`** (`rotation_standard.c:21-31` only calls `wl_arena_reset`). Ledger entries happen on relation lifecycle, not rotation. So "ledger stable across rotation" is tautological today.

This PR ships the genuine residual scope:

| Differentiator | #597 daemon-soak | #598 rss-bounded |
|---|---|---|
| Sampler | `test_peak_rss_kb()` (VmHWM, monotonic) | `test_current_rss_kb()` (VmRSS, current WS) |
| Granularity | End-of-run only | Per-rotation, R=100 |
| Cumulative floor | `max(10%, 4MB)` | `max(10%, 1MB)` (tighter) |
| Strict per-step delta | None | `WL_RSS_BOUNDED_STRICT=1` nightly-only |
| Ledger gate | None | Exact equality of `current_bytes` per rotation |
| CoV self-check | None | SKIP if warmup CoV > 0.05 |
| deep_copy canary | None | Pre-copy + post-destroy ledger snapshot equality |

## What lands

- **`tests/test_rss_util.h`**: extended with `test_current_rss_kb()` (VmRSS sampler distinct from peak). Linux `/proc/self/status:VmRSS:`, macOS `task_info.resident_size`, Windows `WorkingSetSize`. Returns -1 on platform unavailable.
- **`tests/test_rss_bounded.c`**: standalone test with mock session + wired `wl_mem_ledger_t`. Per-rotation cumulative gate (Def#2) at PR, strict delta gate (Def#1) nightly-only, exact ledger equality, CoV self-check with exit-77 SKIP.
- **`tests/test_deep_copy_ledger_canary.c`**: regression canary asserting `col_rel_deep_copy` does not charge source ledger (per `relation.c:1101-1107` contract).
- **`tests/meson.build`**: 5 new test() registrations across PR / nightly / release / asan tiers.
- **`docs/STRESS_BASELINE.md`**: documents VmRSS-vs-VmHWM distinction, vacuous-canary framing for ledger and deep_copy, 100-run baseline pass-rate.

## Notable deviations (each justified)

1. **Mock session instead of full `wl_session_create` pipeline.** Rotation vtable only touches `eval_arena` and `compound_arena` (`rotation_standard.c:21-31`). Full parser/plan adds ~400ms with no extra signal coverage. Mock matches established daemon-soak pattern. Mock wires real `wl_mem_ledger_init` so ledger snapshot is real.
2. **Saturation-driven arena recycle (`max_epochs=32`).** Without it, R=500/1000 tiers accumulated legitimate per-epoch generation overhead and tripped the gate. Mirrors #597 daemon-soak's bounded-RSS pattern.
3. **Direct field assignment `src->mem_ledger = &ledger`** instead of `col_rel_set_ledger` — that API doesn't exist. Matches `test_col_rel_deep_copy.c:840`.

## Known follow-up nit (non-blocking)

Critic flagged that the ledger gate is "doubly vacuous" today — production rotation doesn't charge the ledger AND the mock harness doesn't allocate ledger-tracked memory. Becomes load-bearing if either side starts using the ledger. Documented as regression canary. Doc tightening to explicitly disclose double-vacuity is a follow-up.

## Review trail

- Architect + critic pre-review: REWRITE-SCOPE → drop dead bullets, narrow to per-rotation VmRSS gate + ledger/deep_copy canaries.
- Implementer: 5 atomic commits; 3 deviations all defended against on-disk evidence.
- Code-reviewer: APPROVE — no CRITICAL/MAJOR; 4 minor cosmetic.
- Architect meta-review: CONCUR — all 7 directives faithful.
- Critic meta-review: SHIP-WITH-NIT — gates work; one doc honesty improvement as follow-up.

## Test plan

- [x] `meson test -C build rss_bounded_pr deep_copy_ledger_canary` PASS
- [x] `meson test -C build-san --suite asan` 4/4 OK
- [x] 100/100 PR-tier baseline (recorded in STRESS_BASELINE.md)
- [x] Full suite 196 OK, 1 skipped (perf gate, no regressions)
- [x] CoV self-check verified to fire SKIP on noisy baseline (manual injection)
- [ ] CI green (lint + cross-platform builds + ASan job)