### PR TITLE
Split recursive TDD dispatch profiling

### DIFF
--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -66,6 +66,11 @@ static double g_last_wall_ms = 0.0;
 /* TDD recursive profiling counters (#650). */
 static uint64_t g_last_tdd_total_ns = 0;
 static uint64_t g_last_tdd_dispatch_wait_ns = 0;
+static uint64_t g_last_tdd_submit_loop_ns = 0;
+static uint64_t g_last_tdd_wait_barrier_ns = 0;
+static uint64_t g_last_tdd_worker_sum_ns = 0;
+static uint64_t g_last_tdd_worker_max_ns = 0;
+static uint64_t g_last_tdd_idle_estimate_ns = 0;
 static uint64_t g_last_tdd_queue_drain_ns = 0;
 static uint64_t g_last_tdd_convergence_ns = 0;
 static uint64_t g_last_tdd_exchange_ns = 0;
@@ -338,7 +343,10 @@ run_pipeline_count(const char *source, uint32_t num_workers, int64_t *out_count,
         &g_last_consolidate_slow_hits);
     col_session_get_exchange_time_ns(sess, &g_last_exchange_ns);
     col_session_get_tdd_perf_stats(sess, &g_last_tdd_total_ns,
-        &g_last_tdd_dispatch_wait_ns, &g_last_tdd_queue_drain_ns,
+        &g_last_tdd_dispatch_wait_ns, &g_last_tdd_submit_loop_ns,
+        &g_last_tdd_wait_barrier_ns, &g_last_tdd_worker_sum_ns,
+        &g_last_tdd_worker_max_ns, &g_last_tdd_idle_estimate_ns,
+        &g_last_tdd_queue_drain_ns,
         &g_last_tdd_convergence_ns, &g_last_tdd_exchange_ns,
         &g_last_tdd_final_merge_ns);
 
@@ -971,7 +979,10 @@ run_tdd_bdx_pipeline(const int64_t *rows, uint32_t edge_count,
         &g_last_consolidate_slow_hits);
     col_session_get_exchange_time_ns(sess, &g_last_exchange_ns);
     col_session_get_tdd_perf_stats(sess, &g_last_tdd_total_ns,
-        &g_last_tdd_dispatch_wait_ns, &g_last_tdd_queue_drain_ns,
+        &g_last_tdd_dispatch_wait_ns, &g_last_tdd_submit_loop_ns,
+        &g_last_tdd_wait_barrier_ns, &g_last_tdd_worker_sum_ns,
+        &g_last_tdd_worker_max_ns, &g_last_tdd_idle_estimate_ns,
+        &g_last_tdd_queue_drain_ns,
         &g_last_tdd_convergence_ns, &g_last_tdd_exchange_ns,
         &g_last_tdd_final_merge_ns);
 
