### PR TITLE
feat(#635): wl_easy_open_opts — worker count + eager build via ABI-versioned opts struct

### DIFF
--- a/scripts/ci/check-wl-easy-opts-symbol.sh
+++ b/scripts/ci/check-wl-easy-opts-symbol.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Issue #635: wl_easy_open and wl_easy_open_opts must be exported by libwirelog.
+set -euo pipefail
+
+BUILD_DIR="${1:-build}"
+LIB=""
+for candidate in "$BUILD_DIR/libwirelog.so" "$BUILD_DIR"/libwirelog.so.* \
+                 "$BUILD_DIR/libwirelog.dylib" "$BUILD_DIR"/libwirelog.*.dylib; do
+    if [[ -f "$candidate" ]]; then LIB="$candidate"; break; fi
+done
+if [[ -z "$LIB" ]]; then
+    echo "ERROR: libwirelog shared artifact not found under $BUILD_DIR" >&2
+    exit 2
+fi
+
+nm_dynamic_defined() {
+    if nm -D --defined-only "$1" 2>/dev/null; then
+        return 0
+    fi
+    nm "$1" 2>/dev/null | awk '$2 != "U" && $2 != "u"'
+}
+
+SYMS="$(nm_dynamic_defined "$LIB")"
+# Match either bare or underscore-prefixed symbols so the same probe
+# works for ELF (Linux: "wl_easy_open") and Mach-O (macOS: "_wl_easy_open").
+for sym in wl_easy_open wl_easy_open_opts; do
+    if ! printf '%s\n' "$SYMS" | awk -v sym="$sym" \
+        '$NF == sym || $NF == "_" sym {found = 1} END {exit !found}'; then
+        echo "ERROR: missing exported symbol $sym in $LIB" >&2
+        exit 1
+    fi
+done
+
+echo "OK: wl_easy_open and wl_easy_open_opts exported by $LIB"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -340,6 +340,10 @@ if not is_windows
        find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
        args: [meson.project_build_root()],
        suite: 'abi')
