### PR TITLE
ci: bump clang-tidy gate from LLVM 18 to LLVM 22

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,7 @@ name: CI Main
 # This workflow monitors health; ci-pr.yml enforces quality gates on PRs.
 #
 # Phases (all parallel, non-blocking):
-#   Phase 1 (Lint):       lint-main.yml — editorconfig, uncrustify, clang-tidy 18
+#   Phase 1 (Lint):       lint-main.yml — editorconfig, uncrustify, clang-tidy 22
 #   Phase 2 (Build):      Linux GCC + Clang, macOS Clang, Windows MSVC, ARM64 GCC (optional self-hosted)
 #   Phase 3 (Sanitizers): Linux GCC + Clang ASan/UBSan, macOS Apple Clang ASan/UBSan
 #
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # ==========================================================================
   # Phase 1: Lint monitoring (import lint-main.yml)
-  # editorconfig, uncrustify, clang-tidy 18 — all parallel, non-blocking
+  # editorconfig, uncrustify, clang-tidy 22 — all parallel, non-blocking
   # ==========================================================================
   lint:
     uses: ./.github/workflows/lint-main.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   # ==========================================================================
   # Phase 1: Lint (import lint-pr.yml as prerequisite)
-  # editorconfig -> uncrustify -> clang-tidy 18 (sequential, hard gates)
+  # editorconfig -> uncrustify -> clang-tidy 22 (sequential, hard gates)
   # ==========================================================================
   lint:
     uses: ./.github/workflows/lint-pr.yml

--- a/.github/workflows/lint-main.yml
+++ b/.github/workflows/lint-main.yml
@@ -8,7 +8,7 @@ name: Lint Main
 # Jobs:
 #   - editorconfig-check  : whitespace/encoding/line-ending consistency
 #   - uncrustify-check    : formatting against uncrustify.cfg
-#   - clang-tidy-check    : static analysis via LLVM 18 (Linux only, slow)
+#   - clang-tidy-check    : static analysis via LLVM 22 (Linux only, slow)
 #
 # All jobs have continue-on-error: true — issues are surfaced as annotations
 # and step summaries without failing the workflow run.
@@ -108,27 +108,27 @@ jobs:
           fi
 
   # ==========================================================================
-  # Check 3: clang-tidy 18 (slow, up to 30 min, Linux only)
+  # Check 3: clang-tidy 22 (slow, up to 30 min, Linux only)
   # Non-blocking: reports static analysis findings.
   # Excludes: subprojects/**, build/**
   # ==========================================================================
   clang-tidy-check:
-    name: clang-tidy 18 check (monitor)
+    name: clang-tidy 22 check (monitor)
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install LLVM 18
+      - name: Install LLVM 22
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm-18.list
+          echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-18 clang-tools-18
+          sudo apt-get install -y clang-tidy-22 clang-tools-22
 
       - name: Verify tool version
-        run: clang-tidy-18 --version
+        run: clang-tidy-22 --version
 
       - name: Install build dependencies
         run: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          run-clang-tidy-18 -p builddir-tidy \
+          run-clang-tidy-22 -p builddir-tidy \
             "^\\.\\./wirelog/.*\\.(c|h)$" \
             2>&1 | tee tidy-results.txt || true
 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -114,28 +114,28 @@ jobs:
           fi
 
   # ==========================================================================
-  # Phase 1c: clang-tidy 18 check (slow, up to 30 min, Linux only)
+  # Phase 1c: clang-tidy 22 check (slow, up to 30 min, Linux only)
   # Hard gate: tidy violations fail the PR.
   # Excludes: subprojects/**, build/**
   # Runs only after uncrustify passes.
   # ==========================================================================
   clang-tidy-check:
-    name: clang-tidy 18 check
+    name: clang-tidy 22 check
     needs: [uncrustify-check]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install LLVM 18
+      - name: Install LLVM 22
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm-18.list
+          echo "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-22 main" | sudo tee /etc/apt/sources.list.d/llvm-22.list
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-18 clang-tools-18
+          sudo apt-get install -y clang-tidy-22 clang-tools-22
 
       - name: Verify tool version
