### PR TITLE
Run non-blocking CodeQL in PR CI

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,6 +4,7 @@ queries:
   - uses: security-and-quality
 
 paths:
+  - .github/workflows
   - wirelog
   - tests
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,10 +7,13 @@ name: CI PR
 # Phase 2 (Build):       Linux (GCC + Clang) + macOS (Clang), fail-fast
 # Phase 3 (Sanitizers):  ASan/UBSan + TSan, runs after lint
 #
-# Execution order: lint + CodeQL -> build + sanitizers
+# Execution order on PR: lint + CodeQL -> build + sanitizers
+# Execution order on main push: CodeQL only
 
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 permissions:
@@ -24,6 +27,7 @@ jobs:
   # editorconfig -> uncrustify -> clang-tidy 22 (sequential, hard gates)
   # ==========================================================================
   lint:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/lint-pr.yml
 
   # ==========================================================================
@@ -68,6 +72,7 @@ jobs:
   # Excludes: subprojects/**, build/**
   # ==========================================================================
   build:
+    if: github.event_name == 'pull_request'
     name: Build / ${{ matrix.os }} / ${{ matrix.compiler }}
     needs: [lint]
     runs-on: ${{ matrix.os }}
@@ -188,6 +193,7 @@ jobs:
   # Linux: GCC + Clang; macOS: Clang
   # ==========================================================================
   sanitizer:
+    if: github.event_name == 'pull_request'
     name: Sanitizers / ${{ matrix.os }} / ${{ matrix.compiler }}
     needs: [lint]
     runs-on: ${{ matrix.os }}
@@ -254,6 +260,7 @@ jobs:
   # (thrd_create, mtx_lock) are uninstrumented and cause false SEGV.
   # ==========================================================================
   tsan:
+    if: github.event_name == 'pull_request'
     name: TSan / ubuntu-latest / gcc
     needs: [lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,18 +2,21 @@ name: CI PR
 
 # PR-specific CI workflow with 3-phase validation.
 #
-# Phase 1 (Lint):    lint-pr.yml — editorconfig -> uncrustify -> clang-tidy
-# Phase 2 (Build):   Linux (GCC + Clang) + macOS (Clang), fail-fast
-# Phase 3 (Sanitizers): ASan/UBSan + TSan, runs after lint
+# Phase 1 (Lint):        lint-pr.yml — editorconfig -> uncrustify -> clang-tidy
+# Phase 1b (CodeQL):     non-blocking security-and-quality analysis
+# Phase 2 (Build):       Linux (GCC + Clang) + macOS (Clang), fail-fast
+# Phase 3 (Sanitizers):  ASan/UBSan + TSan, runs after lint
 #
-# Execution order: lint -> build + sanitizers
+# Execution order: lint + CodeQL -> build + sanitizers
 
 on:
   pull_request:
     branches: [main]
 
 permissions:
+  actions: read
   contents: read
+  security-events: write
 
 jobs:
   # ==========================================================================
@@ -22,6 +25,40 @@ jobs:
   # ==========================================================================
   lint:
     uses: ./.github/workflows/lint-pr.yml
+
+  # ==========================================================================
+  # Phase 1b: CodeQL security-and-quality analysis
+  # Runs in parallel with lint and stays non-blocking while the alert baseline
+  # is cleaned up. C/C++ uses build-free analysis to keep PR latency bounded.
+  # ==========================================================================
+  codeql:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
 
   # ==========================================================================
   # Phase 2: Build & Test matrix

--- a/.github/workflows/lint-main.yml
+++ b/.github/workflows/lint-main.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload tidy results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tidy-results-main
           path: tidy-results.txt

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload tidy results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tidy-results-pr
           path: tidy-results.txt


### PR DESCRIPTION
## Summary

- add a non-blocking CodeQL job to PR CI
- run CodeQL in parallel with the existing lint gate
- run the same CodeQL workflow on `main` pushes so default-branch code scanning alerts appear on the Security tab
- use build-free C/C++ analysis to keep PR latency bounded
- include GitHub Actions workflow files in the CodeQL analysis paths
- update `actions/upload-artifact` from v4 to v7 for Node.js 24 compatibility

## Behavior

The CodeQL job has `continue-on-error: true`, so it surfaces security-and-quality findings without directly blocking PR CI while the existing alert baseline is cleaned up. Build and sanitizer jobs still depend only on the lint gate. On `main` pushes, PR-only build/lint/sanitizer jobs are skipped and CodeQL runs to feed default-branch code scanning.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/ci-pr.yml .github/workflows/lint-pr.yml .github/workflows/lint-main.yml .github/codeql/codeql-config.yml`\n\n## Notes\n\nThe CodeQL file coverage notice is informational for PRs. We are leaving the new default in place because it improves PR analysis performance; non-PR analyses still compute file coverage. If repository rulesets or code scanning merge protection are configured to block on CodeQL alerts, those settings must remain non-blocking during this rollout.