### PR TITLE
Support compound column declarations

### DIFF
--- a/docs/COMPOUND_TERMS.md
+++ b/docs/COMPOUND_TERMS.md
@@ -170,11 +170,13 @@ In rule bodies, compound terms appear with functor-application syntax:
 head(...) :- rel(x, f(a, b), y), ...
 ```
 
-The pattern `f(a, b)` in a body literal:
-- Matches any row whose compound column has functor `f` and arity 2.
-- Binds variables `a` and `b` to the compound's arguments.
-- Fails to match rows where the compound column holds a different functor or
-  the null handle.
+For `inline` compound columns, the pattern `f(a, b)` in a body literal:
+- Matches rows whose declared compound column has functor `f` and arity 2.
+- Binds variables `a` and `b` to the inline physical argument columns.
+- Fails to match rows when the declared functor or arity differs.
+
+Side-relation compound declarations are parsed and exposed in schema metadata,
+but side body-argument binding is not yet lowered into a side-relation join.
 
 ### Example: projecting a compound argument
 
@@ -188,11 +190,24 @@ x_values(id, x) :- event(id, point(x, _)).
 ### Example: filtering on a compound field
 
 ```
-.decl item(key: int64, label: tag/2)
+.decl item(key: int64, label: tag/2 inline)
 .decl hot_items(key: int64)
 
 hot_items(key) :- item(key, tag(category, priority)), priority > 10.
 ```
+
+### Current limitation: side-relation body binding
+
+Side declarations are accepted:
+
+```
+.decl event(id: int64, meta: metadata/4)
+.decl event_side(id: int64, meta: metadata/4 side)
+```
+
+The public execution path currently binds compound body variables for inline
+columns only. Support for lowering side patterns through
+`__compound_<functor>_<arity>` side-relation joins is tracked separately.
 
 ### Parser limitation: compound terms in rule heads
 
@@ -284,21 +299,6 @@ When in doubt, omit the hint. The default (`side`) is always correct.
 
 sum_rel(id, x + y) :- pair_rel(id, pair(x, y)).
 ```
-
-### Side-relation compound with filtering
-
-```
-.decl event(id: int64, meta: metadata/4)
-.decl high_risk(id: int64, tenant: int64)
-.output high_risk
-
-high_risk(id, tenant) :-
-    event(id, metadata(tenant, ts, loc, risk)),
-    risk > 100.
-```
-
-The engine creates `__compound_metadata_4` automatically. No `.decl` for the
-side relation is needed.
 
 ### Nested compound (side tier)
 

--- a/docs/COMPOUND_TERMS.md
+++ b/docs/COMPOUND_TERMS.md
@@ -85,15 +85,16 @@ Declare a compound column using the type `functor/arity` in a `.decl` statement:
 The inline tier stores compound arguments as additional physical columns
 appended directly to the main relation.
 
-**Limits** (enforced in IR lowering, `wirelog/columnar/internal.h`):
+**Limits** (enforced when parsing declarations and applying columnar schemas):
 
 | Constant                     | Value | Meaning                                   |
 |------------------------------|-------|-------------------------------------------|
 | `WL_COMPOUND_INLINE_MAX_ARITY` | 4   | Maximum number of compound arguments      |
 | `WL_COMPOUND_INLINE_MAX_DEPTH` | 1   | Maximum nesting depth for inline compounds|
 
-A compound declared with `functor/N inline` where `N > 4` or where it is
-nested inside another compound (depth > 1) is rejected at schema-apply time.
+A compound declared with `functor/N inline` where `N > 4` is rejected by the
+public parser. Inline compounds nested inside another compound (depth > 1) are
+rejected at schema-apply time.
 
 **Physical layout example** — relation `edge(src: int64, lbl: pair/2 inline, dst: int64)`:
 
@@ -103,8 +104,8 @@ Logical columns:   [ src ] [  lbl/2   ]              [ dst ]
 ```
 
 The compound occupies two consecutive physical slots starting at
-`inline_physical_offset`. The `compound_arity_map` array records the arity of
-each logical column (0 for scalars, N for inline compounds).
+`inline_physical_offset`. The `compound_arity_map` array records the physical
+width of each logical column (1 for scalars, N for inline compounds).
 
 ### Side-relation tier
 
@@ -248,14 +249,12 @@ For a nested compound like `scope(metadata(t, ts, loc, risk))`:
    Returns `handle_scope`.
 3. Main relation column: holds `handle_scope`.
 
-Rule body matching follows the same nesting:
+Nested side-tier storage metadata follows the same nesting. Rule-body binding
+for nested side terms is not lowered yet:
 
 ```
 .decl record(id: int64, scope_col: scope/1)
