### PR TITLE
docs(#636): mark wl_session_* internal, align example prose, dedupe callback typedefs

### DIFF
--- a/examples/08-delta-queries/README.md
+++ b/examples/08-delta-queries/README.md
@@ -21,7 +21,7 @@ diff marker.
 ## Files
 
 - **access_control.dl**: Datalog program for the access control example (reference)
-- **delta_demo.c**: C program demonstrating `wl_session_set_delta_cb()`
+- **delta_demo.c**: C program demonstrating `wl_easy_set_delta_cb()`
 - **example.csv**: Sample access control facts used as input
 - **meson.build**: Build configuration for `delta_demo`
 
@@ -42,7 +42,7 @@ Example 08: Delta Queries with Callback API
 
 Inserting access control facts...
 
-Delta output from wl_session_step():
+Delta output from wl_easy_step():
 + granted("alice", "read")
 + granted("alice", "write")
 + granted("bob", "read")
@@ -57,11 +57,11 @@ Done.
 ### 1. Register the Callback
 
 ```c
-wl_session_set_delta_cb(session, on_delta, user_data);
+wl_easy_set_delta_cb(session, on_delta, user_data);
 ```
 
 The callback fires for every output tuple that is newly derived (diff = +1)
-or retracted (diff = -1) when `wl_session_step()` is called.
+or retracted (diff = -1) when `wl_easy_step()` is called.
 
 ### 2. Callback Signature
 
@@ -94,15 +94,14 @@ on_delta(const char *relation, const int64_t *row, uint32_t ncols,
 ```
 
 To insert facts with symbol columns from C code, intern your strings
-with `wl_intern_put()` before creating the session plan:
+with `wl_easy_intern()` first:
 
 ```c
-wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
-int64_t id_alice = wl_intern_put(intern, "alice");
-int64_t id_read  = wl_intern_put(intern, "read");
+int64_t id_alice = wl_easy_intern(s, "alice");
+int64_t id_read  = wl_easy_intern(s, "read");
 
 int64_t row[] = { id_alice, id_read };
-wl_session_insert(session, "can", row, 1, 2);
+wl_easy_insert(s, "can", row, 2);
 ```
 
 ### 4. Datalog Program
@@ -137,8 +136,8 @@ not on every step if the fact was already known.
 
 | API | When to use |
 |-----|-------------|
-| `wl_session_set_delta_cb` + `wl_session_step` | Streaming, event-driven, incremental pipelines |
-| `wl_session_snapshot` | One-shot batch queries |
+| `wl_easy_set_delta_cb` + `wl_easy_step` | Streaming, event-driven, incremental pipelines |
+| `wl_easy_snapshot` | One-shot batch queries |
 
 Delta mode is efficient for cases where facts trickle in over time and
 you want to react to each change without re-scanning the full result set.
@@ -153,7 +152,7 @@ snapshot. This is efficient even for large relation sizes.
 ## Next Steps
 
 - Add role-based rules: `granted(U, P) :- role(U, R), role_perm(R, P)`
-- Extend to retraction: use `wl_session_remove()` to revoke permissions
+- Extend to retraction: use `wl_easy_remove_sym()` to revoke permissions
   and observe diff=-1 callbacks
 - Combine with `07-multi-source-analysis` to integrate permissions from
   multiple identity providers

--- a/examples/08-delta-queries/access_control.dl
+++ b/examples/08-delta-queries/access_control.dl
@@ -2,7 +2,7 @@
  * access_control.dl - Access Control Rules for Example 08
  *
  * Demonstrates the delta-callback API: as can(user, permission) tuples are
- * inserted via wl_session_insert(), the engine derives granted() tuples
+ * inserted via wl_easy_insert_sym(), the engine derives granted() tuples
  * incrementally and fires the delta callback for each newly derived fact.
  *
  * Note: This file is a reference for the Datalog logic embedded in

--- a/examples/09-retraction-basics/README.md
+++ b/examples/09-retraction-basics/README.md
@@ -3,9 +3,8 @@
 ## Overview
 
 This example demonstrates incremental retraction in wirelog using
-`wl_easy_remove_sym` (which wraps `wl_session_remove`).  When a base fact
-is retracted, the engine propagates `-1` deltas to any derived relations
-that depended on it.  The scope here is non-recursive: a single join rule
+`wl_easy_remove_sym`.  When a base fact is retracted, the engine
+propagates `-1` deltas to any derived relations that depended on it.  The scope here is non-recursive: a single join rule
 derives `mutual(A, B)` from `friend(A, B), friend(B, A)`, and removing one
 side of the friendship pair produces exactly two `-1` deltas on `mutual`,
 one for each derived tuple that is no longer supported.
@@ -75,4 +74,4 @@ Done.
 - `examples/08-delta-queries/` -- the preceding example that introduces
   delta callbacks with `wl_easy_print_delta`.
 - `tests/test_delta_retraction.c` -- engine-level retraction tests (issue
-  #158) that exercise the same `wl_session_remove` contract used here.
+  #158) that exercise the same `wl_easy_remove_sym` contract used here.

--- a/examples/10-recursive-under-update/README.md
+++ b/examples/10-recursive-under-update/README.md
@@ -86,4 +86,4 @@ Done.
 - `examples/09-retraction-basics/` -- non-recursive retraction basics with
   `-1` deltas on a single-join rule.
 - `tests/test_delta_retraction.c` -- engine-level retraction tests (issue
-  #158) that exercise the same `wl_session_remove` contract used here.
+  #158) that exercise the same `wl_easy_remove_sym` contract used here.

--- a/wirelog/backend.h
+++ b/wirelog/backend.h
@@ -28,9 +28,12 @@ extern "C" {
 #endif
 
 #include "exec_plan.h"
+#include "wirelog/wirelog-types.h"
 
 #include <stdint.h>
 #include <stdbool.h>
+
+/* wl_on_tuple_fn / wl_on_delta_fn now live in wirelog-types.h (single source of truth). */
 
 /**
  * wl_session_t:
@@ -38,33 +41,6 @@ extern "C" {
  * Opaque handle to an active execution session.
  */
 typedef struct wl_session wl_session_t;
-
-/**
- * wl_on_tuple_fn:
- *
- * Callback invoked once per computed output tuple.
- *
- * @relation:  Null-terminated output relation name.
- * @row:       Array of int64_t values (length = @ncols).
- * @ncols:     Number of columns in the row.
- * @user_data: Opaque pointer passed through from the caller.
- */
-typedef void (*wl_on_tuple_fn)(const char *relation, const int64_t *row,
-                               uint32_t ncols, void *user_data);
-
-/**
- * wl_on_delta_fn:
- *
- * Callback invoked when a tuple is inserted/removed in an incremental session.
- *
- * @relation:  Null-terminated output relation name.
- * @row:       Array of int64_t values (length = @ncols).
- * @ncols:     Number of columns in the row.
- * @diff:      +1 for insertion, -1 for removal.
- * @user_data: Opaque pointer passed through from the caller.
- */
-typedef void (*wl_on_delta_fn)(const char *relation, const int64_t *row,
-                               uint32_t ncols, int32_t diff, void *user_data);
 
 /**
  * wl_compute_backend_t:
@@ -86,24 +62,24 @@ typedef struct {
     const char *name;
 
     int (*session_create)(const wl_plan_t *plan, uint32_t num_workers,
-                          wl_session_t **out);
+        wl_session_t **out);
     void (*session_destroy)(wl_session_t *session);
 
     int (*session_insert)(wl_session_t *session, const char *relation,
-                          const int64_t *data, uint32_t num_rows,
-                          uint32_t num_cols);
+        const int64_t *data, uint32_t num_rows,
+        uint32_t num_cols);
 
     int (*session_remove)(wl_session_t *session, const char *relation,
-                          const int64_t *data, uint32_t num_rows,
-                          uint32_t num_cols);
+        const int64_t *data, uint32_t num_rows,
+        uint32_t num_cols);
 
     int (*session_step)(wl_session_t *session);
 
     void (*session_set_delta_cb)(wl_session_t *session, wl_on_delta_fn callback,
-                                 void *user_data);
+        void *user_data);
 
     int (*session_snapshot)(wl_session_t *session, wl_on_tuple_fn callback,
-                            void *user_data);
+        void *user_data);
 } wl_compute_backend_t;
 
 /**

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -42,13 +42,12 @@ struct wl_session {
 /* Wrapper functions that delegate to the backend vtable */
 
 /*
- * NOTE: For most applications, prefer the high-level wl_easy facade in
- * <wirelog/wl_easy.h>.  wl_easy wraps parse + optimize + plan + session
- * creation behind a single wl_easy_open() call and provides convenience
- * helpers (wl_easy_intern, wl_easy_insert_sym, wl_easy_print_delta, etc.)
- * that remove boilerplate.  The wl_session_* primitives below remain the
- * canonical low-level API for advanced use cases that need direct control
- * over plans, backends, or worker counts.
+ * NOTE: This header is INTERNAL — it is not part of the installed
+ * public surface (see install_headers in the top-level meson.build).
+ * Public users must use <wirelog/wl_easy.h> (or, equivalently, the
+ * umbrella <wirelog/wirelog.h>).  The wl_session_* primitives below
+ * back the wl_easy_* facade and are exercised by in-tree tests; they
+ * are not promised to external consumers and may change without notice.
  */
 
 /**

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -125,6 +125,37 @@ typedef double wirelog_float_t;
 typedef bool wirelog_bool_t;
 
 /* ======================================================================== */
+/* Callbacks                                                                */
+/* ======================================================================== */
+
+/**
+ * wl_on_tuple_fn:
+ *
+ * Callback invoked once per computed output tuple.
+ *
+ * @relation:  Null-terminated output relation name.
+ * @row:       Array of int64_t values (length = @ncols).
+ * @ncols:     Number of columns in the row.
+ * @user_data: Opaque pointer passed through from the caller.
+ */
+typedef void (*wl_on_tuple_fn)(const char *relation, const int64_t *row,
+    uint32_t ncols, void *user_data);
+
+/**
+ * wl_on_delta_fn:
+ *
+ * Callback invoked when a tuple is inserted/removed in an incremental session.
+ *
+ * @relation:  Null-terminated output relation name.
+ * @row:       Array of int64_t values (length = @ncols).
+ * @ncols:     Number of columns in the row.
+ * @diff:      +1 for insertion, -1 for removal.
+ * @user_data: Opaque pointer passed through from the caller.
+ */
+typedef void (*wl_on_delta_fn)(const char *relation, const int64_t *row,
+    uint32_t ncols, int32_t diff, void *user_data);
+
+/* ======================================================================== */
 /* Relation Types                                                           */
 /* ======================================================================== */
 

--- a/wirelog/wl_easy.h
+++ b/wirelog/wl_easy.h
@@ -28,17 +28,9 @@ extern "C" {
 #endif
 
 #include "wirelog/wirelog.h"
+#include "wirelog/wirelog-types.h"
 
 #include <stdint.h>
-
-/* Forward-declared callback typedefs (mirrors wirelog/backend.h, which is
- * not part of the public install set).  Definitions must remain in lock-step
- * with backend.h. */
-typedef void (*wl_on_tuple_fn)(const char *relation, const int64_t *row,
-    uint32_t ncols, void *user_data);
-
-typedef void (*wl_on_delta_fn)(const char *relation, const int64_t *row,
-    uint32_t ncols, int32_t diff, void *user_data);
 
 /**
  * wl_easy_session_t:


### PR DESCRIPTION
Closes #636.

## Summary

Three atomic commits, all docstring/header-of-truth cleanup — no public API change, no observable behavior change:

- **0f182f1** — `wirelog/session.h` block comment was advertising `wl_session_*` as wirelog's "canonical low-level API for advanced use cases", but the header is not in `install_headers` (top-level `meson.build`).  External consumers following that docstring hit `fatal error: wirelog/session.h: No such file or directory` after `meson install`.  Replaced with a truthful internal-header note pointing at `<wirelog/wl_easy.h>` (or the umbrella).
- **1fbbc86** — Example READMEs (08-delta-queries, 09-retraction-basics, 10-recursive-under-update) prose still spoke `wl_session_*` even though every driver `.c` has been on `wl_easy_*` since #441.  Realigned vocabulary; also fixed the C snippet at `examples/08-delta-queries/README.md:99-106` so it matches what `delta_demo.c` actually does (`wl_easy_intern` + `wl_easy_insert`, no `wl_intern_put` / const-cast).
- **096d932** — `wl_on_tuple_fn` / `wl_on_delta_fn` were defined in private `wirelog/backend.h` and forward-declared in public `wirelog/wl_easy.h` with a comment requiring callers to keep both copies "in lock-step".  Single-source-of-truth smell.  Moved canonical definitions to public `wirelog/wirelog-types.h`; both `backend.h` and `wl_easy.h` now `#include "wirelog/wirelog-types.h"` and stop redeclaring.  ABI-equivalent.

Resolves the docstring lie identified during the architect+critic review of #635.  This PR does **not** touch the API surface; #635 (additive `wl_easy_open_opts`) is a separate, unblocked follow-up.

## Test plan

- [x] `ninja -C build` — clean rebuild, no warnings
- [x] `meson test -C build` — 196 pass / 0 fail / 7 skip (unchanged baseline)
- [x] `grep -n "canonical low-level API" wirelog/` — no matches
- [x] `grep -rn "wl_on_tuple_fn\|wl_on_delta_fn" wirelog/` — only the canonical typedef in `wirelog-types.h`; all other hits are uses
- [ ] CI lint matrix (clang-tidy 22, uncrustify, editorconfig) and full build matrix