### PR TITLE
Add TDD profiling counters to flowlog benchmark

### DIFF
--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -61,6 +61,15 @@ static uint64_t g_last_consolidate_fast_hits = 0;
 static uint64_t g_last_consolidate_slow_hits = 0;
 /* Exchange barrier timing (Issue #413): serial fraction measurement */
 static uint64_t g_last_exchange_ns = 0;
+/* Last successful trial wall time, paired with last-run profiling counters. */
+static double g_last_wall_ms = 0.0;
+/* TDD recursive profiling counters (#650). */
+static uint64_t g_last_tdd_total_ns = 0;
+static uint64_t g_last_tdd_dispatch_wait_ns = 0;
+static uint64_t g_last_tdd_queue_drain_ns = 0;
+static uint64_t g_last_tdd_convergence_ns = 0;
+static uint64_t g_last_tdd_exchange_ns = 0;
+static uint64_t g_last_tdd_final_merge_ns = 0;
 
 #ifndef WITH_K_FUSION
 #define WITH_K_FUSION 1
@@ -328,6 +337,10 @@ run_pipeline_count(const char *source, uint32_t num_workers, int64_t *out_count,
     col_session_get_consolidation_stats(sess, &g_last_consolidate_fast_hits,
         &g_last_consolidate_slow_hits);
     col_session_get_exchange_time_ns(sess, &g_last_exchange_ns);
+    col_session_get_tdd_perf_stats(sess, &g_last_tdd_total_ns,
+        &g_last_tdd_dispatch_wait_ns, &g_last_tdd_queue_drain_ns,
+        &g_last_tdd_convergence_ns, &g_last_tdd_exchange_ns,
+        &g_last_tdd_final_merge_ns);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -401,6 +414,7 @@ run_workload(int wl_id, const char *data_path, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -536,6 +550,7 @@ run_andersen_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -669,6 +684,7 @@ run_dyck_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -794,6 +810,7 @@ run_cspa_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -1293,6 +1310,7 @@ run_csda_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -1425,6 +1443,7 @@ run_galen_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -1690,6 +1709,7 @@ run_polonius_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -1883,6 +1903,7 @@ run_ddisasm_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -2057,6 +2078,7 @@ run_crdt_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -2628,6 +2650,7 @@ run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
             status_ok = 0;
             break;
         }
+        g_last_wall_ms = times[r];
         tuples = cnt;
         total_iters = iters;
     }
@@ -2668,8 +2691,8 @@ run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
 /*
  * output_json_row: emit one benchmark result as a JSON object (3B-003).
  *
- * Percentages are computed relative to median wall time.
- * consolidation_ns and kfusion_ns come from g_last_* (last run only).
+ * Whole-run percentages use median wall time.  Last-run profiling fractions
+ * use g_last_wall_ms so numerator and denominator come from the same trial.
  * evaluation_pct = 100 - consolidation_pct - kfusion_pct (residual).
  */
 static void
