### PR TITLE
Add daemon-style rotation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ For fine-grained control over plans, backends, or worker counts, use the `wl_ses
 | `10-recursive-under-update` | Transitive closure under insert/remove |
 | `11-time-evolution` | Per-epoch delta isolation |
 | `12-snapshot-vs-delta` | Snapshot vs streaming API comparison |
+| `13-daemon-style` | Long-running daemon rotation pattern |
 
 ## Build & Test
 

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -47,6 +47,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/progress.c',
   subdir_wirelog / 'columnar/rotation_standard.c',
   subdir_wirelog / 'columnar/rotation_pinned.c',
+  subdir_wirelog / 'columnar/compound_side.c',
   subdir_wirelog / 'util/lockfree_queue.c',
   subdir_wirelog / 'util/log.c',
   subdir_wirelog / 'util/log_emit.c',

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -20,14 +20,19 @@ The executable uses a public side compound declaration for event metadata:
 
 ```datalog
 .decl event(id: int64, tenant: symbol, risk: int64, payload: metadata/4 side)
+.decl pulse(id: int64)
 .decl hot_event(id: int64, tenant: symbol)
+pulse(ID) :- event(ID, _, _, _), ID < 0.
+pulse(ID) :- pulse(ID).
 hot_event(ID, Tenant) :- event(ID, Tenant, Risk, _), Risk > 80.
 ```
 
 The `risk` scalar drives the rule because side-compound body destructuring is a
 larger compiler feature tracked separately. The payload still uses the real
 session-local compound arena, so rotations are triggered by arena saturation
-rather than by a caller-owned event watermark.
+rather than by a caller-owned event watermark. The synthetic empty `pulse`
+recursion forces deterministic epoch advancement for the demo workload; it does
+not change the emitted `hot_event` results.
 The EDB log stores source-level event values rather than encoded Wirelog rows,
 so each fresh session re-interns symbols and rebuilds rows with its own public
 API state.
@@ -71,7 +76,8 @@ sequence:
 
 ```sh
 meson compile -C build daemon_style_demo
-./build/examples/13-daemon-style/daemon_style_demo
+WIRELOG_COMPOUND_MAX_EPOCHS=256 \
+./build/examples/13-daemon-style/daemon_style_demo --events 1000
 ```
 
 For a short deterministic smoke run:
@@ -111,8 +117,8 @@ The exact RSS value depends on platform and allocator state.
 ## What This Demonstrates
 
 - **Daemon lifecycle** -- facts arrive over time, replay is separated from live
-  callbacks, and each live `wl_easy_step` publishes only new deltas for that
-  epoch.
+  callback attachment, and the consumer keeps a monotonic output watermark so
+  repeated rows after rotation are idempotent.
 - **EDB ownership** -- the application owns the durable input log needed to
   reconstruct a fresh session.
 - **Rotation observability** -- `stderr` carries event count, EDB size, live

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -3,10 +3,10 @@
 ## Overview
 
 Long-running daemon processes keep ingesting facts after the initial batch.
-When those facts use compound terms, production callers need a way to rotate
-session-owned state before bounded arenas saturate. This example exercises the
-rotation lifecycle with an inline compound declaration and a deterministic
-caller-owned watermark.
+When those facts use compound terms, production callers need to rotate
+session-owned state after bounded arenas saturate. This example exercises the
+rotation lifecycle with a side compound declaration and the public
+`wirelog_easy_make_compound` saturation signal.
 
 This example shows the daemon pattern using only the installed public API:
 
@@ -16,34 +16,33 @@ This example shows the daemon pattern using only the installed public API:
 - rotate by closing the old session, opening a new one, and replaying the EDB
 - log operator-visible lifecycle data to `stderr`
 
-The executable uses a public inline compound declaration for the event
-metadata:
+The executable uses a public side compound declaration for event metadata:
 
 ```datalog
-.decl event(id: int64, tenant: symbol, payload: metadata/4 inline)
+.decl event(id: int64, tenant: symbol, risk: int64, payload: metadata/4 side)
 .decl hot_event(id: int64, tenant: symbol)
-hot_event(ID, Tenant) :-
-    event(ID, Tenant, metadata(Level, Ts, Host, Risk)), Risk > 80.
+hot_event(ID, Tenant) :- event(ID, Tenant, Risk, _), Risk > 80.
 ```
 
-That keeps the daemon lifecycle executable today while documenting the remaining
-API gap that #550 is meant to close: saturation-aware rotation.
+The `risk` scalar drives the rule because side-compound body destructuring is a
+larger compiler feature tracked separately. The payload still uses the real
+session-local compound arena, so rotations are triggered by arena saturation
+rather than by a caller-owned event watermark.
 The EDB log stores source-level event values rather than encoded Wirelog rows,
 so each fresh session re-interns symbols and rebuilds rows with its own public
 API state.
 
-## Current Public Pattern
+## Saturation Pattern
 
-The current public API does not expose a compound arena epoch, a saturation
-callback, or a session-rotation primitive. Because of that, this example uses a
-caller-owned watermark rather than internal headers:
+The public API returns `WIRELOG_ERR_COMPOUND_SATURATED` when a new side
+compound can no longer be allocated. The daemon handles that by replaying the
+durable EDB source log into a fresh session and retrying the current event:
 
 ```c