+  test('wl_easy_abi_opts_symbol',
+       find_program(meson.project_source_root() / 'scripts/ci/check-wl-easy-opts-symbol.sh'),
+       args: [meson.project_build_root()],
+       suite: 'abi')
 endif
 
 test_intern_exe = executable(

--- a/tests/test_wl_easy.c
+++ b/tests/test_wl_easy.c
@@ -6,8 +6,12 @@
  * For commercial licenses, contact: inquiry@cleverplant.com
  */
 
-#include "../wirelog/wl_easy.h"
+#define _POSIX_C_SOURCE 200809L
 
+#include "../wirelog/wl_easy.h"
+#include "../wirelog/util/log.h"
+
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -113,6 +117,123 @@ collect_tuple(const char *relation, const int64_t *row, uint32_t ncols,
         c->rows[idx][i] = row[i];
 }
 
+static bool
+drive_access_control_trace(wl_easy_session_t *s)
+{
+    int64_t alice = wl_easy_intern(s, "alice");
+    int64_t read = wl_easy_intern(s, "read");
+    if (alice < 0 || read < 0)
+        return false;
+
+    delta_collector_t deltas;
+    memset(&deltas, 0, sizeof(deltas));
+    if (wl_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK)
+        return false;
+
+    int64_t row[2] = { alice, read };
+    if (wl_easy_insert(s, "can", row, 2) != WIRELOG_OK)
+        return false;
+    if (wl_easy_step(s) != WIRELOG_OK)
+        return false;
+
+    bool found_delta = false;
+    for (int i = 0; i < deltas.count; i++) {
+        if (strcmp(deltas.relations[i], "granted") == 0
+            && deltas.ncols[i] == 2 && deltas.rows[i][0] == alice
+            && deltas.rows[i][1] == read && deltas.diffs[i] == 1) {
+            found_delta = true;
+            break;
+        }
+    }
+    if (!found_delta)
+        return false;
+
+    tuple_collector_t granted_t;
+    memset(&granted_t, 0, sizeof(granted_t));
+    if (wl_easy_snapshot(s, "granted", collect_tuple, &granted_t)
+        != WIRELOG_OK)
+        return false;
+
+    for (int i = 0; i < granted_t.count; i++) {
+        if (strcmp(granted_t.relations[i], "granted") == 0
+            && granted_t.ncols[i] == 2 && granted_t.rows[i][0] == alice
+            && granted_t.rows[i][1] == read)
+            return true;
+    }
+    return false;
+}
+
+static bool
+file_contains_substring(const char *path, const char *needle)
+{
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return false;
+
+    char buf[4096];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    return strstr(buf, needle) != NULL;
+}
+
+#ifndef _WIN32
+static bool
+capture_num_workers_log(const wl_easy_open_opts_t *opts, uint32_t expected)
+{
+    char path[128];
+    snprintf(path, sizeof(path), "/tmp/wl-easy-num-test-%ld-%u.log",
+        (long)getpid(), expected);
+    unlink(path);
+
+    char needle[32];
+    snprintf(needle, sizeof(needle), "num_workers=%u", expected);
+
+    setenv("WL_LOG", "SESSION:4", 1);
+    wl_log_init();
+
+    int saved_stderr = dup(STDERR_FILENO);
+    if (saved_stderr < 0) {
+        unsetenv("WL_LOG");
+        return false;
+    }
+
+    int log_fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (log_fd < 0) {
+        close(saved_stderr);
+        unsetenv("WL_LOG");
+        return false;
+    }
+    if (dup2(log_fd, STDERR_FILENO) < 0) {
+        close(log_fd);
+        close(saved_stderr);
+        unsetenv("WL_LOG");
+        return false;
+    }
+    close(log_fd);
+
+    wl_easy_session_t *s = NULL;
+    wirelog_error_t open_rc = wl_easy_open_opts(ACCESS_CONTROL_SRC, opts, &s);
+    wirelog_error_t build_rc = WIRELOG_ERR_EXEC;
+    if (open_rc == WIRELOG_OK && s)
+        build_rc = wl_easy_set_delta_cb(s, NULL, NULL);
+
+    fflush(stderr);
+    bool restored = dup2(saved_stderr, STDERR_FILENO) >= 0;
+    close(saved_stderr);
+
+    bool found = file_contains_substring(path, needle);
+    unsetenv("WL_LOG");
+    wl_log_init();
+    if (s)
+        wl_easy_close(s);
+    unlink(path);
+
+    return restored && open_rc == WIRELOG_OK && build_rc == WIRELOG_OK
+           && found;
+}
+#endif
+
 /* ======================================================================== */
 /* Tests                                                                    */
 /* ======================================================================== */
@@ -152,6 +273,174 @@ test_open_parse_error(void)
         return;
     }
     PASS();
