### PR TITLE
[codex] Fix clang-cl lockfree queue barrier declaration

### DIFF
--- a/wirelog/util/lockfree_queue.c
+++ b/wirelog/util/lockfree_queue.c
@@ -23,6 +23,7 @@
 #include <stdatomic.h>
 #else
 #include <windows.h>
+#include <intrin.h>
 /*
  * MSVC C11 mode does not yet provide full <stdatomic.h> for all types.
  * Provide a minimal shim for _Atomic uint32_t using volatile + Interlocked.


### PR DESCRIPTION
## Summary

- Include `<intrin.h>` for the Windows/MSVC lock-free queue fallback path.
- Make the barrier intrinsic declaration visible when building this code path with clang-cl/MSVC-style headers.

## Root Cause

The Windows fallback uses compiler intrinsics for the queue barrier path, but the translation unit only included `<windows.h>`. With clang-cl, that can leave the intrinsic declaration unavailable and break compilation.

## Impact

This keeps the non-C11-atomics Windows fallback buildable without changing the queue behavior on platforms that use `<stdatomic.h>`.

Fixes #639

## Validation

- `meson test -C build-codex-pr wirelog:lockfree_queue --print-errorlogs` passed.
- `meson test -C build-codex-pr --print-errorlogs` built and ran from a clean build dir; 195 passed, 7 skipped, 2 ABI script checks failed because the local configuration did not produce a `libwirelog` shared artifact for those scripts to inspect.