-.decl result(id: int64, tenant: int64, location: int64)
-
-result(id, t, loc) :-
-    record(id, scope(metadata(t, ts, loc, risk))).
+.decl record(id: int64, scope_col: scope/1)
 ```
 
 ---
@@ -281,7 +280,7 @@ When in doubt, omit the hint. The default (`side`) is always correct.
 |------------------------------------------|-------------------------------------------------------|
 | `f()` — arity zero                       | Parse error: "compound term requires at least one argument" |
 | Nesting > 64 levels                      | Parse error: "compound term nesting too deep"         |
-| `inline` hint with arity > 4            | Schema-apply error; `WL_LOG=COMPOUND:2` emits `error=arity_overflow` |
+| `inline` hint with arity > 4            | Parse error |
 | `inline` hint with depth > 1            | Schema-apply error; `WL_LOG=COMPOUND:2` emits `error=depth_overflow` |
 | Handle from session A used in session B  | `arena_lookup` returns NULL (session seed mismatch)   |
 | Handle after arena saturation (epoch 4095)| `arena_alloc` returns `WL_COMPOUND_HANDLE_NULL`      |
@@ -300,18 +299,14 @@ When in doubt, omit the hint. The default (`side`) is always correct.
 sum_rel(id, x + y) :- pair_rel(id, pair(x, y)).
 ```
 
-### Nested compound (side tier)
+### Nested compound declaration (side tier)
 
 ```
 .decl message(msg_id: int64, envelope: envelope/2)
-.decl trusted_messages(msg_id: int64, sender: int64)
-.output trusted_messages
-
-trusted_messages(msg_id, sender) :-
-    message(msg_id, envelope(header(sender, ts), body_hash)).
 ```
 
-Side relations created: `__compound_header_2`, `__compound_envelope_2`.
+The declaration is accepted and exposed in schema metadata. Binding nested side
+arguments in rule bodies requires the future side-relation lowering path.
 
 ---
 

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -175,6 +175,9 @@ Supported column types:
 - `int64` -- 64-bit signed integer
 - `string` -- variable-length string
 - `symbol` -- interned symbol (string stored as integer ID)
+- `functor/arity` -- compound term handle stored in a 64-bit column
+- `functor/arity side` -- explicit side-relation compound storage
+- `functor/arity inline` -- inline compound storage, limited to arity 4
 
 ---
 

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -223,6 +223,89 @@ test_parse_decl_three_attrs(void)
     PASS();
 }
 
