### PR TITLE
Clean up LLVM 22 clang-tidy findings

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1527,6 +1527,24 @@ test_cli_exe = executable(
 
 test('cli', test_cli_exe)
 
+test_cli_watch_exe = executable(
+  'test_cli_watch',
+  files('test_cli_watch.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('cli_watch', test_cli_watch_exe)
+
 test_cli_delta_exe = executable(
   'test_cli_delta',
   files('test_cli_delta.c'),

--- a/tests/test_cli_watch.c
+++ b/tests/test_cli_watch.c
@@ -1,0 +1,74 @@
+/*
+ * test_cli_watch.c - CLI watch-mode tests
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "../wirelog/cli/driver.h"
+
+#include "test_tmpdir.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+main(void)
+{
+    char inpath[512];
+    test_tmppath(inpath, sizeof(inpath), "wirelog_test_watch_string.in");
+    FILE *in = fopen(inpath, "w");
+    if (!in) {
+        fprintf(stderr, "cannot create watch input file\n");
+        return 1;
+    }
+    fprintf(in, "person \"Alice\"\n");
+    fclose(in);
+
+    if (!freopen(inpath, "r", stdin)) {
+        remove(inpath);
+        fprintf(stderr, "cannot redirect stdin\n");
+        return 1;
+    }
+
+    char outpath[512];
+    test_tmppath(outpath, sizeof(outpath), "wirelog_test_watch_string.out");
+    FILE *out = fopen(outpath, "w");
+    if (!out) {
+        remove(inpath);
+        fprintf(stderr, "cannot create output file\n");
+        return 1;
+    }
+
+    const char *src = ".decl person(name: string)\n"
+        ".decl seen(name: string)\n"
+        "seen(name) :- person(name).\n";
+
+    int rc = wl_run_pipeline(src, 1, false, true, 0, out);
+    fclose(out);
+    if (rc != 0) {
+        remove(inpath);
+        remove(outpath);
+        fprintf(stderr, "wl_run_pipeline returned %d\n", rc);
+        return 1;
+    }
+
+    char *output = wl_read_file(outpath);
+    if (!output) {
+        remove(inpath);
+        remove(outpath);
+        fprintf(stderr, "cannot read output file\n");
+        return 1;
+    }
+
+    int ok = strstr(output, "\"Alice\"") != NULL;
+    if (!ok)
+        fprintf(stderr, "expected watch output to contain Alice: %s\n", output);
+
+    free(output);
+    remove(inpath);
+    remove(outpath);
+    return ok ? 0 : 1;
+}

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -55,8 +55,10 @@ wl_read_file(const char *path)
         fclose(f);
         return NULL;
     }
-
-    rewind(f);
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
 
     char *buf = (char *)malloc((size_t)len + 1);
     if (!buf) {

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -203,7 +203,7 @@ print_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
  * @rel_buf_size: Capacity of @relation_out.
  * @values:       Output buffer for parsed int64_t column values.
  * @ncols_out:    (out) Number of values parsed.
- * @rel_info:     Relation schema for type-aware parsing (may be NULL).
+ * @prog:         Program containing relation schemas (may be NULL).
  * @intern:       Intern table for string columns (may be NULL).
  *
  * Parse a line of the form:
@@ -215,7 +215,7 @@ print_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
 static int
 parse_watch_line(char *line, char *relation_out, size_t rel_buf_size,
     int64_t *values, uint32_t *ncols_out,
-    const wl_ir_relation_info_t *rel_info, wl_intern_t *intern)
+    const wirelog_program_t *prog, wl_intern_t *intern)
 {
     /* Strip trailing newline/carriage-return */
     size_t len = strlen(line);
@@ -256,6 +256,9 @@ parse_watch_line(char *line, char *relation_out, size_t rel_buf_size,
     if (tlen == 0 || tlen >= rel_buf_size)
         return -1;
     memcpy(relation_out, token, tlen + 1);
+
+    const wl_ir_relation_info_t *rel_info = prog
+        ? find_relation(prog, relation_out) : NULL;
 
     /* Parse remaining tokens as column values */
     uint32_t col = 0;
@@ -490,16 +493,11 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
 
         while (fgets(line, (int)sizeof(line), stdin)) {
             uint32_t ncols = 0;
-            const wl_ir_relation_info_t *rel_info
-                = find_relation(prog, relation);
 
             if (parse_watch_line(line, relation, sizeof(relation), values,
-                &ncols, rel_info, prog->intern)
+                &ncols, prog, prog->intern)
                 != 0)
                 continue;
-
-            /* Re-fetch rel_info now that relation name is filled in */
-            rel_info = find_relation(prog, relation);
 
             rc = wl_session_insert(sess, relation, values, 1, ncols);
             if (rc != 0) {

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1486,17 +1486,6 @@ void
 col_session_free_sorted_arrangements(wl_col_session_t *cs);
 
 /* ======================================================================== */
-/* Frontier & Affected Strata (columnar/frontier.c)                         */
-/* ======================================================================== */
-
-uint64_t
-col_compute_affected_strata(wl_session_t *session,
-    const char *inserted_relation);
-uint64_t
-col_compute_affected_rules(wl_session_t *session,
-    const char *inserted_relation);
-
-/* ======================================================================== */
 /* Mobius / Z-set (columnar/mobius.c)                                        */
 /* ======================================================================== */
 

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -136,7 +136,7 @@ col_columns_alloc(uint32_t ncols, uint32_t capacity)
         if (!cols[c]) {
             for (uint32_t j = 0; j < c; j++)
                 free(cols[j]);
-            free(cols);
+            free((void *)cols);
             return NULL;
         }
     }
@@ -151,7 +151,7 @@ col_columns_free(int64_t **cols, uint32_t ncols)
         return;
     for (uint32_t c = 0; c < ncols; c++)
         free(cols[c]);
-    free(cols);
+    free((void *)cols);
 }
 
 /** Realloc each column to new_cap. Returns 0 on success, ENOMEM on failure. */

--- a/wirelog/crc32.c
+++ b/wirelog/crc32.c
@@ -50,10 +50,10 @@ crc32_hw_available(void)
     /* CPUID leaf 1, ECX bit 20 = SSE4.2 (includes CRC32 instruction) */
     /* Note: MSVC does not support GCC-style inline asm, disable HW accel on Windows */
     unsigned int eax, ebx, ecx, edx;
-    __asm__ volatile("cpuid"
-                     : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
-                     : "a"(1), "c"(0));
-    return (ecx >> 20) & 1;
+    __asm__ volatile ("cpuid"
+    : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx)
+    : "a" (1), "c" (0));
+    return ((ecx >> 20) & 1U) != 0U;
 #elif defined(WL_ARCH_ARM64) && !defined(_MSC_VER)
 #if defined(__APPLE__)
     /* Apple Silicon always has CRC32 extension */

--- a/wirelog/intern.c
+++ b/wirelog/intern.c
@@ -12,6 +12,7 @@
 
 #include "intern.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -71,14 +72,16 @@ fnv1a(const char *str)
 static int
 intern_resize(wl_intern_t *intern)
 {
-    uint32_t new_cap = intern->slot_capacity * 2;
+    if (intern->slot_capacity > UINT32_MAX / 2U)
+        return -1;
+    uint32_t new_cap = intern->slot_capacity * 2U;
     wl_intern_slot_t *new_slots
-        = (wl_intern_slot_t *)malloc(new_cap * sizeof(wl_intern_slot_t));
+        = (wl_intern_slot_t *)malloc((size_t)new_cap
+            * sizeof(wl_intern_slot_t));
     if (!new_slots)
         return -1;
 
-    for (uint32_t i = 0; i < new_cap; i++)
-        new_slots[i].string_id = SLOT_EMPTY;
+    memset(new_slots, 0xff, (size_t)new_cap * sizeof(wl_intern_slot_t));
 
     /* Re-insert all existing entries */
     for (uint32_t i = 0; i < intern->count; i++) {
@@ -114,7 +117,7 @@ wl_intern_create(void)
 
     intern->slot_capacity = INTERN_INITIAL_CAP;
     intern->slots = (wl_intern_slot_t *)malloc(intern->slot_capacity
-                                               * sizeof(wl_intern_slot_t));
+            * sizeof(wl_intern_slot_t));
     if (!intern->slots) {
         free((void *)intern->strings);
         free(intern);
@@ -160,9 +163,11 @@ wl_intern_put(wl_intern_t *intern, const char *str)
 
     /* New string: grow string array if needed */
     if (intern->count >= intern->string_capacity) {
-        uint32_t new_cap = intern->string_capacity * 2;
+        if (intern->string_capacity > UINT32_MAX / 2U)
+            return -1;
+        uint32_t new_cap = intern->string_capacity * 2U;
         char **new_strs = (char **)realloc((void *)intern->strings,
-                                           new_cap * sizeof(char *));
+                (size_t)new_cap * sizeof(char *));
         if (!new_strs)
             return -1;
         intern->strings = new_strs;
@@ -175,19 +180,23 @@ wl_intern_put(wl_intern_t *intern, const char *str)
         return -1;
     memcpy(copy, str, slen + 1);
 
+    /* Resize hash table before insertion if the new entry would exceed the load factor. */
+    if ((uint64_t)(intern->count + 1U) * INTERN_LOAD_FACTOR_DEN
+        > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM) {
+        if (intern_resize(intern) != 0) {
+            free(copy);
+            return -1;
+        }
+        mask = intern->slot_capacity - 1U;
+        h = fnv1a(str) & mask;
+        while (intern->slots[h].string_id != SLOT_EMPTY)
+            h = (h + 1U) & mask;
+    }
+
     uint32_t new_id = intern->count;
     intern->strings[new_id] = copy;
     intern->count++;
-
-    /* Insert into hash table */
     intern->slots[h].string_id = new_id;
-
-    /* Resize hash table if load factor exceeded */
-    if (intern->count * INTERN_LOAD_FACTOR_DEN
-        > intern->slot_capacity * INTERN_LOAD_FACTOR_NUM) {
-        if (intern_resize(intern) != 0)
-            return -1; /* resize failed but entry is already stored */
-    }
 
     return (int64_t)new_id;
 }

--- a/wirelog/passes/subsumption.c
+++ b/wirelog/passes/subsumption.c
@@ -113,8 +113,10 @@ mark_subsumed_rules(struct wirelog_program *prog)
 static uint32_t
 compact_marked_rules(struct wirelog_program *prog)
 {
-    if (!prog || prog->rule_count == 0)
-        return prog->rule_count;
+    if (!prog)
+        return 0;
+    if (prog->rule_count == 0)
+        return 0;
 
     uint32_t write_idx = 0;
 
@@ -136,7 +138,7 @@ compact_marked_rules(struct wirelog_program *prog)
 
 int
 wl_subsumption_apply(struct wirelog_program *prog,
-                     wl_subsumption_stats_t *stats)
+    wl_subsumption_stats_t *stats)
 {
     if (!prog)
         return -2;


### PR DESCRIPTION
## Summary

Fixes #634.

This cleans up the current LLVM 22 clang-tidy findings in the touched `wirelog/**` paths without relaxing the lint gate.

Changes:
- remove duplicate affected-frontier declarations from `columnar/internal.h`
- make the column-major `int64_t **` frees explicit at the `void *` boundary
- return the x86 CRC32 hardware bit as a boolean `int`
- resolve watch-mode relation schemas after parsing the relation name
- check the second file seek in `wl_read_file()` instead of using unchecked `rewind()`
- avoid null program access in subsumption compaction
- guard intern-table capacity growth and resize before insertion
- add a watch-mode string-input regression test

## Validation

- `clang-tidy` on changed source/test files using a reduced compile DB: no user-code warning/error lines
- `meson test -C builddir-tidy wirelog:intern wirelog:cli wirelog:cli_watch wirelog:crc32_ethernet wirelog:crc32_castagnoli wirelog:crc32_hw_equivalence wirelog:option2_doop wirelog:option2_cse wirelog:fusion --print-errorlogs`
- `ninja -C builddir-tidy && meson test -C builddir-tidy --print-errorlogs`
  - 198 passed, 7 skipped, 0 failed

## Notes

The `wl_read_file()` second-seek failure branch is defensive and hard to exercise portably through the path-only API, so it is covered by clang-tidy plus existing file-read tests rather than a fault-injection test.