@@ -2682,6 +2705,9 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
     uint64_t exchange_ns)
 {
     double wall_ns = median_ms * 1e6;
+    double profiling_wall_ns = g_last_wall_ms > 0.0
+        ? g_last_wall_ms * 1e6
+        : wall_ns;
     double cons_pct
         = wall_ns > 0 ? 100.0 * (double)consolidation_ns / wall_ns : 0.0;
     double kfus_pct = wall_ns > 0 ? 100.0 * (double)kfusion_ns / wall_ns : 0.0;
@@ -2744,7 +2770,9 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
      * Dispatch time (alloc → worker parallelism → merge) is already factored in. */
     double kf_serial_ns = (double)kfusion_alloc_ns + (double)kfusion_merge_ns
         + (double)kfusion_cleanup_ns;
-    double kf_serial_frac = wall_ns > 0 ? kf_serial_ns / wall_ns : 0.0;
+    double kf_serial_frac = profiling_wall_ns > 0
+        ? kf_serial_ns / profiling_wall_ns
+        : 0.0;
     printf("  \"kfusion_serial_ms\": %.3f,\n", kf_serial_ns / 1e6);
     printf("  \"kfusion_serial_fraction\": %.4f,\n", kf_serial_frac);
     /* Exchange barrier timing (Issue #413): fraction of wall time in serial
@@ -2753,9 +2781,35 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
      * This is a lower bound on the true Amdahl serial fraction f — queue
      * drain and convergence check are not included. */
     double exch_ms = (double)exchange_ns / 1e6;
-    double exch_frac = wall_ns > 0 ? (double)exchange_ns / wall_ns : 0.0;
+    double exch_frac = profiling_wall_ns > 0
+        ? (double)exchange_ns / profiling_wall_ns
+        : 0.0;
     printf("  \"exchange_ms\": %.3f,\n", exch_ms);
     printf("  \"exchange_fraction\": %.4f,\n", exch_frac);
+    double tdd_phase_ns = (double)g_last_tdd_dispatch_wait_ns
+        + (double)g_last_tdd_queue_drain_ns
+        + (double)g_last_tdd_convergence_ns
+        + (double)g_last_tdd_exchange_ns
+        + (double)g_last_tdd_final_merge_ns;
+    double tdd_total_pct = profiling_wall_ns > 0
+        ? 100.0 * (double)g_last_tdd_total_ns / profiling_wall_ns
+        : 0.0;
+    double tdd_accounted_pct = g_last_tdd_total_ns > 0
+        ? 100.0 * tdd_phase_ns / (double)g_last_tdd_total_ns
+        : 0.0;
+    printf("  \"profiling_wall_ms\": %.3f,\n", g_last_wall_ms);
+    printf("  \"tdd_total_ms\": %.3f,\n",
+        (double)g_last_tdd_total_ns / 1e6);
+    printf("  \"tdd_total_pct\": %.1f,\n", tdd_total_pct);
+    printf("  \"tdd_phase_ms\": {\"dispatch_wait\": %.4f, "
+        "\"queue_drain\": %.4f, \"convergence\": %.4f, "
+        "\"exchange\": %.4f, \"final_merge\": %.4f},\n",
+        (double)g_last_tdd_dispatch_wait_ns / 1e6,
+        (double)g_last_tdd_queue_drain_ns / 1e6,
+        (double)g_last_tdd_convergence_ns / 1e6,
+        (double)g_last_tdd_exchange_ns / 1e6,
+        (double)g_last_tdd_final_merge_ns / 1e6);
+    printf("  \"tdd_accounted_pct\": %.1f,\n", tdd_accounted_pct);
     printf("  \"profiling_from_last_run\": true\n");
     printf("}\n");
 }

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -350,9 +350,9 @@ col_session_get_consolidation_stats(wl_session_t *sess,
 /**
  * col_session_get_exchange_time_ns:
  *
- * Return total nanoseconds spent in exchange barriers (tdd_exchange_deltas /
- * tdd_bdx_exchange_deltas) across the last wl_session_snapshot() call.
- * out_exchange_ns is NULL-safe.
+ * Return legacy coordinator serial time across the last wl_session_snapshot()
+ * call.  This includes recursive TDD exchange scatter/gather and the
+ * non-recursive TDD coordinator merge path.  out_exchange_ns is NULL-safe.
  *
  * @param sess            A wl_session_t* backed by the columnar backend.
  * @param out_exchange_ns Accumulated exchange wall time in nanoseconds.
@@ -360,6 +360,28 @@ col_session_get_consolidation_stats(wl_session_t *sess,
 void
 col_session_get_exchange_time_ns(wl_session_t *sess,
     uint64_t *out_exchange_ns);
+
+/**
+ * col_session_get_tdd_perf_stats:
+ *
+ * Return recursive TDD evaluator profiling counters accumulated across the
+ * last wl_session_snapshot() call.  These counters expose the current
+ * queue-assisted after-barrier path for benchmark measurement only.
+ * All out-parameters are NULL-safe.
+ *
+ * @param sess                 A wl_session_t* backed by the columnar backend.
+ * @param out_total_ns         Total recursive TDD evaluator wall time.
+ * @param out_dispatch_wait_ns Submit loop plus wl_workqueue_wait_all time.
+ * @param out_queue_drain_ns   MPSC drain plus delta matrix reconstruction time.
+ * @param out_convergence_ns   Worker empty-delta and convergence checks.
+ * @param out_exchange_ns      Recursive TDD exchange scatter/gather time.
+ * @param out_final_merge_ns   Final coordinator worker-result merge/dedup time.
+ */
+void
+col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
+    uint64_t *out_dispatch_wait_ns, uint64_t *out_queue_drain_ns,
+    uint64_t *out_convergence_ns, uint64_t *out_exchange_ns,
+    uint64_t *out_final_merge_ns);
 
 /**
  * col_session_get_darr_count:

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4023,6 +4023,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     uint32_t W = coord->num_workers;
     uint32_t nrels = sp->relation_count;
     int rc = 0;
+    uint64_t tdd_total_t0 = now_ns();
 
     /* Pre-register empty IDB relations on coordinator (eval.c:291-304) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -4030,11 +4031,14 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             continue;
         col_rel_t *empty = NULL;
         int alloc_rc = col_rel_alloc(&empty, sp->relations[ri].name);
-        if (alloc_rc != 0)
+        if (alloc_rc != 0) {
+            coord->tdd_total_ns += now_ns() - tdd_total_t0;
             return ENOMEM;
+        }
         alloc_rc = session_add_rel(coord, empty);
         if (alloc_rc != 0) {
             col_rel_destroy(empty);
+            coord->tdd_total_ns += now_ns() - tdd_total_t0;
             return alloc_rc;
         }
     }
@@ -4096,13 +4100,16 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         rc = tdd_replicate_workers(coord);
     else
         rc = tdd_init_workers_hybrid(sp, coord);
-    if (rc != 0)
+    if (rc != 0) {
+        coord->tdd_total_ns += now_ns() - tdd_total_t0;
         return rc;
+    }
 
     /* Pre-register empty IDB on each worker */
     rc = tdd_preregister_idb_on_workers(sp, coord);
     if (rc != 0) {
         tdd_cleanup_workers(coord);
+        coord->tdd_total_ns += now_ns() - tdd_total_t0;
         return rc;
     }
 