+static void
+test_parse_decl_compound_types(void)
+{
+    TEST(".decl with compound column types");
+    PARSE(".decl Event(id: int64, payload: metadata/4, "
+        "inline_payload: metadata/4 inline, side_payload: metadata/4 side)");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *decl = child(program, 0);
+    if (decl->child_count != 4) {
+        CLEANUP();
+        FAIL("expected 4 params");
+        return;
+    }
+
+    const char *expected[] = {
+        "int64", "metadata/4", "metadata/4 inline", "metadata/4 side"
+    };
+    for (uint32_t i = 0; i < 4; i++) {
+        const wl_parser_ast_node_t *param = child(decl, i);
+        if (!param || !param->type_name
+            || strcmp(param->type_name, expected[i]) != 0) {
+            CLEANUP();
+            FAIL("compound type_name was not normalized correctly");
+            return;
+        }
+    }
+
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_decl_compound_rejects_zero_arity(void)
+{
+    TEST("error: compound declaration rejects zero arity");
+    PARSE(".decl Event(payload: metadata/0)");
+    if (program != NULL) {
+        CLEANUP();
+        FAIL("expected parse failure");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_decl_compound_rejects_bad_modifier(void)
+{
+    TEST("error: compound declaration rejects bad modifier");
+    PARSE(".decl Event(payload: metadata/4 packed)");
+    if (program != NULL) {
+        CLEANUP();
+        FAIL("expected parse failure");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_decl_compound_rejects_glued_modifier(void)
+{
+    TEST("error: compound declaration rejects glued modifier");
+    PARSE(".decl Event(payload: metadata/4inline)");
+    if (program != NULL) {
+        CLEANUP();
+        FAIL("expected parse failure");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_decl_compound_rejects_inline_overflow(void)
+{
+    TEST("error: inline compound declaration rejects arity > 4");
+    PARSE(".decl Event(payload: metadata/5 inline)");
+    if (program != NULL) {
+        CLEANUP();
+        FAIL("expected parse failure");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* Parser: Input/Output/PrintSize Directives                                */
 /* ======================================================================== */
@@ -1772,6 +1855,11 @@ main(void)
     test_parse_decl_string_type();
     test_parse_decl_empty_params();
     test_parse_decl_three_attrs();
+    test_parse_decl_compound_types();
+    test_parse_decl_compound_rejects_zero_arity();
+    test_parse_decl_compound_rejects_bad_modifier();
+    test_parse_decl_compound_rejects_glued_modifier();
+    test_parse_decl_compound_rejects_inline_overflow();
 
     printf("\n--- Directives ---\n");
     test_parse_input_directive();

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -143,6 +143,65 @@ test_decl_single_relation(void)
 }
 
 static void
+test_decl_compound_column_metadata(void)
+{
+    TEST("Compound declarations populate relation metadata");
+
+    struct wirelog_program *prog
+        = make_program(".decl Event(id: int64, payload: metadata/4, "
+            "inline_payload: metadata/4 inline, "
+            "side_payload: metadata/2 side)\n");
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    const wl_ir_relation_info_t *rel = &prog->relations[0];
+    if (rel->column_count != 4) {
+        wl_ir_program_free(prog);
+        FAIL("expected 4 columns");
+        return;
+    }
+
+    int64_t metadata_id = wl_intern_get(prog->intern, "metadata");
+    if (metadata_id < 0) {
+        wl_ir_program_free(prog);
+        FAIL("metadata functor was not interned");
+        return;
+    }
+
+    if (rel->columns[1].type != WIRELOG_TYPE_INT64
+        || rel->columns[1].compound_kind != WIRELOG_COMPOUND_KIND_SIDE
+        || rel->columns[1].compound_functor_id != (uint32_t)metadata_id
+        || rel->columns[1].compound_arity != 4) {
+        wl_ir_program_free(prog);
+        FAIL("default side compound metadata is incorrect");
+        return;
+    }
+
+    if (rel->columns[2].type != WIRELOG_TYPE_INT64
+        || rel->columns[2].compound_kind != WIRELOG_COMPOUND_KIND_INLINE
+        || rel->columns[2].compound_functor_id != (uint32_t)metadata_id
+        || rel->columns[2].compound_arity != 4
+        || rel->columns[2].compound_inline_col_offset != 2) {
+        wl_ir_program_free(prog);
+        FAIL("inline compound metadata is incorrect");
+        return;
+    }
+
+    if (rel->columns[3].compound_kind != WIRELOG_COMPOUND_KIND_SIDE
+        || rel->columns[3].compound_arity != 2
+        || rel->columns[3].compound_inline_col_offset != 0) {
+        wl_ir_program_free(prog);
+        FAIL("explicit side compound metadata is incorrect");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+static void
 test_input_directive(void)
 {
     TEST("Parse .input marks relation has_input");
@@ -1412,6 +1471,47 @@ test_compound_inline_annotation(void)
 }
 
 static void
+test_compound_inline_annotation_from_declaration(void)
+{
+    TEST("INLINE compound declaration annotates matching body pattern");
+
+    struct wirelog_program *prog
+        = make_program(".decl pred(id: int32, payload: f/1 inline)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- pred(id, f(x)).\n");
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    if (wl_ir_program_convert_rules(prog, prog->ast) != 0) {
+        wl_ir_program_free(prog);
+        FAIL("convert_rules failed");
+        return;
+    }
+
+    const wirelog_ir_node_t *leaf
+        = find_relation_leaf(prog->rules[0].ir_root, "pred");
+    if (!leaf || leaf->type != WIRELOG_IR_COMPOUND_INLINE) {
+        wl_ir_program_free(prog);
+        FAIL("leaf type should be COMPOUND_INLINE");
+        return;
+    }
+
+    int64_t expected_fid = wl_intern_get(prog->intern, "f");
+    if (leaf->compound_inline.functor_id != (uint32_t)expected_fid
+        || leaf->compound_inline.arity != 1
+        || leaf->compound_inline.inline_col_offset != 1) {
+        wl_ir_program_free(prog);
+        FAIL("declared compound metadata incorrect on annotated leaf");
+        return;
+    }
+
+    wl_ir_program_free(prog);
+    PASS();
+}
+
+static void
 test_compound_side_annotation(void)
 {
     TEST("SIDE compound: scan->type becomes COMPOUND_SIDE with metadata");
@@ -2145,6 +2245,40 @@ test_api_get_schema(void)
 }
 
 static void
+test_api_get_schema_compound_columns(void)
+{
+    TEST("wirelog_program_get_schema exposes compound column metadata");
+
+    wirelog_program_t *prog = wirelog_parse_string(
+        ".decl Event(id: int64, payload: metadata/4 inline)\n", NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    const wirelog_schema_t *schema
+        = wirelog_program_get_schema(prog, "Event");
+    if (!schema || schema->column_count != 2) {
+        wirelog_program_free(prog);
+        FAIL("schema for Event should have 2 columns");
+        return;
+    }
+
+    const wirelog_column_t *payload = &schema->columns[1];
+    if (payload->type != WIRELOG_TYPE_INT64
+        || payload->compound_kind != WIRELOG_COMPOUND_KIND_INLINE
+        || payload->compound_arity != 4
+        || payload->compound_inline_col_offset != 1) {
+        wirelog_program_free(prog);
+        FAIL("payload compound metadata is incorrect");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
 test_api_get_schema_null(void)
 {
     TEST("wirelog_program_get_schema(nonexistent) returns NULL");
@@ -2820,6 +2954,7 @@ main(void)
 
     /* Metadata collection */
     test_decl_single_relation();
+    test_decl_compound_column_metadata();
     test_input_directive();
     test_input_directive_param_names_values();
     test_input_io_scheme_present();
@@ -2855,6 +2990,7 @@ main(void)
 
     /* Phase 2B: compound column IR lowering (Issue #531/#539) */
     test_compound_inline_annotation();
+    test_compound_inline_annotation_from_declaration();
     test_compound_side_annotation();
     test_compound_annotation_not_wrapped();
     test_compound_mixed_columns();
@@ -2897,6 +3033,7 @@ main(void)
     test_api_parse_string_error();
     test_api_get_rule_count();
     test_api_get_schema();
+    test_api_get_schema_compound_columns();
     test_api_get_schema_null();
     test_api_get_stratum_count();
     test_api_get_stratum();

--- a/tests/test_wl_easy.c
+++ b/tests/test_wl_easy.c
@@ -516,6 +516,220 @@ test_insert_step_delta(void)
 }
 
 static void
+test_inline_compound_body_binding(void)
+{
+    TEST("inline compound body pattern binds public Datalog variables");
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
+    int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
+    if (wl_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
+        || wl_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t hot;
+    memset(&hot, 0, sizeof(hot));
+    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    wl_easy_close(s);
+
+    if (hot.count != 1 || strcmp(hot.relations[0], "hot") != 0
+        || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
+        FAIL("expected only hot(7)");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_inline_compound_body_join_binding(void)
+{
+    TEST("inline compound body variables participate in joins");
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl threshold(risk: int64)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)), "
+        "threshold(Risk).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t matched_row[5] = { 7, 1, 2, 3, 90 };
+    int64_t unmatched_row[5] = { 8, 1, 2, 3, 40 };
+    int64_t threshold_row[1] = { 90 };
+    if (wl_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
+        || wl_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK
+        || wl_easy_insert(s, "threshold", threshold_row, 1) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t hot;
+    memset(&hot, 0, sizeof(hot));
+    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    wl_easy_close(s);
+
+    if (hot.count != 1 || strcmp(hot.relations[0], "hot") != 0
+        || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
+        FAIL("expected join to derive only hot(7)");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_inline_compound_functor_mismatch_is_empty(void)
+{
+    TEST("inline compound functor mismatch does not match");
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl bad(id: int64)\n"
+        "bad(ID) :- event(ID, other(Level, Ts, Host, Risk)).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t row[5] = { 7, 1, 2, 3, 90 };
+    if (wl_easy_insert(s, "event", row, 5) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t bad;
+    memset(&bad, 0, sizeof(bad));
+    if (wl_easy_snapshot(s, "bad", collect_tuple, &bad) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    wl_easy_close(s);
+
+    if (bad.count != 0) {
+        FAIL("mismatched functor should derive no rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_inline_compound_constant_child_filters(void)
+{
+    TEST("inline compound constant child filters rows");
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(_, _, _, 90)).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
+    int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
+    if (wl_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
+        || wl_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t hot;
+    memset(&hot, 0, sizeof(hot));
+    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    wl_easy_close(s);
+
+    if (hot.count != 1 || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
+        FAIL("expected only row with constant child value 90");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_inline_compound_duplicate_child_variables_filter(void)
+{
+    TEST("inline compound duplicate child variables filter rows");
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl same(id: int64)\n"
+        "same(ID) :- event(ID, metadata(X, X, _, _)).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t matched_row[5] = { 7, 4, 4, 3, 90 };
+    int64_t unmatched_row[5] = { 8, 1, 2, 3, 90 };
+    if (wl_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
+        || wl_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t same;
+    memset(&same, 0, sizeof(same));
+    if (wl_easy_snapshot(s, "same", collect_tuple, &same) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    wl_easy_close(s);
+
+    if (same.count != 1 || same.ncols[0] != 1 || same.rows[0][0] != 7) {
+        FAIL("expected only row with equal duplicate child variables");
+        return;
+    }
+    PASS();
+}
+
+static void
 test_insert_sym_variadic(void)
 {
     TEST("insert_sym variadic helper");
@@ -895,6 +1109,11 @@ main(void)
     test_num_workers_explicit_four();
     test_intern_returns_same_id();
     test_insert_step_delta();
+    test_inline_compound_body_binding();
+    test_inline_compound_body_join_binding();
+    test_inline_compound_functor_mismatch_is_empty();
+    test_inline_compound_constant_child_filters();
+    test_inline_compound_duplicate_child_variables_filter();
     test_insert_sym_variadic();
     test_remove_sym();
     test_snapshot_filter();

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #define INITIAL_CAPACITY 8
+#define WL_IR_COMPOUND_INLINE_MAX_ARITY 4u
 
 /* ======================================================================== */
 /* Column Type Mapping                                                      */
@@ -48,6 +49,9 @@ type_name_to_column_type(const char *type_name)
         return WIRELOG_TYPE_STRING;
     if (strcmp(type_name, "bool") == 0)
         return WIRELOG_TYPE_BOOL;
+
+    if (strchr(type_name, '/'))
+        return WIRELOG_TYPE_INT64;
 
     /* Default to int32 for unknown types */
     return WIRELOG_TYPE_INT32;
@@ -88,6 +92,9 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern)
 
     /* Extract functor name (everything before '/') */
     size_t functor_len = slash - type_name;
+    if (functor_len == 0)
+        return result;
+
     char *functor_name = (char *)malloc(functor_len + 1);
     if (!functor_name)
         return result;
@@ -100,33 +107,43 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern)
     char *arity_end = NULL;
     long arity_val = strtol(arity_str, &arity_end, 10);
 
-    if (arity_end == arity_str || arity_val < 0 || arity_val > UINT32_MAX) {
+    if (arity_end == arity_str || arity_val <= 0 || arity_val > UINT32_MAX) {
         free(functor_name);
         return result; /* Invalid arity */
     }
-
-    result.arity = (uint32_t)arity_val;
-
-    /* Intern the functor name to get ID (default: side-relation for now) */
-    int64_t functor_id = wl_intern_put(intern, functor_name);
-    if (functor_id < 0) {
-        free(functor_name);
-        return result; /* Intern failed */
-    }
-    result.functor_id = (uint32_t)functor_id;
-    result.kind = WIRELOG_COMPOUND_KIND_SIDE; /* Default to side-relation */
 
     /* Check for kind modifier (inline/side) after arity */
     char *kind_str = arity_end;
     while (*kind_str && isspace((unsigned char)*kind_str))
         kind_str++;
 
-    if (strncmp(kind_str, "inline", 6) == 0
-        && (kind_str[6] == '\0' || isspace((unsigned char)kind_str[6])))
-        result.kind = WIRELOG_COMPOUND_KIND_INLINE;
-    else if (strncmp(kind_str, "side", 4) == 0
-        && (kind_str[4] == '\0' || isspace((unsigned char)kind_str[4])))
-        result.kind = WIRELOG_COMPOUND_KIND_SIDE;
+    wirelog_compound_kind_t kind = WIRELOG_COMPOUND_KIND_SIDE;
+    if (*kind_str != '\0') {
+        if (strcmp(kind_str, "inline") == 0) {
+            kind = WIRELOG_COMPOUND_KIND_INLINE;
+        } else if (strcmp(kind_str, "side") == 0) {
+            kind = WIRELOG_COMPOUND_KIND_SIDE;
+        } else {
+            free(functor_name);
+            return result;
+        }
+    }
+
+    if (kind == WIRELOG_COMPOUND_KIND_INLINE
+        && (uint32_t)arity_val > WL_IR_COMPOUND_INLINE_MAX_ARITY) {
+        free(functor_name);
+        return result;
+    }
+
+    /* Intern the functor name to get ID (default: side-relation). */
+    int64_t functor_id = wl_intern_put(intern, functor_name);
+    if (functor_id < 0) {
+        free(functor_name);
+        return result; /* Intern failed */
+    }
+    result.functor_id = (uint32_t)functor_id;
+    result.arity = (uint32_t)arity_val;
+    result.kind = kind;
 
     free(functor_name);
     return result;
@@ -413,6 +430,18 @@ collect_decl(struct wirelog_program *prog,
 
                 idx++;
             }
+        }
+    }
+
+    uint32_t physical_offset = 0;
+    for (uint32_t i = 0; i < rel->column_count; i++) {
+        wirelog_column_t *col = &rel->columns[i];
+        if (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE) {
+            col->compound_inline_col_offset = physical_offset;
+            physical_offset += col->compound_arity;
+        } else {
+            col->compound_inline_col_offset = 0;
+            physical_offset++;
         }
     }
 
@@ -922,6 +951,109 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
 
 /* ---- Scan Building with Intra-atom Filters ---- */
 
+static wl_ir_relation_info_t *
+find_relation_info(const struct wirelog_program *prog, const char *name)
+{
+    if (!prog || !name)
+        return NULL;
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (prog->relations[i].name
+            && strcmp(prog->relations[i].name, name) == 0)
+            return &prog->relations[i];
+    }
+    return NULL;
+}
+
+static bool
+compound_arg_matches_decl(const wl_parser_ast_node_t *arg,
+    const wirelog_column_t *col)
+{
+    if (!arg || !col || arg->type != WL_PARSER_AST_NODE_COMPOUND_TERM)
+        return false;
+    if (col->compound_kind == WIRELOG_COMPOUND_KIND_NONE)
+        return false;
+    if (!arg->name || arg->child_count != col->compound_arity)
+        return false;
+    return true;
+}
+
+static bool
+compound_arg_functor_matches(const wl_parser_ast_node_t *arg,
+    const wirelog_column_t *col, const struct wirelog_program *prog)
+{
+    if (!compound_arg_matches_decl(arg, col) || !prog || !prog->intern)
+        return false;
+    int64_t functor_id = wl_intern_get(prog->intern, arg->name);
+    return functor_id >= 0 && (uint32_t)functor_id == col->compound_functor_id;
+}
+
+static uint32_t
+atom_physical_column_count(const wl_parser_ast_node_t *atom,
+    const wl_ir_relation_info_t *rel_info, const struct wirelog_program *prog)
+{
+    uint32_t count = atom ? atom->child_count : 0;
+    if (!atom || !rel_info || !rel_info->columns)
+        return count;
+
+    for (uint32_t i = 0; i < atom->child_count && i < rel_info->column_count;
+        i++) {
+        const wl_parser_ast_node_t *arg = atom->children[i];
+        const wirelog_column_t *col = &rel_info->columns[i];
+        if (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE
+            && compound_arg_functor_matches(arg, col, prog)
+            && col->compound_arity > 0) {
+            count += col->compound_arity - 1;
+        }
+    }
+    return count;
+}
+
+static wirelog_ir_node_t *
+wrap_false_filter(wirelog_ir_node_t *child)
+{
+    wirelog_ir_node_t *filter = wl_ir_node_create(WIRELOG_IR_FILTER);
+    if (!filter)
+        return child;
+
+    wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_BOOL);
+    if (!expr) {
+        wl_ir_node_free(filter);
+        return child;
+    }
+    expr->bool_value = false;
+    filter->filter_expr = expr;
+    wl_ir_node_add_child(filter, child);
+    return filter;
+}
+
+static wirelog_ir_node_t *
+wrap_column_cmp_filter(wirelog_ir_node_t *child, uint32_t left_col,
+    const wl_ir_expr_t *right_expr)
+{
+    wirelog_ir_node_t *filter = wl_ir_node_create(WIRELOG_IR_FILTER);
+    if (!filter)
+        return child;
+
+    wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
+    wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
+    if (!cmp || !lhs) {
+        wl_ir_expr_free(cmp);
+        wl_ir_expr_free(lhs);
+        wl_ir_node_free(filter);
+        return child;
+    }
+
+    cmp->cmp_op = WIRELOG_CMP_EQ;
+    char col[32];
+    snprintf(col, sizeof(col), "col%u", left_col);
+    lhs->var_name = strdup_safe(col);
+    wl_ir_expr_add_child(cmp, lhs);
+    wl_ir_expr_add_child(cmp, (wl_ir_expr_t *)right_expr);
+    filter->filter_expr = cmp;
+    wl_ir_node_add_child(filter, child);
+    return filter;
+}
+
 static wirelog_ir_node_t *
 build_atom_scan(const wl_parser_ast_node_t *atom,
     const struct wirelog_program *prog, char ***out_var_names,
@@ -960,28 +1092,59 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     wl_ir_node_set_relation(scan, atom->name);
 
     uint32_t arg_count = atom->child_count;
+    wl_ir_relation_info_t *rel_info = find_relation_info(prog, atom->name);
+    uint32_t physical_count
+        = atom_physical_column_count(atom, rel_info, prog);
     scan->column_names
-        = (char **)calloc(arg_count > 0 ? arg_count : 1, sizeof(char *));
-    scan->column_count = arg_count;
+        = (char **)calloc(physical_count > 0 ? physical_count : 1,
+            sizeof(char *));
+    scan->column_count = physical_count;
 
     char **var_names
-        = (char **)calloc(arg_count > 0 ? arg_count : 1, sizeof(char *));
-    if (!scan->column_names || !var_names) {
+        = (char **)calloc(physical_count > 0 ? physical_count : 1,
+            sizeof(char *));
+    const wl_parser_ast_node_t **physical_args
+        = (const wl_parser_ast_node_t **)calloc(
+            physical_count > 0 ? physical_count : 1,
+            sizeof(wl_parser_ast_node_t *));
+    if (!scan->column_names || !var_names || !physical_args) {
+        free(physical_args);
         free(var_names);
         wl_ir_node_free(scan);
         return NULL;
     }
 
     /* Collect column names from atom arguments */
+    uint32_t phys_idx = 0;
     for (uint32_t i = 0; i < arg_count; i++) {
         const wl_parser_ast_node_t *arg = atom->children[i];
         if (arg->type == WL_PARSER_AST_NODE_VARIABLE) {
-            scan->column_names[i] = strdup_safe(arg->name);
-            var_names[i] = strdup_safe(arg->name);
+            physical_args[phys_idx] = arg;
+            scan->column_names[phys_idx] = strdup_safe(arg->name);
+            var_names[phys_idx] = strdup_safe(arg->name);
+            phys_idx++;
+        } else if (rel_info && i < rel_info->column_count
+            && rel_info->columns[i].compound_kind
+            == WIRELOG_COMPOUND_KIND_INLINE
+            && compound_arg_functor_matches(arg, &rel_info->columns[i], prog)) {
+            for (uint32_t c = 0; c < arg->child_count; c++) {
+                const wl_parser_ast_node_t *child = arg->children[c];
+                physical_args[phys_idx] = child;
+                if (child->type == WL_PARSER_AST_NODE_VARIABLE) {
+                    scan->column_names[phys_idx] = strdup_safe(child->name);
+                    var_names[phys_idx] = strdup_safe(child->name);
+                } else {
+                    scan->column_names[phys_idx] = NULL;
+                    var_names[phys_idx] = NULL;
+                }
+                phys_idx++;
+            }
         } else {
             /* Wildcard, integer, string -> NULL (anonymous position) */
-            scan->column_names[i] = NULL;
-            var_names[i] = NULL;
+            physical_args[phys_idx] = arg;
+            scan->column_names[phys_idx] = NULL;
+            var_names[phys_idx] = NULL;
+            phys_idx++;
         }
     }
 
@@ -1002,16 +1165,8 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
      * column). Additional compound columns retain the same scan-leaf
      * shape; richer multi-column lowering is deferred to Phase 2C.
      */
+    bool compound_mismatch = false;
     if (prog && atom->name) {
-        wl_ir_relation_info_t *rel_info = NULL;
-        for (uint32_t i = 0; i < prog->relation_count; i++) {
-            if (prog->relations[i].name
-                && strcmp(prog->relations[i].name, atom->name) == 0) {
-                rel_info = &prog->relations[i];
-                break;
-            }
-        }
-
         if (rel_info && rel_info->columns) {
             for (uint32_t i = 0; i < arg_count && i < rel_info->column_count;
                 i++) {
@@ -1022,6 +1177,14 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                     continue;
                 if (col->compound_kind == WIRELOG_COMPOUND_KIND_NONE)
                     continue;
+                if (!compound_arg_functor_matches(arg, col, prog)) {
+                    compound_mismatch = true;
+                    WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+                        "compound pattern mismatch for relation=%s col=%u, "
+                        "forcing empty match",
+                        atom->name, i);
+                    break;
+                }
 
                 /* Validate compound_kind is a known annotatable value.
                  * Defensive: unknown kinds (from corrupt metadata) are
@@ -1077,11 +1240,14 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         }
     }
 
+    if (compound_mismatch)
+        result = wrap_false_filter(result);
+
     /* Step 1a: Intra-atom FILTER for duplicate variables */
-    for (uint32_t i = 0; i < arg_count; i++) {
+    for (uint32_t i = 0; i < physical_count; i++) {
         if (!var_names[i])
             continue;
-        for (uint32_t j = i + 1; j < arg_count; j++) {
+        for (uint32_t j = i + 1; j < physical_count; j++) {
             if (!var_names[j])
                 continue;
             if (strcmp(var_names[i], var_names[j]) == 0) {
@@ -1093,11 +1259,17 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                 if (cmp) {
                     cmp->cmp_op = WIRELOG_CMP_EQ;
                     wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                    if (lhs)
-                        lhs->var_name = strdup_safe(var_names[i]);
+                    if (lhs) {
+                        char col[32];
+                        snprintf(col, sizeof(col), "col%u", i);
+                        lhs->var_name = strdup_safe(col);
+                    }
                     wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                    if (rhs)
-                        rhs->var_name = strdup_safe(var_names[j]);
+                    if (rhs) {
+                        char col[32];
+                        snprintf(col, sizeof(col), "col%u", j);
+                        rhs->var_name = strdup_safe(col);
+                    }
                     wl_ir_expr_add_child(cmp, lhs);
                     wl_ir_expr_add_child(cmp, rhs);
                 }
@@ -1109,59 +1281,26 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     }
 
     /* Step 1b: Intra-atom FILTER for constants */
-    for (uint32_t i = 0; i < arg_count; i++) {
-        const wl_parser_ast_node_t *arg = atom->children[i];
+    for (uint32_t i = 0; i < physical_count; i++) {
+        const wl_parser_ast_node_t *arg = physical_args[i];
         if (arg->type == WL_PARSER_AST_NODE_INTEGER) {
-            wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-            if (!f)
-                continue;
-
-            wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
-            if (cmp) {
-                cmp->cmp_op = WIRELOG_CMP_EQ;
-                wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                if (lhs) {
-                    char col[32];
-                    snprintf(col, sizeof(col), "col%u", i);
-                    lhs->var_name = strdup_safe(col);
-                }
-                wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
-                if (rhs)
-                    rhs->int_value = arg->int_value;
-                wl_ir_expr_add_child(cmp, lhs);
-                wl_ir_expr_add_child(cmp, rhs);
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
+            if (rhs) {
+                rhs->int_value = arg->int_value;
+                result = wrap_column_cmp_filter(result, i, rhs);
             }
-            f->filter_expr = cmp;
-            wl_ir_node_add_child(f, result);
-            result = f;
         } else if (arg->type == WL_PARSER_AST_NODE_STRING) {
-            wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-            if (!f)
-                continue;
-
-            wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
-            if (cmp) {
-                cmp->cmp_op = WIRELOG_CMP_EQ;
-                wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                if (lhs) {
-                    char col[32];
-                    snprintf(col, sizeof(col), "col%u", i);
-                    lhs->var_name = strdup_safe(col);
-                }
-                wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
-                if (rhs)
-                    rhs->str_value = strdup_safe(arg->str_value);
-                wl_ir_expr_add_child(cmp, lhs);
-                wl_ir_expr_add_child(cmp, rhs);
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
+            if (rhs) {
+                rhs->str_value = strdup_safe(arg->str_value);
+                result = wrap_column_cmp_filter(result, i, rhs);
             }
-            f->filter_expr = cmp;
-            wl_ir_node_add_child(f, result);
-            result = f;
         }
     }
 
+    free(physical_args);
     *out_var_names = var_names;
-    *out_var_count = arg_count;
+    *out_var_count = physical_count;
     return result;
 }
 

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -35,9 +35,12 @@
 
 #include "parser.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define WL_PARSER_COMPOUND_INLINE_MAX_ARITY 4u
 
 /* ======================================================================== */
 /* Utility                                                                  */
@@ -151,6 +154,97 @@ token_to_str_value(const wl_parser_lexer_token_t *token)
         return s;
     }
     return (char *)calloc(1, 1);
+}
+
+static bool
+token_text_equals(const wl_parser_lexer_token_t *token, const char *text)
+{
+    size_t len = strlen(text);
+    return token->length == len && strncmp(token->start, text, len) == 0;
+}
+
+static char *
+parse_declaration_type(wl_parser_t *parser)
+{
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_INT32))
+        return strdup_safe("int32");
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_INT64))
+        return strdup_safe("int64");
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_STRING_TYPE))
+        return strdup_safe("string");
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_SYMBOL_TYPE))
+        return strdup_safe("symbol");
+
+    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
+        "expected type (int32, int64, string, symbol, or compound functor/arity)"))
+    {
+        return NULL;
+    }
+    char *functor = token_to_name(&parser->previous);
+    if (!functor)
+        return NULL;
+
+    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_SLASH,
+        "expected '/' in compound type")) {
+        free(functor);
+        return NULL;
+    }
+    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_INTEGER,
+        "expected compound arity after '/'")) {
+        free(functor);
+        return NULL;
+    }
+
+    int64_t arity_value = parser->previous.int_value;
+    if (arity_value <= 0 || arity_value > UINT32_MAX) {
+        parser_error(parser, "compound arity must be a positive uint32");
+        free(functor);
+        return NULL;
+    }
+
+    const char *modifier = NULL;
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_IDENT)) {
+        if (parser->previous.start + parser->previous.length
+            == parser->current.start) {
+            parser_error(parser,
+                "expected whitespace before compound modifier");
+            free(functor);
+            return NULL;
+        }
+        if (token_text_equals(&parser->current, "inline")) {
+            modifier = "inline";
+        } else if (token_text_equals(&parser->current, "side")) {
+            modifier = "side";
+        } else {
+            parser_error(parser,
+                "expected compound modifier 'inline' or 'side'");
+            free(functor);
+            return NULL;
+        }
+        parser_advance(parser);
+    }
+
+    if (modifier && strcmp(modifier, "inline") == 0
+        && (uint32_t)arity_value > WL_PARSER_COMPOUND_INLINE_MAX_ARITY) {
+        parser_error(parser, "inline compound arity exceeds maximum arity 4");
+        free(functor);
+        return NULL;
+    }
+
+    char arity_buf[32];
+    snprintf(arity_buf, sizeof(arity_buf), "%u", (uint32_t)arity_value);
+
+    size_t len = strlen(functor) + 1 + strlen(arity_buf)
+        + (modifier ? 1 + strlen(modifier) : 0);
+    char *type_name = (char *)malloc(len + 1);
+    if (!type_name) {
+        free(functor);
+        return NULL;
+    }
+    snprintf(type_name, len + 1, "%s/%s%s%s", functor, arity_buf,
+        modifier ? " " : "", modifier ? modifier : "");
+    free(functor);
+    return type_name;
 }
 
 /* ======================================================================== */
@@ -1327,19 +1421,8 @@ parse_declaration(wl_parser_t *parser)
                 return NULL;
             }
 
-            /* Type: int32, int64, string, or symbol */
-            const char *type_str = NULL;
-            if (parser_match(parser, WL_PARSER_LEXER_TOK_INT32)) {
-                type_str = "int32";
-            } else if (parser_match(parser, WL_PARSER_LEXER_TOK_INT64)) {
-                type_str = "int64";
-            } else if (parser_match(parser, WL_PARSER_LEXER_TOK_STRING_TYPE)) {
-                type_str = "string";
-            } else if (parser_match(parser, WL_PARSER_LEXER_TOK_SYMBOL_TYPE)) {
-                type_str = "symbol";
-            } else {
-                parser_error(parser,
-                    "expected type (int32, int64, string, or symbol)");
+            char *type_name = parse_declaration_type(parser);
+            if (!type_name) {
                 free(attr_name);
                 wl_parser_ast_node_free(decl);
                 return NULL;
@@ -1348,7 +1431,7 @@ parse_declaration(wl_parser_t *parser)
             wl_parser_ast_node_t *param = wl_parser_ast_node_create(
                 WL_PARSER_AST_NODE_TYPED_PARAM, attr_line, attr_col);
             param->name = attr_name;
-            param->type_name = strdup_safe(type_str);
+            param->type_name = type_name;
             wl_parser_ast_node_add_child(decl, param);
 
             if (!parser_match(parser, WL_PARSER_LEXER_TOK_COMMA))


### PR DESCRIPTION
## Summary
- Accept public compound column declaration types such as `functor/arity`, `functor/arity inline`, and `functor/arity side`
- Populate compound schema metadata and bind inline compound body arguments through parser, IR, and public wl_easy execution paths
- Document supported declaration syntax and the current side body-binding limitation

Closes #644

## Tests
- `meson test -C build parser program wl_easy --print-errorlogs`
- `meson test -C build --print-errorlogs`