-        run: clang-tidy-18 --version
+        run: clang-tidy-22 --version
 
       - name: Install build dependencies
         run: |
@@ -147,7 +147,7 @@ jobs:
       - name: Run clang-tidy (hard gate)
         run: |
           set -o pipefail
-          run-clang-tidy-18 -p builddir-tidy \
+          run-clang-tidy-22 -p builddir-tidy \
             "^\\.\\./wirelog/.*\\.(c|h)$" \
             2>&1 | tee tidy-results.txt
           if grep -qE '^.*\.(c|h):[0-9]+:[0-9]+: (warning|error):' tidy-results.txt; then

--- a/wirelog/wirelog-optimizer.h
+++ b/wirelog/wirelog-optimizer.h
@@ -102,24 +102,16 @@ typedef struct {
 wirelog_opt_config_t
 wirelog_optimizer_get_default_config(void);
 
-/**
- * wirelog_optimize:
- * @program: Program to optimize
- * @error: (out) (optional): Error code
+/* Note: wirelog_optimize() lives in wirelog.h — this header adds the
+ * config/pass/stats variants on top of the core entry point.
  *
- * Apply all enabled optimizations to a program.
- *
- * Optimizations applied (Phase 0+):
- * 1. Logic Fusion: Merge Join+Map+Filter into FlatMap
- * 2. Join-Project Plan: Determine optimal join order
- * 3. Semijoin Information Passing: Pre-filter with semijoins
- * 4. Subplan Sharing: Share common sub-expressions
- * 5. Boolean Specialization: Optimize diff field encoding
- *
- * Returns: true on success, false on error
+ * Phase 0+ optimization pipeline:
+ *   1. Logic Fusion: Merge Join+Map+Filter into FlatMap
+ *   2. Join-Project Plan: Determine optimal join order
+ *   3. Semijoin Information Passing: Pre-filter with semijoins
+ *   4. Subplan Sharing: Share common sub-expressions
+ *   5. Boolean Specialization: Optimize diff field encoding
  */
-bool
-wirelog_optimize(wirelog_program_t *program, wirelog_error_t *error);
 
 /**
  * wirelog_optimize_with_config:

--- a/wirelog/wirelog-parser.h
+++ b/wirelog/wirelog-parser.h
@@ -50,38 +50,8 @@ typedef struct {
 /* ======================================================================== */
 /* Parsing                                                                  */
 /* ======================================================================== */
-
-/**
- * wirelog_parse:
- * @filename: Path to .dl file
- * @error: (out) (optional): Error code
- *
- * Parse a Datalog program from a file.
- *
- * Supported Datalog features:
- * - Facts (extensional database)
- * - Rules with recursion
- * - Negation (stratified)
- * - Aggregation (COUNT, SUM, MIN, MAX, AVG)
- * - Built-in predicates (=, <, >, <=, >=, !=)
- * - Comments (% line comments)
- *
- * Returns: (transfer full): Parsed program, or NULL on error
- */
-wirelog_program_t *
-wirelog_parse(const char *filename, wirelog_error_t *error);
-
-/**
- * wirelog_parse_string:
- * @program_text: Datalog program as string
- * @error: (out) (optional): Error code
- *
- * Parse a Datalog program from a string.
- *
- * Returns: (transfer full): Parsed program, or NULL on error
- */
-wirelog_program_t *
-wirelog_parse_string(const char *program_text, wirelog_error_t *error);
+/* Note: wirelog_parse() and wirelog_parse_string() live in wirelog.h —
+ * this header only adds the error-info variant on top of the core API. */
 
 /**
  * wirelog_parse_with_error_info:
@@ -94,7 +64,7 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error);
  */
 wirelog_program_t *
 wirelog_parse_with_error_info(const char *filename,
-                              wirelog_parse_error_t *error_info);
+    wirelog_parse_error_t *error_info);
 
 /* ======================================================================== */
 /* Program Inspection                                                       */