+}
+
+static void
+test_open_opts_null_equiv_to_open(void)
+{
+    TEST("open_opts NULL opts equivalent to open");
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open_opts(ACCESS_CONTROL_SRC, NULL, &s) != WIRELOG_OK || !s) {
+        FAIL("open_opts failed");
+        return;
+    }
+    if (!drive_access_control_trace(s)) {
+        FAIL("access-control trace failed");
+        wl_easy_close(s);
+        return;
+    }
+    wl_easy_close(s);
+    PASS();
+}
+
+static void
+test_open_opts_zero_size_rejected(void)
+{
+    TEST("open_opts rejects zero size");
+
+    wl_easy_open_opts_t opts = { 0 };
+    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
+    wirelog_error_t rc = wl_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s);
+    if (rc != WIRELOG_ERR_EXEC) {
+        FAIL("expected WIRELOG_ERR_EXEC");
+        return;
+    }
+    if (s != NULL) {
+        FAIL("*out should be NULL on error");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_open_opts_reserved_rejected(void)
+{
+    TEST("open_opts rejects reserved field before parsing");
+
+    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    opts._reserved = (const void *)0x1;
+    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
+    wirelog_error_t rc
+        = wl_easy_open_opts("this is not datalog", &opts, &s);
+    if (rc != WIRELOG_ERR_EXEC) {
+        FAIL("expected WIRELOG_ERR_EXEC");
+        return;
+    }
+    if (s != NULL) {
+        FAIL("*out should be NULL on error");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_open_opts_init_macro(void)
+{
+    TEST("open_opts init macro sets defaults");
+
+    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    if (opts.size != sizeof(wl_easy_open_opts_t)) {
+        FAIL("unexpected size");
+        return;
+    }
+    if (opts.num_workers != 0) {
+        FAIL("unexpected num_workers");
+        return;
+    }
+    if (opts.eager_build) {
+        FAIL("unexpected eager_build");
+        return;
+    }
+    if (opts._reserved != NULL) {
+        FAIL("unexpected _reserved");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_open_opts_eager_build_ok(void)
+{
+    TEST("open_opts eager_build opens usable session");
+
+    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    opts.eager_build = true;
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s) != WIRELOG_OK || !s) {
+        FAIL("open_opts eager_build failed");
+        return;
+    }
+    if (!drive_access_control_trace(s)) {
+        FAIL("access-control trace failed");
+        wl_easy_close(s);
+        return;
+    }
+    wl_easy_close(s);
+    PASS();
+}
+
+/*
+ * The codebase has no fixture for "parses-clean-but-plans-dirty" today, so
+ * the eager-build error contract is currently exercised only via the
+ * parse-error path (per the architect+critic synthesis plan, scope-narrow per
+ * Critic MAJOR #6).
+ */
+static void
+test_open_opts_eager_build_propagates_parse_error(void)
+{
+    TEST("open_opts eager_build propagates parse error");
+
+    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    opts.eager_build = true;
+    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
+    wirelog_error_t rc
+        = wl_easy_open_opts("definitely not datalog", &opts, &s);
+    if (rc != WIRELOG_ERR_PARSE) {
+        FAIL("expected WIRELOG_ERR_PARSE");
+        return;
+    }
+    if (s != NULL) {
+        FAIL("*out should be NULL on error");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_num_workers_default_is_one(void)
+{
+    TEST("open_opts default num_workers logs one");
+
+#ifdef _WIN32
+    SKIP("POSIX fd redirection not available on Windows");
+    return;
+#else
+    if (!capture_num_workers_log(NULL, 1)) {
+        FAIL("expected num_workers=1 log");
+        return;
+    }
+    PASS();
+#endif
+}
+
+static void
+test_num_workers_explicit_four(void)
+{
+    TEST("open_opts explicit num_workers logs four");
+
+#ifdef _WIN32
+    SKIP("POSIX fd redirection not available on Windows");
+    return;
+#else
+    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    opts.num_workers = 4;
+    if (!capture_num_workers_log(&opts, 4)) {
+        FAIL("expected num_workers=4 log");
+        return;
+    }
+    PASS();
+#endif
 }
 
 static void
@@ -596,6 +885,14 @@ main(void)
 
     test_open_close_null_safe();
     test_open_parse_error();
+    test_open_opts_null_equiv_to_open();
+    test_open_opts_zero_size_rejected();
+    test_open_opts_reserved_rejected();
+    test_open_opts_init_macro();
+    test_open_opts_eager_build_ok();
+    test_open_opts_eager_build_propagates_parse_error();
+    test_num_workers_default_is_one();
+    test_num_workers_explicit_four();
     test_intern_returns_same_id();
     test_insert_step_delta();
     test_insert_sym_variadic();

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -473,6 +473,8 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     sess->plan = plan;
     sess->intern = plan->intern;
     sess->num_workers = num_workers > 0 ? num_workers : 1;
+    WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO, "session created num_workers=%u",
+        sess->num_workers);
 
     /*
      * WL_MAX_WORKERS: Per-worker and W² exchange buffer cost cap

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -33,6 +33,7 @@
 #include "wirelog/wirelog-parser.h"
 #include "wirelog/wirelog-types.h"
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -51,6 +52,7 @@ struct wl_easy_session {
      * wl_intern_put() needs a mutable pointer; the program owns the
      * intern's lifetime so the cast is safe. */
     wl_intern_t *intern_mut;
+    uint32_t num_workers;
     bool plan_built; /* true once first wl_easy_step-class call ran */
 };
 
@@ -59,7 +61,7 @@ struct wl_easy_session {
 /* ======================================================================== */
 
 static wirelog_error_t
-ensure_plan_built(wl_easy_session_t *s)
+ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
@@ -68,14 +70,18 @@ ensure_plan_built(wl_easy_session_t *s)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(s->prog, &plan);
-    if (rc != 0 || !plan)
-        return WIRELOG_ERR_EXEC;
+    if (rc != 0 || !plan) {
+        if (plan)
+            wl_plan_free(plan);
+        return WIRELOG_ERR_INVALID_IR;
+    }
 
     wl_session_t *session = NULL;
-    rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    rc = wl_session_create(wl_backend_columnar(), plan,
+            num_workers > 0 ? num_workers : 1, &session);
     if (rc != 0 || !session) {
         wl_plan_free(plan);
-        return WIRELOG_ERR_EXEC;
+        return (rc == ENOMEM) ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
     }
 
     s->plan = plan;
@@ -89,11 +95,17 @@ ensure_plan_built(wl_easy_session_t *s)
 /* ======================================================================== */
 
 wirelog_error_t
-wl_easy_open(const char *dl_src, wl_easy_session_t **out)
+wl_easy_open_opts(const char *dl_src, const wl_easy_open_opts_t *opts,
+    wl_easy_session_t **out)
 {
     if (!dl_src || !out)
         return WIRELOG_ERR_EXEC;
     *out = NULL;
+
+    if (opts && opts->size < sizeof(wl_easy_open_opts_t))
+        return WIRELOG_ERR_EXEC;
+    if (opts && opts->_reserved)
+        return WIRELOG_ERR_EXEC;
 
     wirelog_error_t err = WIRELOG_OK;
     wirelog_program_t *prog = wirelog_parse_string(dl_src, &err);
@@ -137,10 +149,30 @@ wl_easy_open(const char *dl_src, wl_easy_session_t **out)
     s->intern_mut = (wl_intern_t *)wirelog_program_get_intern(prog);
     s->plan = NULL;
     s->session = NULL;
+    s->num_workers = opts ? opts->num_workers : 0;
     s->plan_built = false;
+
+    if (opts && opts->eager_build) {
+        err = ensure_plan_built(s, s->num_workers);
+        if (err != WIRELOG_OK) {
+            if (s->session)
+                wl_session_destroy(s->session);
+            if (s->plan)
+                wl_plan_free(s->plan);
+            wirelog_program_free(prog);
+            free(s);
+            return err;
+        }
+    }
 
     *out = s;
     return WIRELOG_OK;
+}
+
+wirelog_error_t
+wl_easy_open(const char *dl_src, wl_easy_session_t **out)
+{
+    return wl_easy_open_opts(dl_src, NULL, out);
 }
 
 void
@@ -185,7 +217,7 @@ wl_easy_insert(wl_easy_session_t *s, const char *relation, const int64_t *row,
 {
     if (!s || !relation || !row)
         return WIRELOG_ERR_EXEC;
-    wirelog_error_t err = ensure_plan_built(s);
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
     int rc = wl_session_insert(s->session, relation, row, 1, ncols);
@@ -198,7 +230,7 @@ wl_easy_remove(wl_easy_session_t *s, const char *relation, const int64_t *row,
 {
     if (!s || !relation || !row)
         return WIRELOG_ERR_EXEC;
-    wirelog_error_t err = ensure_plan_built(s);
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
     int rc = wl_session_remove(s->session, relation, row, 1, ncols);
@@ -271,7 +303,7 @@ wl_easy_step(wl_easy_session_t *s)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
-    wirelog_error_t err = ensure_plan_built(s);
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
     int rc = wl_session_step(s->session);
@@ -283,7 +315,7 @@ wl_easy_set_delta_cb(wl_easy_session_t *s, wl_on_delta_fn cb, void *user_data)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
-    wirelog_error_t err = ensure_plan_built(s);
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
     wl_session_set_delta_cb(s->session, cb, user_data);
@@ -388,7 +420,7 @@ wl_easy_snapshot(wl_easy_session_t *s, const char *relation, wl_on_tuple_fn cb,
 {
     if (!s || !relation || !cb)
         return WIRELOG_ERR_EXEC;
-    wirelog_error_t err = ensure_plan_built(s);
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
     wl_easy_snapshot_filter_t filter

--- a/wirelog/wl_easy.h
+++ b/wirelog/wl_easy.h
@@ -30,6 +30,7 @@ extern "C" {
 #include "wirelog/wirelog.h"
 #include "wirelog/wirelog-types.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -51,6 +52,73 @@ extern "C" {
  *   derived state (rows, callback user_data, intern ids) between them.
  */
 typedef struct wl_easy_session wl_easy_session_t;
+
+/**
+ * wl_easy_open_opts_t:
+ *
+ * Optional configuration for wl_easy_open_opts().  All fields are
+ * optional; pass NULL for all defaults (equivalent to wl_easy_open).
+ *
+ * The struct is ABI-versioned via @size.  Callers MUST initialize it
+ * with the WL_EASY_OPEN_OPTS_INIT macro (or assign
+ * `.size = sizeof(wl_easy_open_opts_t)` explicitly) so future field
+ * additions remain ABI-safe.  Library validates `size` on entry and
+ * returns WIRELOG_ERR_EXEC if it is smaller than the runtime
+ * sizeof(wl_easy_open_opts_t) compiled into libwirelog.
+ *
+ * @size:         sizeof(wl_easy_open_opts_t) at the caller's compile
+ *                time.  REQUIRED.  Use WL_EASY_OPEN_OPTS_INIT.
+ * @num_workers:  Number of worker threads for the underlying session.
+ *                0 (the default) is permanently mapped to 1; do not
+ *                rely on a different default in future releases.
+ * @eager_build:  If true, force plan + session build before
+ *                wl_easy_open_opts() returns, so parse/plan/session
+ *                errors surface synchronously.  If false (default),
+ *                the build is deferred until the first
+ *                insert/remove/step/set_delta_cb/snapshot call
+ *                (legacy wl_easy_open behavior).
+ * @_reserved:    Reserved for future use; must be NULL.  Non-NULL
+ *                returns WIRELOG_ERR_EXEC.
+ *
+ * Lifetime: opts is read once during wl_easy_open_opts() and may be
+ * freed by the caller immediately after the call returns.
+ */
+typedef struct {
+    uint32_t size;
+    uint32_t num_workers;
+    bool eager_build;
+    const void *_reserved;
+} wl_easy_open_opts_t;
+
+#define WL_EASY_OPEN_OPTS_INIT \
+        { .size = sizeof(wl_easy_open_opts_t), \
+          .num_workers = 0, \
+          .eager_build = false, \
+          ._reserved = NULL }
+
+/**
+ * wl_easy_open_opts:
+ * @dl_src: Datalog source text (must not be NULL).
+ * @opts:   Optional configuration (may be NULL → defaults).  If
+ *          non-NULL, must have @size set to
+ *          sizeof(wl_easy_open_opts_t) (use WL_EASY_OPEN_OPTS_INIT).
+ * @out:    (out) Receives the new session handle on success.
+ *
+ * Same contract as wl_easy_open() but with optional configuration.
+ * wl_easy_open(dl, out) is equivalent to
+ * wl_easy_open_opts(dl, NULL, out).
+ *
+ * Error codes (in addition to wl_easy_open's):
+ *   WIRELOG_ERR_EXEC      - opts->size too small / opts->_reserved non-NULL
+ *   WIRELOG_ERR_INVALID_IR - eager_build set and plan generation failed
+ *   WIRELOG_ERR_MEMORY    - eager_build set and session allocation failed
+ *
+ * Returns: WIRELOG_OK on success; *out set to NULL on any error.
+ */
+wirelog_error_t
+wl_easy_open_opts(const char *dl_src,
+    const wl_easy_open_opts_t *opts,
+    wl_easy_session_t **out);
 
 /**
  * wl_easy_open:


### PR DESCRIPTION
Closes #635.

## Summary

Adds the public additive entry point `wl_easy_open_opts` to wirelog's
`wl_easy.h` facade so downstream embedders can opt into worker-count
selection (G1) and eager plan/session build (G2) without reaching
into private headers.  `wl_easy_open(dl, out)` is now a one-line
forwarder to `wl_easy_open_opts(dl, NULL, out)` and remains an
exported symbol — zero source breakage, zero ABI break.

3 atomic commits:

- **df2a6c5 — `feat(#635): add wl_easy_open_opts with size-versioned opts struct`**.
  New `wl_easy_open_opts_t` (with mandatory leading `uint32_t size` field
  and `WL_EASY_OPEN_OPTS_INIT` initializer macro) + `wl_easy_open_opts`
  function + parameterized `ensure_plan_built(s, num_workers)` so the
  lazy-build path honors the requested worker count.  Refines
  ensure_plan_built's error mapping: `WIRELOG_ERR_INVALID_IR` for
  plan-time failure, `WIRELOG_ERR_MEMORY` for `ENOMEM`, `WIRELOG_ERR_EXEC`
  otherwise.
- **02a05ad — `test(#635): exhaustive coverage for wl_easy_open_opts and num_workers observable`**.
  Eight regression tests in `tests/test_wl_easy.c` covering NULL opts,
  zero-size rejection, `_reserved` rejection, init-macro contents,
  eager-build OK + parse-error short-circuit, and worker-count
  observability via the existing `WL_LOG=SESSION:4` channel.
  Adds exactly **one** `WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO, ...)`
  line in `wirelog/columnar/session.c` to make `num_workers`
  externally observable from the test without leaking it to the
  public API.
- **ec098ca — `ci(#635): ABI symbol-presence test for wl_easy_open + wl_easy_open_opts`**.
  New `scripts/ci/check-wl-easy-opts-symbol.sh` registered in the
  `abi` suite (`tests/meson.build`).  Greps the dynamic symbol table
  of `libwirelog.so`/`libwirelog.dylib` for both symbols and exits
  non-zero if either disappears in a future refactor.

## Deviation from #635 spec (call-out for review)

The spec proposed:

```c
typedef struct {
    uint32_t num_workers;
    bool     eager_build;
    const void *_reserved;
} wl_easy_open_opts_t;
```

This PR ships with a leading `uint32_t size;` field:

```c
typedef struct {
    uint32_t    size;          // MUST be sizeof(wl_easy_open_opts_t); use WL_EASY_OPEN_OPTS_INIT
    uint32_t    num_workers;
    bool        eager_build;
    const void *_reserved;
} wl_easy_open_opts_t;
```

Reason — architect+critic synthesis identified the unversioned struct
as a CRITICAL ABI trap: the moment 0.31 wants to add a fourth field,
either an old binary linked against 0.30 reads OOB past its short
struct, or the library can never grow.  The codebase already has
the same precedent at `wirelog/io/io_adapter.h:65`
(`uint32_t abi_version`).  The `_reserved` slot from the spec is
preserved as the G3 forward-compat seam and is hard-rejected when
non-NULL.

Documented locked-in semantic for `num_workers == 0` ⇒ `1` (matches
existing `wirelog/columnar/session.c:475` floor).  Future releases
may NOT change this default without an ABI bump.

## Acceptance criteria checklist (#635)

- [x] `wl_easy_open_opts` declared in `wl_easy.h`, no install_headers churn.
- [x] `wl_easy_open(dl, out)` is `wl_easy_open_opts(dl, NULL, out)`, zero behavior delta.
- [x] `num_workers=1` observable via `test_num_workers_default_is_one` and `test_num_workers_explicit_four`.
- [x] `eager_build=true` short-circuits on parse failure (`test_open_opts_eager_build_propagates_parse_error`); plan-failure path scope-narrowed because no in-tree `parses-clean-but-plans-dirty` fixture exists today.
- [x] No behavior change for legacy `wl_easy_open` callers (existing `wl_easy.c` test suite + 8 example demos compile and run unchanged).
- [x] ABI/symbol test added (`wl_easy_abi_opts_symbol` in suite `abi`).

## Test plan

- [x] `meson compile -C build` — clean, no warnings.
- [x] `meson test -C build` — 197 pass / 0 fail / 7 skip (baseline 196 + 1 new ABI test; the 8 new in-process tests are registered as sub-tests inside the existing `wl_easy` target).
- [x] `meson test -C build --suite abi` — all ABI gates pass including the new symbol-presence check.
- [x] `nm -D --defined-only build/libwirelog.so | grep -E '\\bwl_easy_open(_opts)?$\\b'` — both symbols `T`.
- [ ] Full CI (lint matrix, clang-tidy 22, build matrix Linux/macOS/Windows) on this PR.