### PR TITLE
Clarify compound rotation API disposition

### DIFF
--- a/docs/STRESS_BASELINE.md
+++ b/docs/STRESS_BASELINE.md
@@ -488,10 +488,10 @@ The canary adds the residual #598 acceptance bullet:
 **Vacuous in production today**: `col_rel_deep_copy` has NO
 production callers in rotation paths today (verified by grep across
 `wirelog/`). Only `tests/test_col_rel_deep_copy.c` and
-`tests/col_rel_deep_copy_fixture.c` invoke it. The canary becomes
-load-bearing when #550-C `wl_session_rotate` ships: the cross-arena
-rotation helper will deep-copy live relations into the new arena,
-and any ledger churn would corrupt per-session memory accounting.
+`tests/col_rel_deep_copy_fixture.c` invoke it. The canary remains as
+cheap regression coverage for the deep-copy ledger contract; public
+daemon rotation is caller-owned close/open/replay, not an engine-owned
+cross-arena session helper.
 
 Registered in the default suite as `deep_copy_ledger_canary`.
 
@@ -655,9 +655,10 @@ needed).
   W=8 invocation runs manually per the script above. Adding an
   automated release pipeline is a separate (follow-up) issue.
 - **Cross-arena rotation workload**: this harness exercises the
-  *in-place* apply pass (#589 / #590). Cross-arena rotation needs
-  the #550 Option C `wl_session_rotate` helper, which has not
-  landed; a sibling workload will be added when #550-C ships.
+  *in-place* apply pass (#589 / #590). #550 Option C was declined;
+  public daemon rotation is validated through caller-owned
+  close/open/replay coverage instead of an engine-owned cross-arena
+  session helper.
 - **Existing hardcoded canaries**: `test_compound_arena_freeze_
   cycle_stress.c` (#582), `test_gc_freeze_alloc_race.c` (#584),
   and `test_worker_borrow_w2_tsan.c` (#592) are intentionally

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -59,18 +59,12 @@ already-known rows after rotation. The pattern is deliberately conservative and
 demonstrates the lifecycle shape without including internal headers such as
 `wirelog/columnar/internal.h`.
 
-## Remaining Engine Work
+## Rotation Contract
 
-The example still keeps EDB ownership in application code. A future
-engine-owned rotation primitive could replace the manual close/open/replay
-sequence:
-
-```diff
-- wl_easy_close(old);
-- wl_easy_open(program, &fresh);
-- replay_edb(fresh, &edb);
-+ wl_session_rotate(session);
-```
+The example keeps EDB ownership in application code by design. #550's
+engine-owned rotation helper proposal was declined, so the supported public
+contract is to close the saturated session, open a fresh session, replay
+caller-owned durable EDB facts, and retry the current allocation.
 
 ## Build & Run
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2490,8 +2490,8 @@ test('compound_side_relation', test_compound_side_relation_exe)
 # Compound arena freeze-cycle stress (Issue #582)
 # Concurrent workers + many freeze/unfreeze cycles on a borrowed arena.
 # Heavy under TSan; timeout extended.  Note: this is the in-arena freeze
-# cycle, NOT the cross-arena rotation that #550 Option C will introduce;
-# a sibling test will own that path.
+# cycle, not public daemon rotation. #550 Option C was declined; public
+# daemon rotation is covered by the caller-owned replay example.
 # ============================================================================
 
 test_compound_arena_freeze_cycle_stress_exe = executable(
@@ -2917,7 +2917,7 @@ test('rotate_latency_release_pinned', test_rotate_latency_exe,
 # ----------------------------------------------------------------------------
 # deep_copy ledger-charge canary (Issue #598)
 # Vacuous today (col_rel_deep_copy has no production rotation callers);
-# regression canary for #550-C wl_session_rotate.
+# regression canary for the deep-copy ledger contract.
 # ----------------------------------------------------------------------------
 
 test_deep_copy_ledger_canary_exe = executable(

--- a/tests/test_col_rel_deep_copy.c
+++ b/tests/test_col_rel_deep_copy.c
@@ -726,8 +726,8 @@ test_deep_copy_remap_metadata_preserved(void)
      * inline) and Group I/J zero-state helper
      * (deep_copy_fixture_assert_design_invariants) already prove the
      * underlying behaviour, but #587's acceptance bullets call for three
-     * named assertions in one place so a future remap caller (#588 +
-     * #550 Option C) can rely on the contract without grep-archaeology:
+     * named assertions in one place so remap callers can rely on the
+     * contract without grep-archaeology:
      *
      *   1. compound_arity_map deep-copied (non-NULL, non-aliased,
      *      value-equal, mutation-isolated -- Group G)

--- a/tests/test_compound_arena_freeze_cycle_stress.c
+++ b/tests/test_compound_arena_freeze_cycle_stress.c
@@ -14,11 +14,10 @@
  * pair) so the freeze flag, lookup table, and live_handles counter
  * are visible to workers without explicit atomics.
  *
- * Note on naming: this is a freeze-cycle test, NOT an arena-rotation
- * test in the #550-C sense (rotate to a fresh arena while workers are
- * mid-flight).  Issue #582 used the word "rotation" loosely to mean
- * "iteration cycle".  When #550-C lands, a sibling test will exercise
- * the cross-arena swap path; this harness pins the in-arena cycle.
+ * Note on naming: this is a freeze-cycle test, NOT public daemon rotation.
+ * Issue #582 used the word "rotation" loosely to mean "iteration cycle".
+ * #550 Option C was declined; public daemon rotation is covered by
+ * caller-owned close/open/replay tests.
  *
  * Two configurations exercised:
  *   - W = 4, 500 cycles  (smaller fan-out, more turn-around per worker)
@@ -95,10 +94,10 @@ run_freeze_cycle_stress(uint32_t num_workers, uint32_t cycles,
     /* Bound check (test contract): each cycle advances current_epoch by
      * one (gc_epoch_boundary at cycle tail), so the configured cycle
      * count must fit within the arena's epoch cap.  We deliberately do
-     * NOT recover from saturation here — that's the cross-arena swap
-     * path Option C in #550 introduces, and a sibling test will own it.
-     * Keeping the bound assertion explicit makes accidental saturation
-     * loud instead of silently re-creating the arena under workers. */
+     * NOT recover from saturation here. Public daemon rotation is covered
+     * by caller-owned close/open/replay tests. Keeping the bound assertion
+     * explicit makes accidental saturation loud instead of silently
+     * re-creating the arena under workers. */
     if (cycles >= arena->max_epochs) {
         printf("FAIL: requested cycles=%u exceeds max_epochs=%u\n",
             cycles, arena->max_epochs);

--- a/tests/test_deep_copy_ledger_canary.c
+++ b/tests/test_deep_copy_ledger_canary.c
@@ -25,10 +25,9 @@
  * Vacuous in production today (col_rel_deep_copy has NO production
  * callers in rotation paths -- verified by grep across wirelog/).  Only
  * tests/test_col_rel_deep_copy.c and tests/col_rel_deep_copy_fixture.c
- * invoke it.  Becomes load-bearing when #550-C wl_session_rotate ships:
- * the cross-arena rotation helper will deep-copy the live relations into
- * the new arena, and any ledger churn would corrupt the per-session
- * memory accounting.
+ * invoke it.  It remains cheap regression coverage for the deep-copy ledger
+ * contract; public daemon rotation is caller-owned close/open/replay, not an
+ * engine-owned cross-arena session helper.
  */
 
 #include "../wirelog/columnar/internal.h"

--- a/tests/test_handle_remap_apply.c
+++ b/tests/test_handle_remap_apply.c
@@ -7,9 +7,8 @@
  *
  * Drives wl_handle_remap_apply_columns end-to-end against a 10K-row x
  * 3-compound-column fixture, the size #589 pins as the acceptance
- * test.  The fixture builds the remap table by hand (the rotation
- * helper that would normally populate it is #550 Option C, not yet
- * implemented), so this is unit-style coverage of the apply pass +
+ * test.  The fixture builds the remap table by hand because this is
+ * unit-style coverage of the apply pass +
  * the underlying SplitMix64 / open-addressing table together.
  *
  * Acceptance bullets the test pins:

--- a/tests/test_post_remap_invalidate.c
+++ b/tests/test_post_remap_invalidate.c
@@ -22,8 +22,7 @@
  *   4. NULL session is rejected with EINVAL.
  *
  * The test does NOT also call the apply pass; the invalidation
- * helper is independent and the rotation helper (#550-C) calls it
- * after a successful apply.  Calling it standalone here pins the
+ * helper is independent. Calling it standalone here pins the
  * pure-invalidation behaviour without entangling #589/#590 again.
  */
 

--- a/tests/test_stress_harness.c
+++ b/tests/test_stress_harness.c
@@ -33,9 +33,9 @@
  *       wl_handle_remap_apply_columns is single-mutator by contract;
  *       W is accepted as input but ignored, with a one-line note
  *       printed to keep CI tier wiring uniform across workloads.
- *       (No #550 Option C rotation helper required: the apply pass
- *       rewrites the same arena in place; cross-arena swap is a
- *       separate concern that needs its own sibling test.)
+ *       (No engine-owned rotation helper required: the apply pass
+ *       rewrites the same arena in place; public daemon rotation is
+ *       caller-owned close/open/replay coverage.)
  *
  *   "daemon-soak" (#597):
  *       Long-running soak that proves bounded-RSS behavior under

--- a/wirelog/arena/compound_arena.h
+++ b/wirelog/arena/compound_arena.h
@@ -304,9 +304,7 @@ wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena);
  *
  * Return the current live-handle population of @arena (the value of
  * @arena->live_handles), or 0 if @arena is NULL.  Introspection-only
- * accessor used by the rotation-helper path (Issue #586): the remap
- * table sizes itself against this number when migrating compound
- * handles into a fresh session (#562 / #550 Option C).
+ * accessor used by internal remap sizing paths (Issue #586).
  *
  * Stability: NOT stable across rotations or during live K-Fusion
  * worker access.  Callers must invoke this either while the arena

--- a/wirelog/columnar/handle_remap_apply.h
+++ b/wirelog/columnar/handle_remap_apply.h
@@ -10,12 +10,10 @@
  * Row-scan helpers that rewrite compound handles in a col_rel_t's
  * column buffers using a build-then-query wl_handle_remap_t.
  *
- * Used by the rotation helper (#550 Option C) to repoint EDB rows
- * from the old session's compound arena to the new session's arena
- * after a handle-renumbering pass.  The pass is single-threaded and
- * runs while the compound arena is frozen (#561 / #584 freeze
- * contract), so the table itself does not need internal
- * synchronisation.
+ * Used by internal remap callers to repoint EDB rows after a
+ * handle-renumbering pass.  The pass is single-threaded and runs while
+ * the compound arena is frozen (#561 / #584 freeze contract), so the
+ * table itself does not need internal synchronisation.
  *
  * Algorithm
  * ---------
@@ -71,9 +69,8 @@
  *         and column k is rewritten through row r-1, where (r, k) is
  *         the failing cell; (r, k) and beyond are unchanged.
  *         @out_rewrites reflects exactly that prefix.  The relation
- *         is in a half-rotated state — the caller (rotation helper,
- *         #550 Option C) MUST treat it as poisoned: discard, restore
- *         from a snapshot, or abort the rotation.  There is no
+ *         is in a half-remapped state; the caller MUST treat it as
+ *         poisoned: discard, restore from a snapshot, or abort.  There is no
  *         in-band roll-back primitive.
  */
 int

--- a/wirelog/columnar/handle_remap_apply_side.h
+++ b/wirelog/columnar/handle_remap_apply_side.h
@@ -27,9 +27,9 @@
  *      "__compound_<functor>_<arity>" name prefix (#580 convention),
  *      and rewrites column 0 of each match.  Nested-arg rewrites
  *      stay caller-driven because there is no schema-level "this
- *      arg holds a handle" tag today; callers that know the nested
- *      structure (rotation helper #550 Option C) iterate side-
- *      relations themselves and call the per-relation primitive.
+ *      arg holds a handle" tag today; internal callers that know the
+ *      nested structure iterate side-relations themselves and call the
+ *      per-relation primitive.
  *
  * Multiplicity (Z-set) is preserved by construction: the apply pass
  * touches col_rel_t::columns[][] only; col_rel_t::timestamps[] (which
@@ -149,9 +149,8 @@ wl_handle_remap_apply_session_side_relations(struct wl_col_session_t *sess,
  *
  * Out of scope for #591 (call out for #598 / follow-up):
  *   - mat_cache is content-keyed and may carry stale join results
- *     over remapped sources.  Whether to clear or accept the
- *     content-hash miss is left to the rotation helper (#550-C);
- *     this pass does NOT touch mat_cache.
+ *     over remapped sources.  Cache policy for remap callers remains
+ *     outside this pass; this pass does NOT touch mat_cache.
  *   - sarr_entries (sorted-by-key permutations) are not currently
  *     touched by col_session_invalidate_arrangements.  Side-
  *     relations are not expected to have sarr entries today, so

--- a/wirelog/columnar/handle_remap_design.md
+++ b/wirelog/columnar/handle_remap_design.md
@@ -168,13 +168,14 @@ The minimum capacity is 16 (small enough not to matter; large enough
 that the rounding doesn't dominate). This is an implementation detail
 and not exposed through the API.
 
-### 2.8 Initial capacity for rotation evacuation (Issue #586)
+### 2.8 Initial capacity for bulk remap paths (Issue #586)
 
-When the table is created on the rotation-helper path
-(`wl_session_rotate`, #550 Option C / blocked by #562), the caller
+When the table is created for a bulk handle-remap path, the caller
 already knows the live-handle population it is about to migrate:
-`wl_compound_arena_t.live_handles`.  The contract is one-sided to
-avoid double-counting the load-factor headroom against §4.1:
+`wl_compound_arena_t.live_handles`. The contract is one-sided to
+avoid double-counting the load-factor headroom against §4.1. Public
+daemon rotation does not use this path; #550 Option C was declined in
+favor of caller-owned close/open/replay.
 
   - Caller passes the raw `live_handles` value to
     `wl_handle_remap_create(capacity, &out)`.  Do NOT pre-divide by


### PR DESCRIPTION
## Summary

Clarify the final codebase disposition for #550's compound rotation API proposal.

This updates stale docs and comments that still described #550 Option C (`wl_session_rotate`) as future work. After #646, the supported public contract is narrower: callers observe `WIRELOG_ERR_COMPOUND_SATURATED`, close/open a fresh session, replay caller-owned durable EDB facts, and retry the current allocation.

## Why

#646 provided the public saturation signal and daemon example needed by long-running callers without exposing the internal epoch, callback, or engine-owned rotation helper proposed in #550 A/B/C. Leaving comments that said Option C would eventually ship made the codebase inconsistent with that decision.

## Validation

- `meson compile -C build test_wl_easy daemon_style_demo test_compound_arena_freeze_cycle_stress test_handle_remap_apply test_post_remap_invalidate test_deep_copy_ledger_canary`
- `meson test -C build wl_easy example_13_daemon_style_smoke compound_arena_freeze_cycle_stress handle_remap_apply post_remap_invalidate deep_copy_ledger_canary --print-errorlogs`

## Follow-up

After this lands, #550 can be closed as declined for A/B/C with #646's saturation-driven replay pattern as the accepted public API direction.