-if (events_since_rotation >= rotate_every) {
-    wl_easy_step(old);
-    wl_easy_close(old);
-    wl_easy_open(program, &fresh);
-    replay_edb(fresh, &edb);
+rc = wirelog_easy_make_compound(session, "metadata", 4, args, &payload);
+if (rc == WIRELOG_ERR_COMPOUND_SATURATED) {
+    rotate_session(&session, &edb);
+    rc = wirelog_easy_make_compound(session, "metadata", 4, args, &payload);
 }
 ```
 
@@ -55,27 +54,11 @@ already-known rows after rotation. The pattern is deliberately conservative and
 demonstrates the lifecycle shape without including internal headers such as
 `wirelog/columnar/internal.h`.
 
-## After #550
+## Remaining Engine Work
 
-With #550 Option A, the trigger can become an engine-owned epoch query:
-
-```diff
-- if (events_since_rotation >= rotate_every) {
-+ if (wl_session_compound_epoch(session) >= 3686) {
-      rotate_session(&session, &edb);
-  }
-```
-
-With #550 Option B, polling can disappear:
-
-```diff
-- if (wl_session_compound_epoch(session) >= 3686) {
--     rotate_session(&session, &edb);
-- }
-+ wl_session_set_compound_saturation_cb(session, on_saturation, &daemon);
-```
-
-With #550 Option C, the caller-owned EDB replay disappears:
+The example still keeps EDB ownership in application code. A future
+engine-owned rotation primitive could replace the manual close/open/replay
+sequence:
 
 ```diff
 - wl_easy_close(old);
@@ -94,8 +77,9 @@ meson compile -C build daemon_style_demo
 For a short deterministic smoke run:
 
 ```sh
+WIRELOG_COMPOUND_MAX_EPOCHS=64 \
 ./build/examples/13-daemon-style/daemon_style_demo \
-  --events 256 --rotate-every 64 --log-every 64
+  --events 256 --log-every 64
 ```
 
 Or use the wrapper:
@@ -106,22 +90,22 @@ examples/13-daemon-style/run.sh
 
 The wrapper defaults to a paced 10-second run. Override
 `WIRELOG_DAEMON_SECONDS`, `WIRELOG_DAEMON_EVENTS`,
-`WIRELOG_DAEMON_ROTATE_EVERY`, `WIRELOG_DAEMON_LOG_EVERY`, or
-`WIRELOG_DAEMON_SLEEP_MS` to shorten or lengthen it.
+`WIRELOG_DAEMON_LOG_EVERY`, `WIRELOG_DAEMON_SLEEP_MS`, or
+`WIRELOG_COMPOUND_MAX_EPOCHS` to shorten or lengthen it.
 
 ## Sample Trace
 
 The exact RSS value depends on platform and allocator state.
 
 ```text
-[daemon] t=0.01s events=64 edb=64 hot=12 rotations=0 rss_kb=4096
-[daemon] rotation request: events_since_rotation=64 watermark=64
-[daemon] t=0.03s events=128 edb=128 hot=25 rotations=1 rss_kb=4224
-[daemon] rotation request: events_since_rotation=64 watermark=64
-[daemon] t=0.04s events=192 edb=192 hot=38 rotations=2 rss_kb=4288
-[daemon] rotation request: events_since_rotation=64 watermark=64
-[daemon] t=0.05s events=256 edb=256 hot=51 rotations=3 rss_kb=4352
-[daemon] summary: events=256 edb=256 hot=51 rotations=3 rss_kb=4352
+[daemon] t=0.01s events=64 edb=64 hot=12 rotations=0 saturations=0 rss_kb=4096
+[daemon] rotation request: compound arena saturated event=65
+[daemon] t=0.03s events=128 edb=128 hot=25 rotations=1 saturations=1 rss_kb=4224
+[daemon] rotation request: compound arena saturated event=129
+[daemon] t=0.04s events=192 edb=192 hot=38 rotations=2 saturations=2 rss_kb=4288
+[daemon] rotation request: compound arena saturated event=193
+[daemon] t=0.05s events=256 edb=256 hot=51 rotations=3 saturations=3 rss_kb=4352
+[daemon] summary: events=256 edb=256 hot=51 rotations=3 saturations=3 rss_kb=4352
 ```
 
 ## What This Demonstrates
@@ -132,10 +116,10 @@ The exact RSS value depends on platform and allocator state.
 - **EDB ownership** -- the application owns the durable input log needed to
   reconstruct a fresh session.
 - **Rotation observability** -- `stderr` carries event count, EDB size, live
-  derived hot-event count, rotation count, and RSS where available.
-- **API gap** -- saturation-aware rotation cannot be driven directly from the
-  installed public surface today; #550 is the API that should remove that
-  workaround.
+  derived hot-event count, saturation count, rotation count, and RSS where
+  available.
+- **Compound-arena pressure** -- tests can set `WIRELOG_COMPOUND_MAX_EPOCHS`
+  to force fast deterministic saturation without internal headers.
 
 ## See Also
 

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -1,0 +1,145 @@
+# Example 13: Daemon-Style Session Rotation
+
+## Overview
+
+Long-running daemon processes keep ingesting facts after the initial batch.
+When those facts use compound terms, production callers need a way to rotate
+session-owned state before bounded arenas saturate. This example exercises the
+rotation lifecycle with an inline compound declaration and a deterministic
+caller-owned watermark.
+
+This example shows the daemon pattern using only the installed public API:
+
+- keep a caller-owned copy of long-lived EDB facts
+- stream new facts through `wl_easy_insert`
+- consume changes through `wl_easy_set_delta_cb` and `wl_easy_step`
+- rotate by closing the old session, opening a new one, and replaying the EDB
+- log operator-visible lifecycle data to `stderr`
+
+The executable uses a public inline compound declaration for the event
+metadata:
+
+```datalog
+.decl event(id: int64, tenant: symbol, payload: metadata/4 inline)
+.decl hot_event(id: int64, tenant: symbol)
+hot_event(ID, Tenant) :-
+    event(ID, Tenant, metadata(Level, Ts, Host, Risk)), Risk > 80.
+```
+
+That keeps the daemon lifecycle executable today while documenting the remaining
+API gap that #550 is meant to close: saturation-aware rotation.
+The EDB log stores source-level event values rather than encoded Wirelog rows,
+so each fresh session re-interns symbols and rebuilds rows with its own public
+API state.
+
+## Current Public Pattern
+
+The current public API does not expose a compound arena epoch, a saturation
+callback, or a session-rotation primitive. Because of that, this example uses a
+caller-owned watermark rather than internal headers:
+
+```c
+if (events_since_rotation >= rotate_every) {
+    wl_easy_step(old);
+    wl_easy_close(old);
+    wl_easy_open(program, &fresh);
+    replay_edb(fresh, &edb);
+}
+```
+
+Replay into the fresh session is intentionally separated from live delivery:
+the demo restores historical EDB facts before reattaching the live delta path,
+then keeps a monotonic `hot_event` id watermark in the consumer. That makes the
+downstream side effect idempotent even if a public delta step re-presents
+already-known rows after rotation. The pattern is deliberately conservative and
+demonstrates the lifecycle shape without including internal headers such as
+`wirelog/columnar/internal.h`.
+
+## After #550
+
+With #550 Option A, the trigger can become an engine-owned epoch query:
+
+```diff
+- if (events_since_rotation >= rotate_every) {
++ if (wl_session_compound_epoch(session) >= 3686) {
+      rotate_session(&session, &edb);
+  }
+```
+
+With #550 Option B, polling can disappear:
+
+```diff
+- if (wl_session_compound_epoch(session) >= 3686) {
+-     rotate_session(&session, &edb);
+- }
++ wl_session_set_compound_saturation_cb(session, on_saturation, &daemon);
+```
+
+With #550 Option C, the caller-owned EDB replay disappears:
+
+```diff
+- wl_easy_close(old);
+- wl_easy_open(program, &fresh);
+- replay_edb(fresh, &edb);
++ wl_session_rotate(session);
+```
+
+## Build & Run
+
+```sh
+meson compile -C build daemon_style_demo
+./build/examples/13-daemon-style/daemon_style_demo
+```
+
+For a short deterministic smoke run:
+
+```sh
+./build/examples/13-daemon-style/daemon_style_demo \
+  --events 256 --rotate-every 64 --log-every 64
+```
+
+Or use the wrapper:
+
+```sh
+examples/13-daemon-style/run.sh
+```
+
+The wrapper defaults to a paced 10-second run. Override
+`WIRELOG_DAEMON_SECONDS`, `WIRELOG_DAEMON_EVENTS`,
+`WIRELOG_DAEMON_ROTATE_EVERY`, `WIRELOG_DAEMON_LOG_EVERY`, or
+`WIRELOG_DAEMON_SLEEP_MS` to shorten or lengthen it.
+
+## Sample Trace
+
+The exact RSS value depends on platform and allocator state.
+
+```text
+[daemon] t=0.01s events=64 edb=64 hot=12 rotations=0 rss_kb=4096
+[daemon] rotation request: events_since_rotation=64 watermark=64
+[daemon] t=0.03s events=128 edb=128 hot=25 rotations=1 rss_kb=4224
+[daemon] rotation request: events_since_rotation=64 watermark=64
+[daemon] t=0.04s events=192 edb=192 hot=38 rotations=2 rss_kb=4288
+[daemon] rotation request: events_since_rotation=64 watermark=64
+[daemon] t=0.05s events=256 edb=256 hot=51 rotations=3 rss_kb=4352
+[daemon] summary: events=256 edb=256 hot=51 rotations=3 rss_kb=4352
+```
+
+## What This Demonstrates
+
+- **Daemon lifecycle** -- facts arrive over time, replay is separated from live
+  callbacks, and each live `wl_easy_step` publishes only new deltas for that
+  epoch.
+- **EDB ownership** -- the application owns the durable input log needed to
+  reconstruct a fresh session.
+- **Rotation observability** -- `stderr` carries event count, EDB size, live
+  derived hot-event count, rotation count, and RSS where available.
+- **API gap** -- saturation-aware rotation cannot be driven directly from the
+  installed public surface today; #550 is the API that should remove that
+  workaround.
+
+## See Also
+
+- `docs/COMPOUND_TERMS.md` -- compound term storage and arena lifecycle
+- `examples/08-delta-queries/` -- first delta-callback example
+- `examples/11-time-evolution/` -- per-epoch delta isolation
+- `wirelog/wl_easy.h` -- public convenience facade

--- a/examples/13-daemon-style/daemon.c
+++ b/examples/13-daemon-style/daemon.c
@@ -2,11 +2,9 @@
  * daemon.c - Example 13: Daemon-style session rotation
  *
  * Demonstrates a long-running wl_easy caller that preserves persistent EDB
- * facts across session rotations.  The example uses a public inline compound
- * declaration for event metadata.  Today the public API does not expose the
- * compound arena epoch, a saturation callback, or an engine-owned rotation
- * primitive, so the daemon uses a caller-owned watermark as the rotation
- * trigger.  See README.md for how #550 would simplify the loop.
+ * facts across session rotations.  The example uses a public side compound
+ * declaration for event metadata and rotates when the compound arena reports
+ * saturation through the installed public API.
  */
 
 #if !defined(_WIN32)
@@ -30,10 +28,13 @@
 #endif
 
 static const char *DAEMON_SRC
-    = ".decl event(id: int64, tenant: symbol, payload: metadata/4 inline)\n"
+    = ".decl event(id: int64, tenant: symbol, risk: int64, "
+    "payload: metadata/4 side)\n"
+    ".decl pulse(id: int64)\n"
     ".decl hot_event(id: int64, tenant: symbol)\n"
-    "hot_event(ID, Tenant) :- "
-    "event(ID, Tenant, metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
+    "pulse(ID) :- event(ID, _, _, _), ID < 0.\n"
+    "pulse(ID) :- pulse(ID).\n"
+    "hot_event(ID, Tenant) :- event(ID, Tenant, Risk, _), Risk > 80.\n";
 
 typedef struct {
     int64_t tenant_a;
@@ -66,10 +67,15 @@ typedef struct {
 typedef struct {
     uint64_t max_events;
     uint64_t max_seconds;
-    uint64_t rotate_every;
     uint64_t log_every;
     uint64_t sleep_ms;
 } daemon_opts_t;
+
+typedef enum {
+    INSERT_OK = 0,
+    INSERT_SATURATED = 1,
+    INSERT_FAILED = 2,
+} insert_status_t;
 
 typedef struct {
 #if defined(_WIN32)
@@ -112,7 +118,6 @@ parse_args(int argc, char **argv, daemon_opts_t *opts)
 {
     opts->max_events = 512;
     opts->max_seconds = 0;
-    opts->rotate_every = 128;
     opts->log_every = 64;
     opts->sleep_ms = 0;
 
@@ -122,9 +127,6 @@ parse_args(int argc, char **argv, daemon_opts_t *opts)
                 return -1;
         } else if (strcmp(argv[i], "--seconds") == 0 && i + 1 < argc) {
             if (parse_u64(argv[++i], &opts->max_seconds) != 0)
-                return -1;
-        } else if (strcmp(argv[i], "--rotate-every") == 0 && i + 1 < argc) {
-            if (parse_u64(argv[++i], &opts->rotate_every) != 0)
                 return -1;
         } else if (strcmp(argv[i], "--log-every") == 0 && i + 1 < argc) {
             if (parse_u64(argv[++i], &opts->log_every) != 0)
@@ -143,8 +145,8 @@ static void
 usage(const char *argv0)
 {
     fprintf(stderr,
-        "usage: %s [--events N] [--seconds N] [--rotate-every N] "
-        "[--log-every N] [--sleep-ms N]\n",
+        "usage: %s [--events N] [--seconds N] [--log-every N] "
+        "[--sleep-ms N]\n",
         argv0);
 }
 
@@ -267,15 +269,6 @@ enable_delta_cb(wl_easy_session_t *s, delta_stats_t *stats)
 }
 
 static int
-baseline_delta_state(wl_easy_session_t *s, delta_stats_t *stats)
-{
-    stats->suppress_deltas = true;
-    wirelog_error_t rc = wl_easy_step(s);
-    stats->suppress_deltas = false;
-    return rc == WIRELOG_OK ? 0 : -1;
-}
-
-static int
 open_session(wl_easy_session_t **out, symbol_ids_t *ids, delta_stats_t *stats,
     bool emit_live_deltas)
 {
@@ -294,18 +287,35 @@ open_session(wl_easy_session_t **out, symbol_ids_t *ids, delta_stats_t *stats,
     return 0;
 }
 
-static int
+static insert_status_t
 insert_event(wl_easy_session_t *s, const symbol_ids_t *ids,
     const event_record_t *record)
 {
-    int64_t row[6];
+    const int64_t level = record->hot ? ids->warn : ids->info;
+    const int64_t ts = (int64_t)(1700000000u + record->id);
+    const int64_t host = record->host_a ? ids->host_a : ids->host_b;
+    const int64_t risk = record->hot ? 95 : 10;
+    wirelog_compound_arg_t payload_args[4] = {
+        { WIRELOG_TYPE_STRING, level },
+        { WIRELOG_TYPE_INT64, ts },
+        { WIRELOG_TYPE_STRING, host },
+        { WIRELOG_TYPE_INT64, risk },
+    };
+    uint64_t payload = WIRELOG_COMPOUND_HANDLE_NULL;
+    wirelog_error_t rc = wirelog_easy_make_compound(s, "metadata", 4,
+            payload_args, &payload);
+    if (rc == WIRELOG_ERR_COMPOUND_SATURATED)
+        return INSERT_SATURATED;
+    if (rc != WIRELOG_OK || payload == WIRELOG_COMPOUND_HANDLE_NULL)
+        return INSERT_FAILED;
+
+    int64_t row[4];
     row[0] = (int64_t)record->id;
     row[1] = record->tenant_a ? ids->tenant_a : ids->tenant_b;
-    row[2] = record->hot ? ids->warn : ids->info;
-    row[3] = (int64_t)(1700000000u + record->id);
-    row[4] = record->host_a ? ids->host_a : ids->host_b;
-    row[5] = record->hot ? 95 : 10;
-    return wl_easy_insert(s, "event", row, 6) == WIRELOG_OK ? 0 : -1;
+    row[2] = risk;
+    row[3] = (int64_t)payload;
+    return wl_easy_insert(s, "event", row, 4) == WIRELOG_OK ? INSERT_OK
+                                                            : INSERT_FAILED;
 }
 
 static int
@@ -313,10 +323,10 @@ replay_edb(wl_easy_session_t *s, const symbol_ids_t *ids,
     const edb_store_t *edb)
 {
     for (size_t i = 0; i < edb->count; i++) {
-        if (insert_event(s, ids, &edb->records[i]) != 0)
+        if (insert_event(s, ids, &edb->records[i]) != INSERT_OK)
             return -1;
     }
-    return wl_easy_step(s) == WIRELOG_OK ? 0 : -1;
+    return 0;
 }
 
 static int
@@ -324,9 +334,6 @@ rotate_session(wl_easy_session_t **session_io, symbol_ids_t *ids,
     const edb_store_t *edb, delta_stats_t *stats, uint64_t *rotations)
 {
     wl_easy_session_t *fresh = NULL;
-    if (wl_easy_step(*session_io) != WIRELOG_OK)
-        return -1;
-
     if (open_session(&fresh, ids, stats, false) != 0)
         return -1;
     if (replay_edb(fresh, ids, edb) != 0) {
@@ -334,10 +341,6 @@ rotate_session(wl_easy_session_t **session_io, symbol_ids_t *ids,
         return -1;
     }
     if (enable_delta_cb(fresh, stats) != 0) {
-        wl_easy_close(fresh);
-        return -1;
-    }
-    if (baseline_delta_state(fresh, stats) != 0) {
         wl_easy_close(fresh);
         return -1;
     }
@@ -367,7 +370,7 @@ main(int argc, char **argv)
     delta_stats_t stats = { 0 };
     edb_store_t edb = { 0 };
     uint64_t rotations = 0;
-    uint64_t since_rotation = 0;
+    uint64_t saturations = 0;
     uint64_t event_id = 0;
     monotonic_time_t start;
 
@@ -390,13 +393,24 @@ main(int argc, char **argv)
             break;
         event_id++;
         event_record_t record = make_event_record(event_id);
-        if (edb_push(&edb, &record) != 0) {
-            fprintf(stderr, "[daemon] out of memory while recording EDB\n");
-            wl_easy_close(session);
-            edb_free(&edb);
-            return 1;
+
+        insert_status_t insert_rc = insert_event(session, &ids, &record);
+        if (insert_rc == INSERT_SATURATED) {
+            saturations++;
+            fprintf(stderr,
+                "[daemon] rotation request: compound arena saturated "
+                "event=%" PRIu64 "\n",
+                event_id);
+            if (rotate_session(&session, &ids, &edb, &stats, &rotations)
+                != 0) {
+                fprintf(stderr, "[daemon] rotation failed\n");
+                wl_easy_close(session);
+                edb_free(&edb);
+                return 1;
+            }
+            insert_rc = insert_event(session, &ids, &record);
         }
-        if (insert_event(session, &ids, &record) != 0) {
+        if (insert_rc != INSERT_OK) {
             fprintf(stderr, "[daemon] insert failed at event=%" PRIu64 "\n",
                 event_id);
             wl_easy_close(session);
@@ -410,34 +424,21 @@ main(int argc, char **argv)
             edb_free(&edb);
             return 1;
         }
+        if (edb_push(&edb, &record) != 0) {
+            fprintf(stderr, "[daemon] out of memory while recording EDB\n");
+            wl_easy_close(session);
+            edb_free(&edb);
+            return 1;
+        }
 
-        since_rotation++;
         if (opts.log_every != 0 && (event_id % opts.log_every) == 0) {
             fprintf(stderr,
                 "[daemon] t=%.2fs events=%" PRIu64 " edb=%zu hot=%" PRIu64
-                " rotations=%" PRIu64 " rss_kb=%" PRIu64 "\n",
+                " rotations=%" PRIu64 " saturations=%" PRIu64
+                " rss_kb=%" PRIu64 "\n",
                 monotonic_elapsed_seconds(&start), event_id, edb.count,
                 stats.hot_deltas,
-                rotations, rss_kb());
-        }
-
-        const bool reached_event_limit = event_id >= opts.max_events;
-        const bool reached_time_limit = opts.max_seconds != 0
-            && monotonic_elapsed_seconds(&start) >= (double)opts.max_seconds;
-        if (since_rotation >= opts.rotate_every && !reached_event_limit
-            && !reached_time_limit) {
-            fprintf(stderr,
-                "[daemon] rotation request: events_since_rotation=%" PRIu64
-                " watermark=%" PRIu64 "\n",
-                since_rotation, opts.rotate_every);
-            if (rotate_session(&session, &ids, &edb, &stats, &rotations)
-                != 0) {
-                fprintf(stderr, "[daemon] rotation failed\n");
-                wl_easy_close(session);
-                edb_free(&edb);
-                return 1;
-            }
-            since_rotation = 0;
+                rotations, saturations, rss_kb());
         }
 
         sleep_millis(opts.sleep_ms);
@@ -445,8 +446,10 @@ main(int argc, char **argv)
 
     fprintf(stderr,
         "[daemon] summary: events=%" PRIu64 " edb=%zu hot=%" PRIu64
-        " rotations=%" PRIu64 " rss_kb=%" PRIu64 "\n",
-        event_id, edb.count, stats.hot_deltas, rotations, rss_kb());
+        " rotations=%" PRIu64 " saturations=%" PRIu64 " rss_kb=%" PRIu64
+        "\n",
+        event_id, edb.count, stats.hot_deltas, rotations, saturations,
+        rss_kb());
 
     wl_easy_close(session);
     edb_free(&edb);

--- a/examples/13-daemon-style/daemon.c
+++ b/examples/13-daemon-style/daemon.c
@@ -1,0 +1,454 @@
+/*
+ * daemon.c - Example 13: Daemon-style session rotation
+ *
+ * Demonstrates a long-running wl_easy caller that preserves persistent EDB
+ * facts across session rotations.  The example uses a public inline compound
+ * declaration for event metadata.  Today the public API does not expose the
+ * compound arena epoch, a saturation callback, or an engine-owned rotation
+ * primitive, so the daemon uses a caller-owned watermark as the rotation
+ * trigger.  See README.md for how #550 would simplify the loop.
+ */
+
+#if !defined(_WIN32)
+#  define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(__linux__) || defined(__APPLE__)
+#  include <unistd.h>
+#elif defined(_WIN32)
+#  include <windows.h>
+#endif
+
+static const char *DAEMON_SRC
+    = ".decl event(id: int64, tenant: symbol, payload: metadata/4 inline)\n"
+    ".decl hot_event(id: int64, tenant: symbol)\n"
+    "hot_event(ID, Tenant) :- "
+    "event(ID, Tenant, metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
+
+typedef struct {
+    int64_t tenant_a;
+    int64_t tenant_b;
+    int64_t info;
+    int64_t warn;
+    int64_t host_a;
+    int64_t host_b;
+} symbol_ids_t;
+
+typedef struct {
+    uint64_t id;
+    bool tenant_a;
+    bool hot;
+    bool host_a;
+} event_record_t;
+
+typedef struct {
+    event_record_t *records;
+    size_t count;
+    size_t cap;
+} edb_store_t;
+
+typedef struct {
+    uint64_t hot_deltas;
+    uint64_t max_hot_id_seen;
+    bool suppress_deltas;
+} delta_stats_t;
+
+typedef struct {
+    uint64_t max_events;
+    uint64_t max_seconds;
+    uint64_t rotate_every;
+    uint64_t log_every;
+    uint64_t sleep_ms;
+} daemon_opts_t;
+
+typedef struct {
+#if defined(_WIN32)
+    LARGE_INTEGER counter;
+#else
+    struct timespec ts;
+#endif
+} monotonic_time_t;
+
+static void
+on_delta(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    delta_stats_t *stats = (delta_stats_t *)user_data;
+    if (stats && stats->suppress_deltas)
+        return;
+    if (stats && diff > 0 && strcmp(relation, "hot_event") == 0 && ncols > 0
+        && row[0] > 0 && (uint64_t)row[0] > stats->max_hot_id_seen) {
+        stats->max_hot_id_seen = (uint64_t)row[0];
+        stats->hot_deltas++;
+    }
+}
+
+static int
+parse_u64(const char *s, uint64_t *out)
+{
+    char *endp = NULL;
+    unsigned long long v;
+    if (!s || !out)
+        return -1;
+    v = strtoull(s, &endp, 10);
+    if (endp == s || *endp != '\0' || v == 0)
+        return -1;
+    *out = (uint64_t)v;
+    return 0;
+}
+
+static int
+parse_args(int argc, char **argv, daemon_opts_t *opts)
+{
+    opts->max_events = 512;
+    opts->max_seconds = 0;
+    opts->rotate_every = 128;
+    opts->log_every = 64;
+    opts->sleep_ms = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--events") == 0 && i + 1 < argc) {
+            if (parse_u64(argv[++i], &opts->max_events) != 0)
+                return -1;
+        } else if (strcmp(argv[i], "--seconds") == 0 && i + 1 < argc) {
+            if (parse_u64(argv[++i], &opts->max_seconds) != 0)
+                return -1;
+        } else if (strcmp(argv[i], "--rotate-every") == 0 && i + 1 < argc) {
+            if (parse_u64(argv[++i], &opts->rotate_every) != 0)
+                return -1;
+        } else if (strcmp(argv[i], "--log-every") == 0 && i + 1 < argc) {
+            if (parse_u64(argv[++i], &opts->log_every) != 0)
+                return -1;
+        } else if (strcmp(argv[i], "--sleep-ms") == 0 && i + 1 < argc) {
+            if (parse_u64(argv[++i], &opts->sleep_ms) != 0)
+                return -1;
+        } else {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void
+usage(const char *argv0)
+{
+    fprintf(stderr,
+        "usage: %s [--events N] [--seconds N] [--rotate-every N] "
+        "[--log-every N] [--sleep-ms N]\n",
+        argv0);
+}
+
+static uint64_t
+rss_kb(void)
+{
+#if defined(__linux__)
+    FILE *f = fopen("/proc/self/statm", "r");
+    unsigned long pages = 0;
+    long page_kb = 0;
+    if (!f)
+        return 0;
+    if (fscanf(f, "%*s %lu", &pages) != 1) {
+        fclose(f);
+        return 0;
+    }
+    fclose(f);
+    page_kb = sysconf(_SC_PAGESIZE) / 1024;
+    if (page_kb <= 0)
+        return 0;
+    return (uint64_t)pages * (uint64_t)page_kb;
+#else
+    return 0;
+#endif
+}
+
+static double
+monotonic_elapsed_seconds(const monotonic_time_t *start)
+{
+#if defined(_WIN32)
+    LARGE_INTEGER now;
+    LARGE_INTEGER freq;
+    QueryPerformanceCounter(&now);
+    QueryPerformanceFrequency(&freq);
+    return (double)(now.QuadPart - start->counter.QuadPart)
+           / (double)freq.QuadPart;
+#else
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+        return 0.0;
+    return (double)(now.tv_sec - start->ts.tv_sec)
+           + (double)(now.tv_nsec - start->ts.tv_nsec) / 1000000000.0;
+#endif
+}
+
+static int
+monotonic_now(monotonic_time_t *out)
+{
+#if defined(_WIN32)
+    return QueryPerformanceCounter(&out->counter) ? 0 : -1;
+#else
+    return clock_gettime(CLOCK_MONOTONIC, &out->ts) == 0 ? 0 : -1;
+#endif
+}
+
+static void
+sleep_millis(uint64_t ms)
+{
+#if defined(__linux__) || defined(__APPLE__)
+    if (ms > 0) {
+        struct timespec req;
+        req.tv_sec = (time_t)(ms / 1000u);
+        req.tv_nsec = (long)(ms % 1000u) * 1000000L;
+        (void)nanosleep(&req, NULL);
+    }
+#elif defined(_WIN32)
+    if (ms > 0)
+        Sleep((DWORD)ms);
+#else
+    (void)ms;
+#endif
+}
+
+static int
+edb_push(edb_store_t *edb, const event_record_t *record)
+{
+    event_record_t *next;
+    size_t next_cap;
+    if (edb->count == edb->cap) {
+        next_cap = edb->cap ? edb->cap * 2u : 128u;
+        next
+            = (event_record_t *)realloc(edb->records, next_cap * sizeof(*next));
+        if (!next)
+            return -1;
+        edb->records = next;
+        edb->cap = next_cap;
+    }
+    edb->records[edb->count++] = *record;
+    return 0;
+}
+
+static void
+edb_free(edb_store_t *edb)
+{
+    free(edb->records);
+    edb->records = NULL;
+    edb->count = 0;
+    edb->cap = 0;
+}
+
+static int
+intern_symbols(wl_easy_session_t *s, symbol_ids_t *ids)
+{
+    ids->tenant_a = wl_easy_intern(s, "tenant-a");
+    ids->tenant_b = wl_easy_intern(s, "tenant-b");
+    ids->info = wl_easy_intern(s, "info");
+    ids->warn = wl_easy_intern(s, "warn");
+    ids->host_a = wl_easy_intern(s, "edge-01");
+    ids->host_b = wl_easy_intern(s, "edge-02");
+    return (ids->tenant_a < 0 || ids->tenant_b < 0 || ids->info < 0
+           || ids->warn < 0 || ids->host_a < 0 || ids->host_b < 0)
+        ? -1
+        : 0;
+}
+
+static int
+enable_delta_cb(wl_easy_session_t *s, delta_stats_t *stats)
+{
+    return wl_easy_set_delta_cb(s, on_delta, stats) == WIRELOG_OK ? 0 : -1;
+}
+
+static int
+baseline_delta_state(wl_easy_session_t *s, delta_stats_t *stats)
+{
+    stats->suppress_deltas = true;
+    wirelog_error_t rc = wl_easy_step(s);
+    stats->suppress_deltas = false;
+    return rc == WIRELOG_OK ? 0 : -1;
+}
+
+static int
+open_session(wl_easy_session_t **out, symbol_ids_t *ids, delta_stats_t *stats,
+    bool emit_live_deltas)
+{
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(DAEMON_SRC, &s) != WIRELOG_OK)
+        return -1;
+    if (intern_symbols(s, ids) != 0) {
+        wl_easy_close(s);
+        return -1;
+    }
+    if (emit_live_deltas && enable_delta_cb(s, stats) != 0) {
+        wl_easy_close(s);
+        return -1;
+    }
+    *out = s;
+    return 0;
+}
+
+static int
+insert_event(wl_easy_session_t *s, const symbol_ids_t *ids,
+    const event_record_t *record)
+{
+    int64_t row[6];
+    row[0] = (int64_t)record->id;
+    row[1] = record->tenant_a ? ids->tenant_a : ids->tenant_b;
+    row[2] = record->hot ? ids->warn : ids->info;
+    row[3] = (int64_t)(1700000000u + record->id);
+    row[4] = record->host_a ? ids->host_a : ids->host_b;
+    row[5] = record->hot ? 95 : 10;
+    return wl_easy_insert(s, "event", row, 6) == WIRELOG_OK ? 0 : -1;
+}
+
+static int
+replay_edb(wl_easy_session_t *s, const symbol_ids_t *ids,
+    const edb_store_t *edb)
+{
+    for (size_t i = 0; i < edb->count; i++) {
+        if (insert_event(s, ids, &edb->records[i]) != 0)
+            return -1;
+    }
+    return wl_easy_step(s) == WIRELOG_OK ? 0 : -1;
+}
+
+static int
+rotate_session(wl_easy_session_t **session_io, symbol_ids_t *ids,
+    const edb_store_t *edb, delta_stats_t *stats, uint64_t *rotations)
+{
+    wl_easy_session_t *fresh = NULL;
+    if (wl_easy_step(*session_io) != WIRELOG_OK)
+        return -1;
+
+    if (open_session(&fresh, ids, stats, false) != 0)
+        return -1;
+    if (replay_edb(fresh, ids, edb) != 0) {
+        wl_easy_close(fresh);
+        return -1;
+    }
+    if (enable_delta_cb(fresh, stats) != 0) {
+        wl_easy_close(fresh);
+        return -1;
+    }
+    if (baseline_delta_state(fresh, stats) != 0) {
+        wl_easy_close(fresh);
+        return -1;
+    }
+    wl_easy_close(*session_io);
+    *session_io = fresh;
+    (*rotations)++;
+    return 0;
+}
+
+static event_record_t
+make_event_record(uint64_t event_id)
+{
+    event_record_t record;
+    record.id = event_id;
+    record.tenant_a = (event_id % 2u) != 0u;
+    record.hot = (event_id % 5u) == 0u;
+    record.host_a = (event_id % 2u) != 0u;
+    return record;
+}
+
+int
+main(int argc, char **argv)
+{
+    daemon_opts_t opts;
+    wl_easy_session_t *session = NULL;
+    symbol_ids_t ids;
+    delta_stats_t stats = { 0 };
+    edb_store_t edb = { 0 };
+    uint64_t rotations = 0;
+    uint64_t since_rotation = 0;
+    uint64_t event_id = 0;
+    monotonic_time_t start;
+
+    if (parse_args(argc, argv, &opts) != 0) {
+        usage(argv[0]);
+        return 2;
+    }
+    if (monotonic_now(&start) != 0) {
+        fprintf(stderr, "[daemon] failed to read monotonic clock\n");
+        return 1;
+    }
+    if (open_session(&session, &ids, &stats, true) != 0) {
+        fprintf(stderr, "[daemon] failed to open wirelog session\n");
+        return 1;
+    }
+
+    while (event_id < opts.max_events) {
+        if (opts.max_seconds != 0
+            && monotonic_elapsed_seconds(&start) >= (double)opts.max_seconds)
+            break;
+        event_id++;
+        event_record_t record = make_event_record(event_id);
+        if (edb_push(&edb, &record) != 0) {
+            fprintf(stderr, "[daemon] out of memory while recording EDB\n");
+            wl_easy_close(session);
+            edb_free(&edb);
+            return 1;
+        }
+        if (insert_event(session, &ids, &record) != 0) {
+            fprintf(stderr, "[daemon] insert failed at event=%" PRIu64 "\n",
+                event_id);
+            wl_easy_close(session);
+            edb_free(&edb);
+            return 1;
+        }
+        if (wl_easy_step(session) != WIRELOG_OK) {
+            fprintf(stderr, "[daemon] step failed at event=%" PRIu64 "\n",
+                event_id);
+            wl_easy_close(session);
+            edb_free(&edb);
+            return 1;
+        }
+
+        since_rotation++;
+        if (opts.log_every != 0 && (event_id % opts.log_every) == 0) {
+            fprintf(stderr,
+                "[daemon] t=%.2fs events=%" PRIu64 " edb=%zu hot=%" PRIu64
+                " rotations=%" PRIu64 " rss_kb=%" PRIu64 "\n",
+                monotonic_elapsed_seconds(&start), event_id, edb.count,
+                stats.hot_deltas,
+                rotations, rss_kb());
+        }
+
+        const bool reached_event_limit = event_id >= opts.max_events;
+        const bool reached_time_limit = opts.max_seconds != 0
+            && monotonic_elapsed_seconds(&start) >= (double)opts.max_seconds;
+        if (since_rotation >= opts.rotate_every && !reached_event_limit
+            && !reached_time_limit) {
+            fprintf(stderr,
+                "[daemon] rotation request: events_since_rotation=%" PRIu64
+                " watermark=%" PRIu64 "\n",
+                since_rotation, opts.rotate_every);
+            if (rotate_session(&session, &ids, &edb, &stats, &rotations)
+                != 0) {
+                fprintf(stderr, "[daemon] rotation failed\n");
+                wl_easy_close(session);
+                edb_free(&edb);
+                return 1;
+            }
+            since_rotation = 0;
+        }
+
+        sleep_millis(opts.sleep_ms);
+    }
+
+    fprintf(stderr,
+        "[daemon] summary: events=%" PRIu64 " edb=%zu hot=%" PRIu64
+        " rotations=%" PRIu64 " rss_kb=%" PRIu64 "\n",
+        event_id, edb.count, stats.hot_deltas, rotations, rss_kb());
+
+    wl_easy_close(session);
+    edb_free(&edb);
+    return rotations > 0 ? 0 : 1;
+}

--- a/examples/13-daemon-style/meson.build
+++ b/examples/13-daemon-style/meson.build
@@ -1,0 +1,38 @@
+# examples/13-daemon-style/meson.build
+# Daemon-style session rotation demo (#629)
+#
+# Include all wirelog sources directly (same pattern as example 08 and
+# wirelog_cli) to ensure proper linking under LTO.
+
+daemon_style_demo = executable(
+  'daemon_style_demo',
+  files('daemon.c'),
+  wirelog_sources,
+  config_h_file,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+
+test(
+  'example_13_daemon_style_smoke',
+  daemon_style_demo,
+  args: ['--events', '128', '--rotate-every', '32', '--log-every', '64'],
+  suite: 'examples',
+  is_parallel: false,
+)
+
+test(
+  'example_13_daemon_style_paced',
+  daemon_style_demo,
+  args: [
+    '--events', '1200',
+    '--seconds', '10',
+    '--rotate-every', '128',
+    '--log-every', '256',
+    '--sleep-ms', '10',
+  ],
+  suite: 'examples',
+  is_parallel: false,
+  timeout: 30,
+)

--- a/examples/13-daemon-style/meson.build
+++ b/examples/13-daemon-style/meson.build
@@ -17,8 +17,9 @@ daemon_style_demo = executable(
 test(
   'example_13_daemon_style_smoke',
   daemon_style_demo,
-  args: ['--events', '128', '--rotate-every', '32', '--log-every', '64'],
+  args: ['--events', '96', '--log-every', '32'],
   suite: 'examples',
+  env: {'WIRELOG_COMPOUND_MAX_EPOCHS': '32'},
   is_parallel: false,
 )
 
@@ -28,11 +29,11 @@ test(
   args: [
     '--events', '1200',
     '--seconds', '10',
-    '--rotate-every', '128',
     '--log-every', '256',
     '--sleep-ms', '10',
   ],
   suite: 'examples',
+  env: {'WIRELOG_COMPOUND_MAX_EPOCHS': '64'},
   is_parallel: false,
   timeout: 30,
 )

--- a/examples/13-daemon-style/run.sh
+++ b/examples/13-daemon-style/run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+root_dir=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+build_dir=${BUILD_DIR:-"$root_dir/build"}
+demo="$build_dir/examples/13-daemon-style/daemon_style_demo"
+
+if [ ! -x "$demo" ]; then
+  echo "daemon_style_demo is not built; run: meson compile -C $build_dir daemon_style_demo" >&2
+  exit 1
+fi
+
+"$demo" --events "${WIRELOG_DAEMON_EVENTS:-1000}" \
+  --seconds "${WIRELOG_DAEMON_SECONDS:-10}" \
+  --rotate-every "${WIRELOG_DAEMON_ROTATE_EVERY:-128}" \
+  --log-every "${WIRELOG_DAEMON_LOG_EVERY:-64}" \
+  --sleep-ms "${WIRELOG_DAEMON_SLEEP_MS:-10}"

--- a/examples/13-daemon-style/run.sh
+++ b/examples/13-daemon-style/run.sh
@@ -10,8 +10,10 @@ if [ ! -x "$demo" ]; then
   exit 1
 fi
 
+: "${WIRELOG_COMPOUND_MAX_EPOCHS:=256}"
+export WIRELOG_COMPOUND_MAX_EPOCHS
+
 "$demo" --events "${WIRELOG_DAEMON_EVENTS:-1000}" \
   --seconds "${WIRELOG_DAEMON_SECONDS:-10}" \
-  --rotate-every "${WIRELOG_DAEMON_ROTATE_EVERY:-128}" \
   --log-every "${WIRELOG_DAEMON_LOG_EVERY:-64}" \
   --sleep-ms "${WIRELOG_DAEMON_SLEEP_MS:-10}"

--- a/meson.build
+++ b/meson.build
@@ -343,6 +343,7 @@ subdir('examples/09-retraction-basics')
 subdir('examples/10-recursive-under-update')
 subdir('examples/11-time-evolution')
 subdir('examples/12-snapshot-vs-delta')
+subdir('examples/13-daemon-style')
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Documentation

--- a/tests/test_wl_easy.c
+++ b/tests/test_wl_easy.c
@@ -23,6 +23,24 @@
 #include <signal.h>
 #endif
 
+#ifdef _WIN32
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#endif
+
 /* ======================================================================== */
 /* Test Harness                                                             */
 /* ======================================================================== */
@@ -730,6 +748,73 @@ test_inline_compound_duplicate_child_variables_filter(void)
 }
 
 static void
+test_side_compound_public_allocation_saturates(void)
+{
+    TEST("public side compound allocation reports saturation");
+
+    if (setenv("WIRELOG_COMPOUND_MAX_EPOCHS", "2", 1) != 0) {
+        FAIL("setenv failed");
+        return;
+    }
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl seen(id: int64)\n"
+        ".decl edge(x: int64, y: int64)\n"
+        ".decl tc(x: int64, y: int64)\n"
+        "seen(ID) :- event(ID, _).\n"
+        "tc(X, Y) :- edge(X, Y).\n"
+        "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+        unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+        FAIL("open failed");
+        return;
+    }
+
+    wirelog_compound_arg_t args[4] = {
+        { WIRELOG_TYPE_INT64, 1 },
+        { WIRELOG_TYPE_INT64, 2 },
+        { WIRELOG_TYPE_INT64, 3 },
+        { WIRELOG_TYPE_INT64, 4 },
+    };
+    uint64_t handle = 0;
+    wirelog_error_t rc = wirelog_easy_make_compound(s, "metadata", 4, args,
+            &handle);
+    if (rc != WIRELOG_OK || handle == 0) {
+        wl_easy_close(s);
+        unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+        FAIL("first compound allocation failed");
+        return;
+    }
+    int64_t row[2] = { 1, (int64_t)handle };
+    int64_t edge_12[2] = { 1, 2 };
+    int64_t edge_23[2] = { 2, 3 };
+    int64_t edge_34[2] = { 3, 4 };
+    if (wl_easy_insert(s, "event", row, 2) != WIRELOG_OK
+        || wl_easy_insert(s, "edge", edge_12, 2) != WIRELOG_OK
+        || wl_easy_insert(s, "edge", edge_23, 2) != WIRELOG_OK
+        || wl_easy_insert(s, "edge", edge_34, 2) != WIRELOG_OK
+        || wl_easy_step(s) != WIRELOG_OK) {
+        wl_easy_close(s);
+        unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+        FAIL("first insert/step failed");
+        return;
+    }
+
+    handle = 123;
+    rc = wirelog_easy_make_compound(s, "metadata", 4, args, &handle);
+    wl_easy_close(s);
+    unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+    if (rc != WIRELOG_ERR_COMPOUND_SATURATED || handle != 0) {
+        FAIL("expected WIRELOG_ERR_COMPOUND_SATURATED with cleared handle");
+        return;
+    }
+    PASS();
+}
+
+static void
 test_insert_sym_variadic(void)
 {
     TEST("insert_sym variadic helper");
@@ -1114,6 +1199,7 @@ main(void)
     test_inline_compound_functor_mismatch_is_empty();
     test_inline_compound_constant_child_filters();
     test_inline_compound_duplicate_child_variables_filter();
+    test_side_compound_public_allocation_saturates();
     test_insert_sym_variadic();
     test_remove_sym();
     test_snapshot_filter();

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -305,6 +305,12 @@ wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
 {
     if (!arena)
         return (uint32_t)-1;
+    if (arena->current_epoch >= arena->max_epochs) {
+        WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_WARN,
+            "lifecycle event=gc_skip_saturated current_epoch=%u max_epochs=%u",
+            arena->current_epoch, arena->max_epochs);
+        return 0;
+    }
     if (arena->frozen) {
         /* Issue #561 / #584: freeze guard is a no-op skip, not a reset.
          * Returning the unchanged current_epoch (rather than 0) lets

--- a/wirelog/backend.h
+++ b/wirelog/backend.h
@@ -53,6 +53,7 @@ typedef struct wl_session wl_session_t;
  * @session_create: Initialize a session for a given ir plan.
  * @session_destroy: Deallocate session state.
  * @session_insert: Insert EDB facts.
+ * @session_make_compound: Allocate a side-tier compound handle.
  * @session_remove: Retract EDB facts (for incremental backends).
  * @session_step: Perform one epoch advance (incremental).
  * @session_set_delta_cb: Set delta callback on updates.
@@ -68,6 +69,10 @@ typedef struct {
     int (*session_insert)(wl_session_t *session, const char *relation,
         const int64_t *data, uint32_t num_rows,
         uint32_t num_cols);
+
+    int (*session_make_compound)(wl_session_t *session, const char *functor,
+        uint32_t arity, const wirelog_compound_arg_t *args,
+        uint64_t *handle_out);
 
     int (*session_remove)(wl_session_t *session, const char *relation,
         const int64_t *data, uint32_t num_rows,

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -8,6 +8,7 @@
 
 #define _GNU_SOURCE
 
+#include "columnar/compound_side.h"
 #include "columnar/internal.h"
 #include "wirelog/util/log.h"
 
@@ -65,6 +66,22 @@ session_find_rel(wl_col_session_t *sess, const char *name)
             return sess->rels[i];
     }
     return NULL;
+}
+
+static uint32_t
+session_compound_max_epochs_from_env(void)
+{
+    const char *env = getenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+    if (!env || env[0] == '\0')
+        return 0u;
+    char *endp = NULL;
+    errno = 0;
+    unsigned long v = strtoul(env, &endp, 10);
+    if (endp == env || *endp != '\0' || errno == ERANGE || v == 0)
+        return 0u;
+    if (v > (unsigned long)(WL_COMPOUND_EPOCH_MAX + 1u))
+        return 0u;
+    return (uint32_t)v;
 }
 
 int
@@ -739,19 +756,23 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
      * default_gen_cap=4096 mirrors the smoke-test usage in
      * tests/test_compound_arena.c; max_epochs=0 selects the library
      * default (WL_COMPOUND_EPOCH_MAX + 1). */
-    sess->compound_arena = wl_compound_arena_create(0x53455353u, 4096u, 0u);
+    uint32_t compound_max_epochs = session_compound_max_epochs_from_env();
+    sess->compound_arena = wl_compound_arena_create(0x53455353u, 4096u,
+            compound_max_epochs);
     if (!sess->compound_arena)
         goto oom;
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,
-        "event=compound_arena_init seed=0x%08x default_gen_cap=%u",
-        0x53455353u, 4096u);
+        "event=compound_arena_init seed=0x%08x default_gen_cap=%u "
+        "max_epochs=%u",
+        0x53455353u, 4096u, sess->compound_arena->max_epochs);
     /* Issue #583: lifecycle audit trail for the compound side-relation
      * subsystem.  WL_LOG=COMPOUND:5 captures create/destroy/alloc/
      * freeze/unfreeze in one section without enabling the noisier
      * SESSION INFO surface. */
     WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
-        "lifecycle event=session_create seed=0x%08x default_gen_cap=%u",
-        0x53455353u, 4096u);
+        "lifecycle event=session_create seed=0x%08x default_gen_cap=%u "
+        "max_epochs=%u",
+        0x53455353u, 4096u, sess->compound_arena->max_epochs);
 
     /* Pre-register EDB relations (ncols determined at first insert) */
     for (uint32_t i = 0; i < plan->edb_count; i++) {
@@ -1238,6 +1259,73 @@ col_session_insert(wl_session_t *session, const char *relation,
      * skip condition to reduce iterations on subsequent snapshots. */
     COL_SESSION(session)->last_inserted_relation = relation;
 
+    return 0;
+}
+
+static int
+col_session_make_compound(wl_session_t *session, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
+{
+    if (handle_out)
+        *handle_out = WIRELOG_COMPOUND_HANDLE_NULL;
+    if (!session || !functor || !args || arity == 0 || !handle_out)
+        return EINVAL;
+    if (arity > UINT32_MAX - 1u)
+        return EOVERFLOW;
+    if (arity > UINT32_MAX / (uint32_t)sizeof(int64_t))
+        return EOVERFLOW;
+
+    wl_col_session_t *sess = COL_SESSION(session);
+    if (!sess || !sess->compound_arena)
+        return EINVAL;
+    if (sess->compound_arena->frozen)
+        return EBUSY;
+    if (sess->compound_arena->current_epoch >= sess->compound_arena->max_epochs)
+        return ENOSPC;
+
+    col_rel_t *side_rel = NULL;
+    int rc = wl_compound_side_ensure(sess, functor, arity, &side_rel);
+    if (rc != 0)
+        return rc;
+    if (!side_rel)
+        return EINVAL;
+
+    uint32_t payload_size = arity * (uint32_t)sizeof(int64_t);
+    uint64_t handle = wl_compound_arena_alloc(sess->compound_arena,
+            payload_size);
+    if (handle == WIRELOG_COMPOUND_HANDLE_NULL) {
+        if (sess->compound_arena->frozen)
+            return EBUSY;
+        if (sess->compound_arena->current_epoch
+            >= sess->compound_arena->max_epochs)
+            return ENOSPC;
+        return ENOMEM;
+    }
+
+    uint32_t ncols = arity + 1u;
+    int64_t stack_row[16];
+    int64_t *row = stack_row;
+    if (ncols > (uint32_t)(sizeof(stack_row) / sizeof(stack_row[0]))) {
+        row = (int64_t *)malloc((size_t)ncols * sizeof(*row));
+        if (!row) {
+            wl_compound_arena_retain(sess->compound_arena, handle, -1);
+            return ENOMEM;
+        }
+    }
+
+    row[0] = (int64_t)handle;
+    for (uint32_t i = 0; i < arity; i++)
+        row[i + 1u] = args[i].value;
+
+    rc = col_rel_append_row(side_rel, row);
+    if (row != stack_row)
+        free(row);
+    if (rc != 0) {
+        wl_compound_arena_retain(sess->compound_arena, handle, -1);
+        return rc;
+    }
+
+    *handle_out = handle;
     return 0;
 }
 
@@ -2074,6 +2162,7 @@ static const wl_compute_backend_t col_backend = {
     .session_create = col_session_create,
     .session_destroy = col_session_destroy,
     .session_insert = col_session_insert,
+    .session_make_compound = col_session_make_compound,
     .session_remove = col_session_remove,
     .session_step = col_session_step,
     .session_set_delta_cb = col_session_set_delta_cb,

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1262,6 +1262,22 @@ col_session_insert(wl_session_t *session, const char *relation,
     return 0;
 }
 
+static bool
+compound_arg_type_valid(wirelog_column_type_t type)
+{
+    switch (type) {
+    case WIRELOG_TYPE_INT32:
+    case WIRELOG_TYPE_INT64:
+    case WIRELOG_TYPE_UINT32:
+    case WIRELOG_TYPE_UINT64:
+    case WIRELOG_TYPE_FLOAT:
+    case WIRELOG_TYPE_STRING:
+    case WIRELOG_TYPE_BOOL:
+        return true;
+    }
+    return false;
+}
+
 static int
 col_session_make_compound(wl_session_t *session, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
@@ -1274,6 +1290,10 @@ col_session_make_compound(wl_session_t *session, const char *functor,
         return EOVERFLOW;
     if (arity > UINT32_MAX / (uint32_t)sizeof(int64_t))
         return EOVERFLOW;
+    for (uint32_t i = 0; i < arity; i++) {
+        if (!compound_arg_type_valid(args[i].type))
+            return EINVAL;
+    }
 
     wl_col_session_t *sess = COL_SESSION(session);
     if (!sess || !sess->compound_arena)

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -21,11 +21,12 @@
  */
 
 #include "session.h"
+#include <errno.h>
 #include <stddef.h>
 
 int
 wl_session_create(const wl_compute_backend_t *backend, const wl_plan_t *plan,
-                  uint32_t num_workers, wl_session_t **out)
+    uint32_t num_workers, wl_session_t **out)
 {
     int rc;
     if (!backend || !backend->session_create || !out)
@@ -49,22 +50,34 @@ wl_session_destroy(wl_session_t *session)
 
 int
 wl_session_insert(wl_session_t *session, const char *relation,
-                  const int64_t *data, uint32_t num_rows, uint32_t num_cols)
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols)
 {
     if (!session || !session->backend || !session->backend->session_insert)
         return -1;
     return session->backend->session_insert(session, relation, data, num_rows,
-                                            num_cols);
+               num_cols);
+}
+
+int
+wl_session_make_compound(wl_session_t *session, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args,
+    uint64_t *handle_out)
+{
+    if (!session || !session->backend
+        || !session->backend->session_make_compound)
+        return EINVAL;
+    return session->backend->session_make_compound(session, functor, arity,
+               args, handle_out);
 }
 
 int
 wl_session_remove(wl_session_t *session, const char *relation,
-                  const int64_t *data, uint32_t num_rows, uint32_t num_cols)
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols)
 {
     if (!session || !session->backend || !session->backend->session_remove)
         return -1;
     return session->backend->session_remove(session, relation, data, num_rows,
-                                            num_cols);
+               num_cols);
 }
 
 int
@@ -77,7 +90,7 @@ wl_session_step(wl_session_t *session)
 
 void
 wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
-                        void *user_data)
+    void *user_data)
 {
     if (!session || !session->backend
         || !session->backend->session_set_delta_cb)
@@ -87,7 +100,7 @@ wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
 
 int
 wl_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
-                    void *user_data)
+    void *user_data)
 {
     if (!session || !session->backend || !session->backend->session_snapshot)
         return -1;

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -96,6 +96,27 @@ wl_session_insert(wl_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
 /**
+ * wl_session_make_compound:
+ * @session:    The active execution session.
+ * @functor:    Compound functor name.
+ * @arity:      Number of compound arguments.
+ * @args:       Argument values and declared scalar types.
+ * @handle_out: (out) Newly allocated session-local handle.
+ *
+ * Allocate a handle-backed side-tier compound and append its side-relation row.
+ *
+ * Returns:
+ *    0 on success.
+ *    ENOSPC if the compound arena is saturated.
+ *    EBUSY if the compound arena is temporarily frozen.
+ *    ENOMEM on allocation failure.
+ *    EINVAL or another errno-style value for invalid arguments/backend errors.
+ */
+int
+wl_session_make_compound(wl_session_t *session, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
+
+/**
  * wl_session_remove:
  * @session:   The active execution session.
  * @relation:  The null-terminated name of the relation to revoke facts from.

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -185,6 +185,13 @@ typedef enum {
     WIRELOG_COMPOUND_KIND_SIDE = 2,   /* f/N side-relation compound (default) */
 } wirelog_compound_kind_t;
 
+#define WIRELOG_COMPOUND_HANDLE_NULL ((uint64_t)0)
+
+typedef struct {
+    wirelog_column_type_t type;
+    int64_t value;
+} wirelog_compound_arg_t;
+
 /**
  * wirelog_column_t:
  *

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -92,6 +92,8 @@ typedef enum {
     WIRELOG_ERR_EXEC = 3,
     WIRELOG_ERR_MEMORY = 4,
     WIRELOG_ERR_IO = 5,
+    WIRELOG_ERR_COMPOUND_SATURATED = 6,
+    WIRELOG_ERR_COMPOUND_BUSY = 7,
     WIRELOG_ERR_UNKNOWN = 255,
 } wirelog_error_t;
 

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -211,9 +211,10 @@ wirelog_error_t
 wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
 {
+    if (handle_out)
+        *handle_out = WIRELOG_COMPOUND_HANDLE_NULL;
     if (!s || !functor || !args || arity == 0 || !handle_out)
         return WIRELOG_ERR_EXEC;
-    *handle_out = 0;
 
     wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -207,6 +207,33 @@ wl_easy_intern(wl_easy_session_t *s, const char *sym)
     return wl_intern_put(s->intern_mut, sym);
 }
 
+wirelog_error_t
+wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
+{
+    if (!s || !functor || !args || arity == 0 || !handle_out)
+        return WIRELOG_ERR_EXEC;
+    *handle_out = 0;
+
+    wirelog_error_t err = ensure_plan_built(s, s->num_workers);
+    if (err != WIRELOG_OK)
+        return err;
+
+    int rc = wl_session_make_compound(s->session, functor, arity, args,
+            handle_out);
+    if (rc == 0)
+        return WIRELOG_OK;
+    if (rc == ENOSPC)
+        return WIRELOG_ERR_COMPOUND_SATURATED;
+    if (rc == EBUSY)
+        return WIRELOG_ERR_COMPOUND_BUSY;
+    if (rc == ENOMEM)
+        return WIRELOG_ERR_MEMORY;
+    if (handle_out)
+        *handle_out = 0;
+    return WIRELOG_ERR_EXEC;
+}
+
 /* ======================================================================== */
 /* Insert / Remove                                                          */
 /* ======================================================================== */

--- a/wirelog/wl_easy.h
+++ b/wirelog/wl_easy.h
@@ -167,6 +167,30 @@ int64_t
 wl_easy_intern(wl_easy_session_t *s, const char *sym);
 
 /**
+ * wirelog_easy_make_compound:
+ * @s:          Open wl_easy session.
+ * @functor:    Compound functor name, e.g. "metadata".
+ * @arity:      Number of compound arguments.
+ * @args:       Row values for arg0..arg{arity-1}.
+ * @handle_out: (out) Receives a session-local compound handle.
+ *
+ * Allocate a handle-backed side-tier compound in the session-local compound
+ * arena and insert its side-relation row (`__compound_<functor>_<arity>`).
+ * The returned handle is valid only for this session.  Callers that rotate
+ * sessions must persist source-level argument values and rebuild handles in
+ * the fresh session; do not persist handles across `wl_easy_open()` calls.
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_COMPOUND_SATURATED when the arena
+ * refuses allocation after epoch saturation, WIRELOG_ERR_COMPOUND_BUSY when it
+ * is temporarily frozen, WIRELOG_ERR_MEMORY for allocation failure, or
+ * WIRELOG_ERR_EXEC for invalid arguments, plan/session build failure,
+ * side-relation registration failure, or insertion failure.
+ */
+wirelog_error_t
+wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
+
+/**
  * wl_easy_insert:
  * @s:        Open session.
  * @relation: Relation name (must not be NULL).


### PR DESCRIPTION
## Summary

Closes #647.
Closes #629.

Adds a public side-compound allocation path and updates `examples/13-daemon-style` so the daemon rotates on real compound-arena saturation rather than a caller-owned event watermark.

The PR now:
- exposes `wirelog_easy_make_compound()` for session-local side compound handles
- adds public compound saturation/busy errors and a public compound argument type
- creates side-relation rows through the backend/session boundary without public internal headers
- keeps daemon EDB state as source-level records and rebuilds intern IDs plus compound handles after rotation
- changes the daemon example to `metadata/4 side` and rotates on `WIRELOG_ERR_COMPOUND_SATURATED`
- documents the remaining side body-destructuring limitation while keeping the example allocation/rotation-focused

## Review Resolution

Reviewer concerns were handled in a follow-up commit:
- failure paths now clear `handle_out` before returning
- public compound argument type enum values are validated before allocation
- README direct-run, delta/idempotence wording, and the synthetic `pulse` recursion are documented accurately

Architect and critic meta-review agreed that full side compound body destructuring is a follow-up feature, not a blocker for #647/#629, because this PR honestly scopes the example to public side allocation and saturation-driven rotation.

## Validation

- `meson test -C build wl_easy example_13_daemon_style_smoke example_13_daemon_style_paced --print-errorlogs`
- `rm -rf build-629-asan build-629-tsan build-tsan`
- `meson setup build-629-asan -Db_sanitize=address -Db_lundef=false`
- `meson setup build-629-tsan -Db_sanitize=thread -Db_lundef=false`
- `meson compile -C build-629-asan daemon_style_demo`
- `meson test -C build-629-asan example_13_daemon_style_smoke example_13_daemon_style_paced --print-errorlogs`
- `meson compile -C build-629-tsan daemon_style_demo`
- `meson test -C build-629-tsan example_13_daemon_style_smoke example_13_daemon_style_paced --print-errorlogs`
- `git diff --check origin/main..HEAD`
