### PR TITLE
Make wirelog.h an umbrella header

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ path(X, Z) :- path(X, Y), edge(Y, Z).
 Run it from C using the `wl_easy` facade:
 
 ```c
-#include "wirelog/wl_easy.h"
+#include <wirelog/wirelog.h>  /* umbrella: pulls in wl_easy and the rest */
 
 int main(void) {
     wl_easy_session_t *s = NULL;

--- a/examples/08-delta-queries/delta_demo.c
+++ b/examples/08-delta-queries/delta_demo.c
@@ -13,7 +13,7 @@
  * Run:   ./build/examples/08-delta-queries/delta_demo
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/09-retraction-basics/retract_demo.c
+++ b/examples/09-retraction-basics/retract_demo.c
@@ -28,7 +28,7 @@
  * Run:   ./build/examples/09-retraction-basics/retract_demo
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/examples/10-recursive-under-update/tc_demo.c
+++ b/examples/10-recursive-under-update/tc_demo.c
@@ -28,7 +28,7 @@
  * Run:   ./build/examples/10-recursive-under-update/tc_demo
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/examples/11-time-evolution/time_evolution_demo.c
+++ b/examples/11-time-evolution/time_evolution_demo.c
@@ -27,7 +27,7 @@
  * Run:   ./build/examples/11-time-evolution/time_evolution_demo
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/examples/12-snapshot-vs-delta/snapshot_demo.c
+++ b/examples/12-snapshot-vs-delta/snapshot_demo.c
@@ -33,7 +33,7 @@
  * Run:   ./build/examples/12-snapshot-vs-delta/snapshot_demo
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog.h"
 
 #include <inttypes.h>
 #include <stdint.h>

--- a/examples/path_a_pcap_skeleton/main.c
+++ b/examples/path_a_pcap_skeleton/main.c
@@ -14,7 +14,7 @@
  * See also: Issue #446 (Option C design), Issue #462 (CI compile gate).
  */
 
-#include <wirelog/io/io_adapter.h>
+#include <wirelog/wirelog.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/wirelog/wirelog-optimizer.h
+++ b/wirelog/wirelog-optimizer.h
@@ -23,6 +23,13 @@
 #ifndef WIRELOG_OPTIMIZER_H
 #define WIRELOG_OPTIMIZER_H
 
+/*
+ * Pull in wirelog.h for the foundational opaque types
+ * (wirelog_program_t) and the wirelog_error_t enum.  The umbrella
+ * include in wirelog.h handles the cycle via header guards.
+ */
+#include "wirelog/wirelog.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,7 +49,7 @@ extern "C" {
 typedef enum {
     WIRELOG_OPT_LOGIC_FUSION = 0, /* Fuse Join+Map+Filter operations */
     WIRELOG_OPT_JOIN_PROJECT_PLAN
-    = 1,                             /* Optimize join ordering and projection */
+        = 1,                         /* Optimize join ordering and projection */
     WIRELOG_OPT_SEMIJOIN = 2,        /* Apply semijoin pre-filtering */
     WIRELOG_OPT_SUBPLAN_SHARING = 3, /* Share common subplans (CTEs) */
     WIRELOG_OPT_BOOLEAN_SPEC = 4,    /* Specialize Boolean operations */
@@ -112,7 +119,7 @@ wirelog_optimizer_get_default_config(void);
  * Returns: true on success, false on error
  */
 bool
-wirelog_optimize(void *program, int *error);
+wirelog_optimize(wirelog_program_t *program, wirelog_error_t *error);
 
 /**
  * wirelog_optimize_with_config:
@@ -125,8 +132,9 @@ wirelog_optimize(void *program, int *error);
  * Returns: true on success, false on error
  */
 bool
-wirelog_optimize_with_config(void *program, const wirelog_opt_config_t *config,
-                             int *error);
+wirelog_optimize_with_config(wirelog_program_t *program,
+    const wirelog_opt_config_t *config,
+    wirelog_error_t *error);
 
 /**
  * wirelog_optimize_apply_pass:
@@ -141,7 +149,8 @@ wirelog_optimize_with_config(void *program, const wirelog_opt_config_t *config,
  * Returns: true on success, false on error
  */
 bool
-wirelog_optimize_apply_pass(void *program, wirelog_opt_pass_t pass, int *error);
+wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
+    wirelog_error_t *error);
 
 /* ======================================================================== */
 /* Optimization Analysis                                                    */
@@ -157,7 +166,8 @@ wirelog_optimize_apply_pass(void *program, wirelog_opt_pass_t pass, int *error);
  * Returns: true if stats were collected, false otherwise
  */
 bool
-wirelog_optimizer_get_stats(const void *program, wirelog_opt_stats_t *stats);
+wirelog_optimizer_get_stats(const wirelog_program_t *program,
+    wirelog_opt_stats_t *stats);
 
 /**
  * wirelog_optimizer_debug_print:
@@ -172,7 +182,7 @@ wirelog_optimizer_get_stats(const void *program, wirelog_opt_stats_t *stats);
  * - Join ordering rationale
  */
 void
-wirelog_optimizer_debug_print(const void *program);
+wirelog_optimizer_debug_print(const wirelog_program_t *program);
 
 /**
  * wirelog_optimizer_cost_estimate:
@@ -183,7 +193,7 @@ wirelog_optimizer_debug_print(const void *program);
  * Returns: Estimated cost (arbitrary units), or 0 if not available
  */
 uint64_t
-wirelog_optimizer_cost_estimate(const void *program);
+wirelog_optimizer_cost_estimate(const wirelog_program_t *program);
 
 #ifdef __cplusplus
 }

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -23,6 +23,18 @@
 #ifndef WIRELOG_H
 #define WIRELOG_H
 
+/*
+ * wirelog.h is the umbrella header for the wirelog public API.
+ * Downstream users should include only this header:
+ *
+ *     #include <wirelog/wirelog.h>
+ *
+ * Individual sub-headers (wirelog-types.h, wirelog-parser.h,
+ * wirelog-ir.h, wirelog-optimizer.h, wirelog-export.h, wl_easy.h,
+ * io/io_adapter.h) are still installed for backwards compatibility
+ * but should not be included directly in new code.
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,8 +52,8 @@ extern "C" {
 #define WIRELOG_VERSION_PATCH 0
 
 #define WIRELOG_VERSION                                          \
-    (WIRELOG_VERSION_MAJOR * 10000 + WIRELOG_VERSION_MINOR * 100 \
-     + WIRELOG_VERSION_PATCH)
+        (WIRELOG_VERSION_MAJOR * 10000 + WIRELOG_VERSION_MINOR * 100 \
+        + WIRELOG_VERSION_PATCH)
 
 /* ======================================================================== */
 /* Type Definitions                                                         */
@@ -131,8 +143,8 @@ wirelog_program_get_intern(const wirelog_program_t *prog);
  */
 int
 wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
-                          int64_t **data, uint32_t *num_rows,
-                          uint32_t *num_cols);
+    int64_t **data, uint32_t *num_rows,
+    uint32_t *num_cols);
 
 /**
  * Load all inline facts from the program into a DD worker.
@@ -184,8 +196,8 @@ wirelog_executor_free(wirelog_executor_t *executor);
 
 bool
 wirelog_load_facts_from_csv(wirelog_executor_t *executor,
-                            const char *relation_name, const char *csv_file,
-                            wirelog_error_t *error);
+    const char *relation_name, const char *csv_file,
+    wirelog_error_t *error);
 
 wirelog_result_t *
 wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error);
@@ -196,16 +208,16 @@ wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error);
 
 const void *
 wirelog_result_get_relation(const wirelog_result_t *result,
-                            const char *relation_name);
+    const char *relation_name);
 
 uint64_t
 wirelog_result_relation_cardinality(const wirelog_result_t *result,
-                                    const char *relation_name);
+    const char *relation_name);
 
 bool
 wirelog_result_write_csv(const wirelog_result_t *result,
-                         const char *relation_name, const char *output_file,
-                         wirelog_error_t *error);
+    const char *relation_name, const char *output_file,
+    wirelog_error_t *error);
 
 void
 wirelog_result_free(wirelog_result_t *result);
@@ -232,5 +244,21 @@ wirelog_config_threads(void);
 #ifdef __cplusplus
 }
 #endif
+
+/* ======================================================================== */
+/* Umbrella includes                                                        */
+/*                                                                          */
+/* Pull in the rest of the public API so users only need this header.       */
+/* Each sub-header has its own include guard, so this is cycle-safe;        */
+/* sub-headers may also reference the opaque types declared above.          */
+/* ======================================================================== */
+
+#include "wirelog/wirelog-export.h"
+#include "wirelog/wirelog-types.h"
+#include "wirelog/wirelog-parser.h"
+#include "wirelog/wirelog-ir.h"
+#include "wirelog/wirelog-optimizer.h"
+#include "wirelog/wl_easy.h"
+#include "wirelog/io/io_adapter.h"
 
 #endif /* WIRELOG_H */


### PR DESCRIPTION
## Summary

- `wirelog/wirelog.h` is now an umbrella that pulls in every public sub-header, so downstream code only needs `#include <wirelog/wirelog.h>` instead of remembering which sub-header (`wl_easy.h`, `wirelog-parser.h`, `wirelog-ir.h`, `wirelog-optimizer.h`, `io/io_adapter.h`, `wirelog-types.h`, `wirelog-export.h`) declares each symbol. Sub-headers stay installed for backwards compatibility.
- `wirelog/wirelog-optimizer.h` includes `wirelog.h` and tightens the six optimizer-extension declarations from `void *program, int *error` to `wirelog_program_t *, wirelog_error_t *`. This resolves the conflicting-types error that surfaced once both headers reached the same translation unit. Those symbols have no implementations or callers today, so no behavioral change.
- All examples (`examples/{08..12}/*.c`, `examples/path_a_pcap_skeleton/main.c`) and the README quick-start switch to the umbrella include, modeling the new recommended usage.

## Test plan

- [x] `meson compile -C build` — 6769/6769 targets built clean
- [x] `meson test -C build` — 196 pass / 0 fail / 7 skip
- [x] Standalone install + downstream build via pkg-config — `path_a_pcap_skeleton` compiles and links against the installed wirelog headers using only `#include <wirelog/wirelog.h>`, confirming no header-install regression