@@ -4129,12 +4136,14 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             col_rel_t *slot = col_rel_new_auto(dname, ncols_ri);
             if (!slot) {
                 tdd_cleanup_workers(coord);
+                coord->tdd_total_ns += now_ns() - tdd_total_t0;
                 return ENOMEM;
             }
             rc = session_add_rel(&coord->tdd_workers[w], slot);
             if (rc != 0) {
                 col_rel_destroy(slot);
                 tdd_cleanup_workers(coord);
+                coord->tdd_total_ns += now_ns() - tdd_total_t0;
                 return rc;
             }
         }
@@ -4353,6 +4362,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
 
             /* DISPATCH */
             bool submit_ok = true;
+            uint64_t dispatch_t0 = now_ns();
             for (uint32_t w = 0; w < W; w++) {
                 if (wl_workqueue_submit(coord->wq, tdd_worker_subpass_fn,
                     &ctxs[w]) != 0) {
@@ -4372,6 +4382,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
 
             /* BARRIER */
             wl_workqueue_wait_all(coord->wq);
+            coord->tdd_dispatch_wait_ns += now_ns() - dispatch_t0;
 
             /* Collect first worker error */
             for (uint32_t w = 0; w < W; w++) {
@@ -4390,6 +4401,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * ctxs[w].delta_rels[ri] via adapter.  Workers dual-write to both
              * ctx and queue; shadow assert verifies agreement (debug only). */
             if (coord->delta_queue) {
+                uint64_t queue_t0 = now_ns();
                 uint32_t max_msgs = W * nrels;
                 wl_delta_msg_t *msgs = (wl_delta_msg_t *)calloc(
                     max_msgs > 0 ? max_msgs : 1u, sizeof(wl_delta_msg_t));
@@ -4405,7 +4417,10 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                         W, nrels);
                     free(msgs);
                 }
+                coord->tdd_queue_drain_ns += now_ns() - queue_t0;
             }
+
+            uint64_t convergence_t0 = now_ns();
 
             /* Stratum-level early exit: all workers have all_empty_delta */
             bool all_workers_empty = true;
@@ -4416,6 +4431,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 }
             }
             if (all_workers_empty) {
+                coord->tdd_convergence_ns += now_ns() - convergence_t0;
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
                         col_rel_destroy(ctxs[w].delta_rels[ri]);
@@ -4438,12 +4454,14 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * detection.
              */
             if (tdd_check_convergence(ctxs, W)) {
+                coord->tdd_convergence_ns += now_ns() - convergence_t0;
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
                         col_rel_destroy(ctxs[w].delta_rels[ri]);
                 converged = true;
                 break;
             }
+            coord->tdd_convergence_ns += now_ns() - convergence_t0;
 
             /* EXCHANGE: BDX for Category C, hash scatter/gather for
              * standard hybrid, broadcast for replicate/self_join_mode.
@@ -4458,7 +4476,9 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 else
                     brc = tdd_exchange_deltas(sp, coord, ctxs, W,
                             !replicate_mode, self_join_mode);
-                coord->exchange_time_ns += now_ns() - t0;
+                uint64_t exchange_ns = now_ns() - t0;
+                coord->exchange_time_ns += exchange_ns;
+                coord->tdd_exchange_ns += exchange_ns;
             }
 
             if (brc != 0) {
@@ -4506,14 +4526,17 @@ done:
         if (bdx_mode) {
             /* BDX mode: coordinator IDB is already maintained (monotonic
              * growth via tdd_bdx_exchange_deltas).  Just dedup final. */
+            uint64_t merge_t0 = now_ns();
             for (uint32_t ri = 0; ri < nrels; ri++) {
                 col_rel_t *r = session_find_rel(coord,
                         sp->relations[ri].name);
                 if (r && r->nrows > 1)
                     tdd_dedup_rel(r);
             }
+            coord->tdd_final_merge_ns += now_ns() - merge_t0;
         } else {
             /* Non-BDX: Merge worker IDB into coordinator */
+            uint64_t merge_t0 = now_ns();
             rc = tdd_merge_worker_results(sp, coord);
 
             /* Dedup coordinator IDB (broadcast exchange may introduce
@@ -4526,10 +4549,12 @@ done:
                         tdd_dedup_rel(r);
                 }
             }
+            coord->tdd_final_merge_ns += now_ns() - merge_t0;
         }
     }
 
     tdd_cleanup_workers(coord);
+    coord->tdd_total_ns += now_ns() - tdd_total_t0;
     return rc;
 }
 

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -842,6 +842,16 @@ typedef struct wl_col_session_t {
      * for Amdahl's Law validation at varying worker counts W.
      * Coordinator-only; reset at the start of each wl_session_snapshot(). */
     uint64_t exchange_time_ns;
+    /* TDD recursive evaluator profiling (#650).  These counters split the
+     * current queue-assisted after-barrier path into phases that can be
+     * compared across W=4/W=8/W=16 before choosing an async/exchange change.
+     * Coordinator-only; reset at the start of each wl_session_snapshot(). */
+    uint64_t tdd_total_ns;
+    uint64_t tdd_dispatch_wait_ns;
+    uint64_t tdd_queue_drain_ns;
+    uint64_t tdd_convergence_ns;
+    uint64_t tdd_exchange_ns;
+    uint64_t tdd_final_merge_ns;
     /* Phase 4: tracks which relation was just inserted via
      * col_session_insert_incremental, enables affected-stratum skip
      * optimization. Borrowed pointer; lifetime: until next session_step.

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -253,9 +253,9 @@ col_session_get_consolidation_stats(wl_session_t *sess,
 /*
  * col_session_get_exchange_time_ns:
  *
- * Return total nanoseconds spent in tdd_exchange_deltas /
- * tdd_bdx_exchange_deltas (scatter/gather barriers) across the last
- * wl_session_snapshot() call.  out_exchange_ns is NULL-safe.
+ * Return legacy coordinator serial time across the last wl_session_snapshot()
+ * call.  This includes recursive TDD exchange scatter/gather and the
+ * non-recursive TDD coordinator merge path.  out_exchange_ns is NULL-safe.
  */
 void
 col_session_get_exchange_time_ns(wl_session_t *sess,
@@ -264,6 +264,35 @@ col_session_get_exchange_time_ns(wl_session_t *sess,
     wl_col_session_t *cs = COL_SESSION(sess);
     if (out_exchange_ns)
         *out_exchange_ns = cs->exchange_time_ns;
+}
+
+/*
+ * col_session_get_tdd_perf_stats:
+ *
+ * Return recursive TDD evaluator profiling counters from the last
+ * wl_session_snapshot() call.  The counters expose the current
+ * queue-assisted after-barrier implementation without changing execution.
+ * All out-parameters are NULL-safe.
+ */
+void
+col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
+    uint64_t *out_dispatch_wait_ns, uint64_t *out_queue_drain_ns,
+    uint64_t *out_convergence_ns, uint64_t *out_exchange_ns,
+    uint64_t *out_final_merge_ns)
+{
+    wl_col_session_t *cs = COL_SESSION(sess);
+    if (out_total_ns)
+        *out_total_ns = cs->tdd_total_ns;
+    if (out_dispatch_wait_ns)
+        *out_dispatch_wait_ns = cs->tdd_dispatch_wait_ns;
+    if (out_queue_drain_ns)
+        *out_queue_drain_ns = cs->tdd_queue_drain_ns;
+    if (out_convergence_ns)
+        *out_convergence_ns = cs->tdd_convergence_ns;
+    if (out_exchange_ns)
+        *out_exchange_ns = cs->tdd_exchange_ns;
+    if (out_final_merge_ns)
+        *out_final_merge_ns = cs->tdd_final_merge_ns;
 }
 
 /*
@@ -1781,6 +1810,12 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     sess->consolidate_fast_hits = 0;
     sess->consolidate_slow_hits = 0;
     sess->exchange_time_ns = 0;
+    sess->tdd_total_ns = 0;
+    sess->tdd_dispatch_wait_ns = 0;
+    sess->tdd_queue_drain_ns = 0;
+    sess->tdd_convergence_ns = 0;
+    sess->tdd_exchange_ns = 0;
+    sess->tdd_final_merge_ns = 0;
 
     /* Phase 4 incremental skip: when last_inserted_relation is set, only
      * re-evaluate strata that transitively depend on the inserted relation.


### PR DESCRIPTION
## Summary

Adds benchmark-facing profiling for the current recursive TDD evaluator path so issue #650 can collect measured W=4/W=8/W=16 data before choosing an exchange or async implementation.

## Changes

- Track recursive TDD total time, dispatch/wait, MPSC queue drain/reconstruction, convergence checks, recursive exchange, and final merge/dedup time.
- Expose the counters through the columnar backend profiling getter.
- Emit the new fields from `bench_flowlog --format json` alongside the existing legacy `exchange_ms` output.
- Pair last-run profiling fractions with `profiling_wall_ms` from the same successful trial.
- Clarify that the legacy exchange counter also includes the non-recursive TDD coordinator merge path.

## Validation

- `meson compile -C build bench_flowlog`
- `meson test -C build lockfree_queue workqueue_capacity queue_transport doop_multiworker bench_argv --print-errorlogs`
- `git diff --check`
- `./build/bench/bench_flowlog --workload tc --data bench/data/graph_10.csv --workers 4 --repeat 1 --format json`

## Notes

This is intentionally measurement-only. It does not change the TDD transport, exchange, barrier, convergence, or fixpoint semantics.

Refs #650