@@ -122,7 +92,7 @@ wirelog_program_get_stratum_count(const wirelog_program_t *program);
  */
 const wirelog_stratum_t *
 wirelog_program_get_stratum(const wirelog_program_t *program,
-                            uint32_t stratum_id);
+    uint32_t stratum_id);
 
 /**
  * wirelog_program_get_rule_count:
@@ -146,7 +116,7 @@ wirelog_program_get_rule_count(const wirelog_program_t *program);
  */
 const wirelog_schema_t *
 wirelog_program_get_schema(const wirelog_program_t *program,
-                           const char *relation_name);
+    const char *relation_name);
 
 /**
  * wirelog_program_is_stratified:
@@ -159,18 +129,7 @@ wirelog_program_get_schema(const wirelog_program_t *program,
 bool
 wirelog_program_is_stratified(const wirelog_program_t *program);
 
-/* ======================================================================== */
-/* Cleanup                                                                  */
-/* ======================================================================== */
-
-/**
- * wirelog_program_free:
- * @program: (transfer full): Program to free
- *
- * Free a parsed program and all associated resources.
- */
-void
-wirelog_program_free(wirelog_program_t *program);
+/* Note: wirelog_program_free() lives in wirelog.h. */
 
 #ifdef __cplusplus
 }

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -99,12 +99,44 @@ typedef enum {
 /* Parser API                                                               */
 /* ======================================================================== */
 
+/**
+ * wirelog_parse:
+ * @filename: Path to .dl file
+ * @error: (out) (optional): Error code
+ *
+ * Parse a Datalog program from a file.
+ *
+ * Supported Datalog features:
+ * - Facts (extensional database)
+ * - Rules with recursion
+ * - Negation (stratified)
+ * - Aggregation (COUNT, SUM, MIN, MAX, AVG)
+ * - Built-in predicates (=, <, >, <=, >=, !=)
+ * - Comments (% line comments)
+ *
+ * Returns: (transfer full): Parsed program, or NULL on error
+ */
 wirelog_program_t *
 wirelog_parse(const char *filename, wirelog_error_t *error);
 
+/**
+ * wirelog_parse_string:
+ * @program_text: Datalog program as string
+ * @error: (out) (optional): Error code
+ *
+ * Parse a Datalog program from a string.
+ *
+ * Returns: (transfer full): Parsed program, or NULL on error
+ */
 wirelog_program_t *
 wirelog_parse_string(const char *program_text, wirelog_error_t *error);
 
+/**
+ * wirelog_program_free:
+ * @program: (transfer full): Program to free
+ *
+ * Free a parsed program and all associated resources.
+ */
 void
 wirelog_program_free(wirelog_program_t *program);
 


### PR DESCRIPTION
## Summary

- Pin the clang-tidy lint gate to **LLVM 22** (was 18) across all four workflow files (`lint-pr.yml`, `lint-main.yml`, `ci-pr.yml`, `ci-main.yml`). Each touched workflow swaps the apt source, package set, version banner, and `run-clang-tidy-N` invocation.
- The existing `.clang-tidy` config (explicit C-safe allowlist) is unchanged: every check it requests still exists in clang-tidy 22, verified locally via `clang-tidy --list-checks`.
- One new check fires under v22 that v18 missed: `readability-redundant-declaration` flags the parser/optimizer sub-headers for re-declaring functions that `wirelog.h` already declares (latent issue surfaced by the umbrella header). Fix: drop the redundant prototypes from the sub-headers and migrate the rich docstrings up to `wirelog.h` so no documentation is lost.
  - `wirelog/wirelog.h`: add doxygen blocks for `wirelog_parse`, `wirelog_parse_string`, `wirelog_program_free`, copied verbatim from `wirelog-parser.h`.
  - `wirelog/wirelog-parser.h`: drop the three redundant prototypes; leave a one-line note pointing at `wirelog.h`.
  - `wirelog/wirelog-optimizer.h`: drop the redundant `wirelog_optimize` prototype (kept the optimization-pipeline docstring as a header note for the remaining config/pass/stats variants).

## Test plan

- [x] `meson compile -C build` — clean rebuild, no warnings
- [x] `meson test -C build` — 196 pass / 0 fail / 7 skip
- [x] `run-clang-tidy` (LLVM 22) on `wl_easy.c` — zero diagnostics, confirming the redundant-decl warnings are gone
- [ ] CI lint job runs clang-tidy 22 against the full `wirelog/**.c` set