@@ -2946,9 +2957,17 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
         (double)g_last_tdd_total_ns / 1e6);
     printf("  \"tdd_total_pct\": %.1f,\n", tdd_total_pct);
     printf("  \"tdd_phase_ms\": {\"dispatch_wait\": %.4f, "
+        "\"submit_loop\": %.4f, \"wait_barrier\": %.4f, "
+        "\"worker_sum\": %.4f, \"worker_max\": %.4f, "
+        "\"idle_estimate\": %.4f, "
         "\"queue_drain\": %.4f, \"convergence\": %.4f, "
         "\"exchange\": %.4f, \"final_merge\": %.4f},\n",
         (double)g_last_tdd_dispatch_wait_ns / 1e6,
+        (double)g_last_tdd_submit_loop_ns / 1e6,
+        (double)g_last_tdd_wait_barrier_ns / 1e6,
+        (double)g_last_tdd_worker_sum_ns / 1e6,
+        (double)g_last_tdd_worker_max_ns / 1e6,
+        (double)g_last_tdd_idle_estimate_ns / 1e6,
         (double)g_last_tdd_queue_drain_ns / 1e6,
         (double)g_last_tdd_convergence_ns / 1e6,
         (double)g_last_tdd_exchange_ns / 1e6,

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -372,6 +372,11 @@ col_session_get_exchange_time_ns(wl_session_t *sess,
  * @param sess                 A wl_session_t* backed by the columnar backend.
  * @param out_total_ns         Total recursive TDD evaluator wall time.
  * @param out_dispatch_wait_ns Submit loop plus wl_workqueue_wait_all time.
+ * @param out_submit_loop_ns   Workqueue submit loop wall time.
+ * @param out_wait_barrier_ns  wl_workqueue_wait_all barrier wall time.
+ * @param out_worker_sum_ns    Sum of worker sub-pass wall runtimes.
+ * @param out_worker_max_ns    Sum of per-sub-pass maximum worker runtimes.
+ * @param out_idle_estimate_ns Estimated barrier/idle time: max(wait - worker max, 0).
  * @param out_queue_drain_ns   MPSC drain plus delta matrix reconstruction time.
  * @param out_convergence_ns   Worker empty-delta and convergence checks.
  * @param out_exchange_ns      Recursive TDD exchange scatter/gather time.
@@ -379,7 +384,10 @@ col_session_get_exchange_time_ns(wl_session_t *sess,
  */
 void
 col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
-    uint64_t *out_dispatch_wait_ns, uint64_t *out_queue_drain_ns,
+    uint64_t *out_dispatch_wait_ns, uint64_t *out_submit_loop_ns,
+    uint64_t *out_wait_barrier_ns, uint64_t *out_worker_sum_ns,
+    uint64_t *out_worker_max_ns, uint64_t *out_idle_estimate_ns,
+    uint64_t *out_queue_drain_ns,
     uint64_t *out_convergence_ns, uint64_t *out_exchange_ns,
     uint64_t *out_final_merge_ns);
 

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1851,6 +1851,12 @@ tdd_worker_subpass_fn(void *arg)
     const wl_plan_stratum_t *sp = ctx->sp;
     uint32_t eff_iter = ctx->eff_iter;
     uint32_t nrels = sp->relation_count;
+    uint64_t worker_t0 = now_ns();
+#define TDD_WORKER_RETURN() \
+        do { \
+            ctx->runtime_ns = now_ns() - worker_t0; \
+            return; \
+        } while (0)
 
     /* Issue #282: Enable differential operators from eff_iter 1 onward.
      * Mirrors eval.c:410-411 / Clarification 3.
@@ -1884,7 +1890,7 @@ tdd_worker_subpass_fn(void *arg)
             ctx->all_empty_delta = true;
             sess->tdd_subpass_active = saved_tdd_subpass;
             sess->diff_operators_active = saved_diff;
-            return;
+            TDD_WORKER_RETURN();
         }
     }
 
@@ -1894,7 +1900,7 @@ tdd_worker_subpass_fn(void *arg)
         ctx->rc = ENOMEM;
         sess->tdd_subpass_active = saved_tdd_subpass;
         sess->diff_operators_active = saved_diff;
-        return;
+        TDD_WORKER_RETURN();
     }
     for (uint32_t ri = 0; ri < nrels; ri++) {
         col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
@@ -1918,7 +1924,7 @@ tdd_worker_subpass_fn(void *arg)
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
             sess->diff_operators_active = saved_diff;
-            return;
+            TDD_WORKER_RETURN();
         }
 
         if (stack.top == 0)
@@ -1946,7 +1952,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
                 result.owned = false;
             } else {
@@ -1957,7 +1963,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
                 rc = col_rel_append_all(copy, result.rel, sess->eval_arena);
                 if (rc != 0) {
@@ -1966,7 +1972,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
             }
             rc = session_add_rel(sess, copy);
@@ -1976,7 +1982,7 @@ tdd_worker_subpass_fn(void *arg)
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
                 sess->diff_operators_active = saved_diff;
-                return;
+                TDD_WORKER_RETURN();
             }
         } else {
             if (target->ncols == 0 && result.rel->ncols > 0) {
@@ -1989,7 +1995,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
             }
             rc = col_rel_append_all(target, result.rel, sess->eval_arena);
@@ -2000,7 +2006,7 @@ tdd_worker_subpass_fn(void *arg)
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
                 sess->diff_operators_active = saved_diff;
-                return;
+                TDD_WORKER_RETURN();
             }
         }
     }
@@ -2035,7 +2041,7 @@ tdd_worker_subpass_fn(void *arg)
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
             sess->diff_operators_active = saved_diff;
-            return;
+            TDD_WORKER_RETURN();
         }
 
         int rc2 = 0;
@@ -2052,7 +2058,7 @@ tdd_worker_subpass_fn(void *arg)
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
                 sess->diff_operators_active = saved_diff;
-                return;
+                TDD_WORKER_RETURN();
             }
             uint32_t keep = snap[ri];
             for (uint32_t i = snap[ri]; i < r->nrows; i++) {
@@ -2091,7 +2097,7 @@ tdd_worker_subpass_fn(void *arg)
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
             sess->diff_operators_active = saved_diff;
-            return;
+            TDD_WORKER_RETURN();
         }
 
         if (delta->nrows > 0) {
@@ -2104,7 +2110,7 @@ tdd_worker_subpass_fn(void *arg)
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
                 sess->diff_operators_active = saved_diff;
-                return;
+                TDD_WORKER_RETURN();
             }
             for (uint32_t ti = 0; ti < delta->nrows; ti++) {
                 delta->timestamps[ti].iteration = eff_iter;
@@ -2124,7 +2130,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
             }
 
@@ -2143,7 +2149,7 @@ tdd_worker_subpass_fn(void *arg)
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
                     sess->diff_operators_active = saved_diff;
-                    return;
+                    TDD_WORKER_RETURN();
                 }
             } else {
                 /* No queue (creation failed): fall back to direct ctx write. */
@@ -2170,6 +2176,8 @@ tdd_worker_subpass_fn(void *arg)
     ctx->any_new = any_new;
     sess->tdd_subpass_active = saved_tdd_subpass;
     sess->diff_operators_active = saved_diff;
+    ctx->runtime_ns = now_ns() - worker_t0;
+#undef TDD_WORKER_RETURN
 }
 
 /*
@@ -4357,6 +4365,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 ctxs[w].any_new = false;
                 ctxs[w].all_empty_delta = false;
                 ctxs[w].force_diff = bdx_mode;
+                ctxs[w].runtime_ns = 0;
                 ctxs[w].rc = 0;
             }
 
@@ -4371,6 +4380,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                     break;
                 }
             }
+            uint64_t submit_ns = now_ns() - dispatch_t0;
+            coord->tdd_submit_loop_ns += submit_ns;
 
             if (!submit_ok) {
                 for (uint32_t w = 0; w < W; w++)
@@ -4381,8 +4392,22 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             }
 
             /* BARRIER */
+            uint64_t wait_t0 = now_ns();
             wl_workqueue_wait_all(coord->wq);
-            coord->tdd_dispatch_wait_ns += now_ns() - dispatch_t0;
+            uint64_t wait_ns = now_ns() - wait_t0;
+            coord->tdd_wait_barrier_ns += wait_ns;
+            coord->tdd_dispatch_wait_ns += submit_ns + wait_ns;
+            uint64_t worker_sum_ns = 0;
+            uint64_t worker_max_ns = 0;
+            for (uint32_t w = 0; w < W; w++) {
+                worker_sum_ns += ctxs[w].runtime_ns;
+                if (ctxs[w].runtime_ns > worker_max_ns)
+                    worker_max_ns = ctxs[w].runtime_ns;
+            }
+            coord->tdd_worker_sum_ns += worker_sum_ns;
+            coord->tdd_worker_max_ns += worker_max_ns;
+            if (wait_ns > worker_max_ns)
+                coord->tdd_idle_estimate_ns += wait_ns - worker_max_ns;
 
             /* Collect first worker error */
             for (uint32_t w = 0; w < W; w++) {

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -848,6 +848,11 @@ typedef struct wl_col_session_t {
      * Coordinator-only; reset at the start of each wl_session_snapshot(). */
     uint64_t tdd_total_ns;
     uint64_t tdd_dispatch_wait_ns;
+    uint64_t tdd_submit_loop_ns;
+    uint64_t tdd_wait_barrier_ns;
+    uint64_t tdd_worker_sum_ns;
+    uint64_t tdd_worker_max_ns;
+    uint64_t tdd_idle_estimate_ns;
     uint64_t tdd_queue_drain_ns;
     uint64_t tdd_convergence_ns;
     uint64_t tdd_exchange_ns;
@@ -1757,6 +1762,7 @@ typedef struct {
     bool all_empty_delta;          /* OUT: all FORCE_DELTA empty, skipped */
     bool force_diff;               /* IN: enable diff from eff_iter 0 (BDX) */
     col_rel_t **delta_rels;        /* OUT: produced deltas [nrels], coord frees */
+    uint64_t runtime_ns;           /* OUT: worker sub-pass wall runtime */
     int rc;                        /* OUT: return code                */
 } col_eval_tdd_worker_ctx_t;
 

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -276,7 +276,10 @@ col_session_get_exchange_time_ns(wl_session_t *sess,
  */
 void
 col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
-    uint64_t *out_dispatch_wait_ns, uint64_t *out_queue_drain_ns,
+    uint64_t *out_dispatch_wait_ns, uint64_t *out_submit_loop_ns,
+    uint64_t *out_wait_barrier_ns, uint64_t *out_worker_sum_ns,
+    uint64_t *out_worker_max_ns, uint64_t *out_idle_estimate_ns,
+    uint64_t *out_queue_drain_ns,
     uint64_t *out_convergence_ns, uint64_t *out_exchange_ns,
     uint64_t *out_final_merge_ns)
 {
@@ -285,6 +288,16 @@ col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
         *out_total_ns = cs->tdd_total_ns;
     if (out_dispatch_wait_ns)
         *out_dispatch_wait_ns = cs->tdd_dispatch_wait_ns;
+    if (out_submit_loop_ns)
+        *out_submit_loop_ns = cs->tdd_submit_loop_ns;
+    if (out_wait_barrier_ns)
+        *out_wait_barrier_ns = cs->tdd_wait_barrier_ns;
+    if (out_worker_sum_ns)
+        *out_worker_sum_ns = cs->tdd_worker_sum_ns;
+    if (out_worker_max_ns)
+        *out_worker_max_ns = cs->tdd_worker_max_ns;
+    if (out_idle_estimate_ns)
+        *out_idle_estimate_ns = cs->tdd_idle_estimate_ns;
     if (out_queue_drain_ns)
         *out_queue_drain_ns = cs->tdd_queue_drain_ns;
     if (out_convergence_ns)
@@ -1812,6 +1825,11 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     sess->exchange_time_ns = 0;
     sess->tdd_total_ns = 0;
     sess->tdd_dispatch_wait_ns = 0;
+    sess->tdd_submit_loop_ns = 0;
+    sess->tdd_wait_barrier_ns = 0;
+    sess->tdd_worker_sum_ns = 0;
+    sess->tdd_worker_max_ns = 0;
+    sess->tdd_idle_estimate_ns = 0;
     sess->tdd_queue_drain_ns = 0;
     sess->tdd_convergence_ns = 0;
     sess->tdd_exchange_ns = 0;


### PR DESCRIPTION
## Summary

Splits the recursive TDD `dispatch_wait` profiling bucket so #650 can distinguish worker compute from coordinator/barrier overhead before changing evaluator architecture.

## Changes

- Keeps the existing JSON field `tdd_phase_ms.dispatch_wait` for compatibility.
- Adds split recursive TDD profiling counters:
  - `submit_loop`
  - `wait_barrier`
  - `worker_sum`
  - `worker_max`
  - `idle_estimate`
- Records worker sub-pass runtime through each worker's context only, then aggregates on the coordinator after `wl_workqueue_wait_all()`.
- Computes `idle_estimate` per sub-pass as `max(wait_barrier - worker_max, 0)`.
- Extends the existing internal columnar profiling getter and `bench_flowlog --format json` output.

## Review Workflow

- Architect review: accepted the architecture-preserving split and confirmed the final calculation matches the intended design.
- Critic review: accepted the implementation after verifying no worker writes coordinator counters directly, early worker returns are timed, `worker_max` is per-sub-pass, and worker runtime is not included in `tdd_accounted_pct` wall-time accounting.

## Validation

- `meson compile -C build bench_flowlog test_tdd_recursive`
- `meson test -C build tdd_recursive queue_transport doop_multiworker workqueue bench_flowlog_tdd_bdx_smoke --print-errorlogs`
- `git diff --check`
- `./build/bench/bench_flowlog --workload tdd-bdx --data bench/data/graph_100.csv --workers 4 --repeat 1 --format json`

JSON check showed `dispatch_wait`, `submit_loop`, `wait_barrier`, `worker_sum`, `worker_max`, and `idle_estimate` present under `tdd_phase_ms`.

Closes #654
Refs #650
