### PR TITLE
Add recursive TDD exchange phase profiling

### DIFF
--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -38,6 +38,12 @@ extern void
 col_session_get_cache_stats(wl_session_t *sess, uint64_t *out_hits,
     uint64_t *out_misses);
 
+extern void
+wl_columnar_session_get_tdd_exchange_breakdown_stats(wl_session_t *sess,
+    uint64_t *out_matrix_ns, uint64_t *out_coordinator_ns,
+    uint64_t *out_scatter_ns, uint64_t *out_gather_ns,
+    uint64_t *out_broadcast_ns);
+
 /* ----------------------------------------------------------------
  * Global output format and per-run profiling accumulators (3B-003)
  *
@@ -74,6 +80,11 @@ static uint64_t g_last_tdd_idle_estimate_ns = 0;
 static uint64_t g_last_tdd_queue_drain_ns = 0;
 static uint64_t g_last_tdd_convergence_ns = 0;
 static uint64_t g_last_tdd_exchange_ns = 0;
+static uint64_t g_last_tdd_exchange_matrix_ns = 0;
+static uint64_t g_last_tdd_exchange_coordinator_ns = 0;
+static uint64_t g_last_tdd_exchange_scatter_ns = 0;
+static uint64_t g_last_tdd_exchange_gather_ns = 0;
+static uint64_t g_last_tdd_exchange_broadcast_ns = 0;
 static uint64_t g_last_tdd_final_merge_ns = 0;
 
 #ifndef WITH_K_FUSION
@@ -349,6 +360,11 @@ run_pipeline_count(const char *source, uint32_t num_workers, int64_t *out_count,
         &g_last_tdd_queue_drain_ns,
         &g_last_tdd_convergence_ns, &g_last_tdd_exchange_ns,
         &g_last_tdd_final_merge_ns);
+    wl_columnar_session_get_tdd_exchange_breakdown_stats(sess,
+        &g_last_tdd_exchange_matrix_ns,
+        &g_last_tdd_exchange_coordinator_ns,
+        &g_last_tdd_exchange_scatter_ns,
+        &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -985,6 +1001,11 @@ run_tdd_bdx_pipeline(const int64_t *rows, uint32_t edge_count,
         &g_last_tdd_queue_drain_ns,
         &g_last_tdd_convergence_ns, &g_last_tdd_exchange_ns,
         &g_last_tdd_final_merge_ns);
+    wl_columnar_session_get_tdd_exchange_breakdown_stats(sess,
+        &g_last_tdd_exchange_matrix_ns,
+        &g_last_tdd_exchange_coordinator_ns,
+        &g_last_tdd_exchange_scatter_ns,
+        &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -2972,6 +2993,14 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
         (double)g_last_tdd_convergence_ns / 1e6,
         (double)g_last_tdd_exchange_ns / 1e6,
         (double)g_last_tdd_final_merge_ns / 1e6);
+    printf("  \"tdd_exchange_phase_ms\": {\"matrix\": %.4f, "
+        "\"coordinator\": %.4f, \"scatter\": %.4f, \"gather\": %.4f, "
+        "\"broadcast\": %.4f},\n",
+        (double)g_last_tdd_exchange_matrix_ns / 1e6,
+        (double)g_last_tdd_exchange_coordinator_ns / 1e6,
+        (double)g_last_tdd_exchange_scatter_ns / 1e6,
+        (double)g_last_tdd_exchange_gather_ns / 1e6,
+        (double)g_last_tdd_exchange_broadcast_ns / 1e6);
     printf("  \"tdd_accounted_pct\": %.1f,\n", tdd_accounted_pct);
     printf("  \"profiling_from_last_run\": true\n");
     printf("}\n");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -218,6 +218,18 @@ test('bench_flowlog_tdd_bdx_smoke', bench_flowlog,
      suite: 'bench',
      timeout: 30)
 
+bench_flowlog_json_py3 = find_program('python3', 'python', required: true)
+bench_flowlog_tdd_json_validator = files('validate_bench_flowlog_tdd_json.py')
+test('bench_flowlog_tdd_bdx_json', bench_flowlog_json_py3,
+     args: [
+       bench_flowlog_tdd_json_validator[0],
+       bench_flowlog.full_path(),
+       meson.project_source_root() / 'bench/data/graph_10.csv',
+     ],
+     depends: bench_flowlog,
+     suite: 'bench',
+     timeout: 30)
+
 # Issue #287: logger env parser tests (pure function; no env mutation).
 test_log_parse_exe = executable(
   'test_log_parse',

--- a/tests/validate_bench_flowlog_tdd_json.py
+++ b/tests/validate_bench_flowlog_tdd_json.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+
+
+def extract_json(stdout):
+    start = stdout.find("{")
+    end = stdout.rfind("}")
+    if start < 0 or end < start:
+        raise AssertionError("bench_flowlog did not print a JSON object")
+    return json.loads(stdout[start : end + 1])
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: validate_bench_flowlog_tdd_json.py BENCH_FLOWLOG DATA")
+        return 2
+
+    proc = subprocess.run(
+        [
+            sys.argv[1],
+            "--workload",
+            "tdd-bdx",
+            "--data",
+            sys.argv[2],
+            "--workers",
+            "4",
+            "--repeat",
+            "1",
+            "--format",
+            "json",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        print(proc.stdout, end="")
+        print(proc.stderr, end="", file=sys.stderr)
+        return proc.returncode
+
+    row = extract_json(proc.stdout)
+    tdd_phase = row.get("tdd_phase_ms")
+    exchange_phase = row.get("tdd_exchange_phase_ms")
+    if not isinstance(tdd_phase, dict):
+        raise AssertionError("missing tdd_phase_ms object")
+    if not isinstance(exchange_phase, dict):
+        raise AssertionError("missing tdd_exchange_phase_ms object")
+
+    exchange = tdd_phase.get("exchange")
+    if not isinstance(exchange, (int, float)) or exchange < 0:
+        raise AssertionError("tdd_phase_ms.exchange must be nonnegative")
+
+    keys = ("matrix", "coordinator", "scatter", "gather", "broadcast")
+    subtotal = 0.0
+    positive = False
+    for key in keys:
+        value = exchange_phase.get(key)
+        if not isinstance(value, (int, float)):
+            raise AssertionError(f"missing numeric exchange phase: {key}")
+        if value < 0:
+            raise AssertionError(f"negative exchange phase: {key}")
+        subtotal += float(value)
+        positive = positive or value > 0
+
+    if exchange > 0.01 and not positive:
+        raise AssertionError("exchange sub-counters are all zero")
+
+    # The parent exchange timer has small unclassified overhead around the
+    # sub-counters.  Printed millisecond precision can also round tiny runs.
+    tolerance = max(1.0, exchange * 0.25)
+    if subtotal > exchange + tolerance:
+        raise AssertionError(
+            f"exchange sub-counters exceed parent: {subtotal} > {exchange}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2747,8 +2747,10 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
      * worker can probe its 1/W IDB partition with the full delta. */
     if (self_join_mode && default_hash) {
         int rc = 0;
+        uint64_t t0 = now_ns();
         for (uint32_t ri = 0; rc == 0 && ri < nrels; ri++)
             rc = tdd_broadcast_relation_delta(sp, ri, coord, ctxs, W);
+        coord->tdd_exchange_broadcast_ns += now_ns() - t0;
         return rc;
     }
 
@@ -2764,16 +2766,26 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
     }
 
     /* No EXCHANGE metadata and no default hash: broadcast (replicate mode). */
-    if (!has_exchange && !default_hash)
-        return tdd_broadcast_deltas(sp, coord, ctxs, W);
+    if (!has_exchange && !default_hash) {
+        uint64_t t0 = now_ns();
+        int rc = tdd_broadcast_deltas(sp, coord, ctxs, W);
+        coord->tdd_exchange_broadcast_ns += now_ns() - t0;
+        return rc;
+    }
 
     /* Replicate mode: all workers hold identical data, so hash scatter/gather
      * would produce W× duplicate deltas.  Force broadcast to avoid bloat. */
-    if (!default_hash)
-        return tdd_broadcast_deltas(sp, coord, ctxs, W);
+    if (!default_hash) {
+        uint64_t t0 = now_ns();
+        int rc = tdd_broadcast_deltas(sp, coord, ctxs, W);
+        coord->tdd_exchange_broadcast_ns += now_ns() - t0;
+        return rc;
+    }
 
     /* Hash-partitioned scatter/gather exchange. */
+    uint64_t matrix_t0 = now_ns();
     int rc = tdd_alloc_exchange_bufs(coord, W);
+    coord->tdd_exchange_matrix_ns += now_ns() - matrix_t0;
     if (rc != 0) {
         for (uint32_t w = 0; w < W; w++)
             for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -2787,6 +2799,7 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
         const char *dname = sp->relations[ri].delta_name;
 
         /* Locate EXCHANGE key columns for this relation (if any). */
+        uint64_t prepare_t0 = now_ns();
         const uint32_t *key_cols = NULL;
         uint32_t key_count = 0;
         for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
@@ -2815,10 +2828,12 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
             key_cols = default_key;
             key_count = 1;
         }
+        coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
 
         if (!key_cols || key_count == 0) {
             /* Broadcast: union worker deltas, install on every worker.
              * Used for replicate-mode strata where IDB is not partitioned. */
+            uint64_t broadcast_t0 = now_ns();
             uint32_t total = 0, ncols = 0;
             for (uint32_t w = 0; w < W; w++) {
                 col_rel_t *d = ctxs[w].delta_rels[ri];
@@ -2872,8 +2887,10 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
                     }
                 }
             }
+            coord->tdd_exchange_broadcast_ns += now_ns() - broadcast_t0;
         } else {
             /* Hash-partitioned scatter/gather for EXCHANGE-keyed relations */
+            uint64_t scatter_t0 = now_ns();
             for (uint32_t w = 0; w < W; w++) {
                 col_rel_t *d = ctxs[w].delta_rels[ri];
                 ctxs[w].delta_rels[ri] = NULL;
@@ -2890,8 +2907,10 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
                 if (rc != 0)
                     goto exchange_done;
             }
+            coord->tdd_exchange_scatter_ns += now_ns() - scatter_t0;
 
             /* Gather: worker dst receives exchange_bufs[*][dst]. */
+            uint64_t gather_t0 = now_ns();
             for (uint32_t dst = 0; dst < W; dst++) {
                 col_rel_t *gathered = NULL;
                 rc = tdd_gather_for_worker(coord, dst, W, dname, &gathered);
@@ -2906,20 +2925,25 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
                     }
                 }
             }
+            coord->tdd_exchange_gather_ns += now_ns() - gather_t0;
         }
 
         /* Release exchange_bufs[*][*] for this relation — data was copied
          * into the gathered relations above. */
+        uint64_t matrix_release_t0 = now_ns();
         for (uint32_t src = 0; src < W; src++) {
             for (uint32_t dst = 0; dst < W; dst++) {
                 col_rel_destroy(coord->exchange_bufs[src][dst]);
                 coord->exchange_bufs[src][dst] = NULL;
             }
         }
+        coord->tdd_exchange_matrix_ns += now_ns() - matrix_release_t0;
     }
 
 exchange_done:
+    matrix_t0 = now_ns();
     tdd_free_exchange_bufs(coord);
+    coord->tdd_exchange_matrix_ns += now_ns() - matrix_t0;
     return rc;
 }
 
@@ -3834,6 +3858,8 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
         const char *dname = sp->relations[ri].delta_name;
         const char *rel_name = sp->relations[ri].name;
 
+        uint64_t prepare_t0 = now_ns();
+
         /* Remove stale $d$ from workers */
         for (uint32_t w = 0; w < W; w++)
             session_remove_rel(&coord->tdd_workers[w], dname);
@@ -3854,6 +3880,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
                 col_rel_destroy(ctxs[w].delta_rels[ri]);
                 ctxs[w].delta_rels[ri] = NULL;
             }
+            coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
             continue;
         }
 
@@ -3884,6 +3911,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
 
         if (combined->nrows == 0) {
             col_rel_destroy(combined);
+            coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
             continue;
         }
 
@@ -3919,9 +3947,11 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             if (widb)
                 widb->nrows = snap[w * nrels + ri];
         }
+        coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
 
         /* Step 5: Hash-partition combined_delta by EXCHANGE key,
          * append to correct worker's IDB */
+        uint64_t scatter_t0 = now_ns();
         const uint32_t *key_cols = NULL;
         uint32_t key_count = 0;
         for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
@@ -3980,8 +4010,10 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             col_rel_destroy(parts[w]);
         }
         free(parts);
+        coord->tdd_exchange_scatter_ns += now_ns() - scatter_t0;
 
         /* Step 8: Broadcast combined_delta as $d$ via col_shared zero-copy */
+        uint64_t broadcast_t0 = now_ns();
         rc = session_add_rel(&coord->tdd_workers[0], combined);
         if (rc != 0) {
             col_rel_destroy(combined);
@@ -4006,6 +4038,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
                 return rc;
             }
         }
+        coord->tdd_exchange_broadcast_ns += now_ns() - broadcast_t0;
     }
 
     return 0;

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -856,6 +856,11 @@ typedef struct wl_col_session_t {
     uint64_t tdd_queue_drain_ns;
     uint64_t tdd_convergence_ns;
     uint64_t tdd_exchange_ns;
+    uint64_t tdd_exchange_matrix_ns;
+    uint64_t tdd_exchange_coordinator_ns;
+    uint64_t tdd_exchange_scatter_ns;
+    uint64_t tdd_exchange_gather_ns;
+    uint64_t tdd_exchange_broadcast_ns;
     uint64_t tdd_final_merge_ns;
     /* Phase 4: tracks which relation was just inserted via
      * col_session_insert_incremental, enables affected-stratum skip

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -309,6 +309,36 @@ col_session_get_tdd_perf_stats(wl_session_t *sess, uint64_t *out_total_ns,
 }
 
 /*
+ * wl_columnar_session_get_tdd_exchange_breakdown_stats:
+ *
+ * Return private recursive TDD exchange sub-counters from the last
+ * wl_session_snapshot() call.  Kept out of the installed columnar header so
+ * benchmark instrumentation can advance without changing public API shape.
+ * All out-parameters are NULL-safe.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4
+__attribute__((visibility("hidden")))
+#endif
+void
+wl_columnar_session_get_tdd_exchange_breakdown_stats(wl_session_t *sess,
+    uint64_t *out_matrix_ns, uint64_t *out_coordinator_ns,
+    uint64_t *out_scatter_ns, uint64_t *out_gather_ns,
+    uint64_t *out_broadcast_ns)
+{
+    wl_col_session_t *cs = COL_SESSION(sess);
+    if (out_matrix_ns)
+        *out_matrix_ns = cs->tdd_exchange_matrix_ns;
+    if (out_coordinator_ns)
+        *out_coordinator_ns = cs->tdd_exchange_coordinator_ns;
+    if (out_scatter_ns)
+        *out_scatter_ns = cs->tdd_exchange_scatter_ns;
+    if (out_gather_ns)
+        *out_gather_ns = cs->tdd_exchange_gather_ns;
+    if (out_broadcast_ns)
+        *out_broadcast_ns = cs->tdd_exchange_broadcast_ns;
+}
+
+/*
  * col_session_cleanup_old_data:
  *
  * Remove data that is entirely before the frontier (iteration, stratum).
@@ -1833,6 +1863,11 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     sess->tdd_queue_drain_ns = 0;
     sess->tdd_convergence_ns = 0;
     sess->tdd_exchange_ns = 0;
+    sess->tdd_exchange_matrix_ns = 0;
+    sess->tdd_exchange_coordinator_ns = 0;
+    sess->tdd_exchange_scatter_ns = 0;
+    sess->tdd_exchange_gather_ns = 0;
+    sess->tdd_exchange_broadcast_ns = 0;
     sess->tdd_final_merge_ns = 0;
 
     /* Phase 4 incremental skip: when last_inserted_relation is set, only


### PR DESCRIPTION
## Summary

Adds recursive TDD exchange sub-phase counters to make issue #656 measurement-driven before changing the exchange representation. The benchmark JSON now reports `tdd_exchange_phase_ms` with `matrix`, `coordinator`, `scatter`, `gather`, and `broadcast`.

This is a non-closing measurement step for #656. It does not change Datalog semantics, barrier behavior, public headers, or public API/ABI. The benchmark-only getter is hidden from the shared library dynamic symbol table.

## Measurements

`./build/bench/bench_flowlog --workload tdd-bdx --data bench/data/graph_100.csv --repeat 1 --format json`

| Workers | Tuples | Iterations | Wall ms | Exchange ms | Matrix ms | Coordinator ms | Scatter ms | Gather ms | Broadcast ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 4950 | 7 | 23.971 | 1.8714 | 0.0000 | 1.1500 | 0.6811 | 0.0000 | 0.0381 |
| 8 | 4950 | 7 | 24.586 | 2.6264 | 0.0000 | 1.6820 | 0.8579 | 0.0000 | 0.0844 |
| 16 | 4950 | 8 | 26.779 | 3.6515 | 0.0000 | 2.3488 | 1.1215 | 0.0000 | 0.1783 |

These numbers show the current `tdd-bdx` workload is not exercising the standard W-by-W matrix gather path; its exchange cost is dominated by coordinator merge/dedup/truncate and scatter/broadcast.

## Validation

- `meson setup --reconfigure build`
- `meson compile -C build bench_flowlog bench_flowlog_seq`
- `meson compile -C build wirelog`
- `meson test -C build tdd_recursive queue_transport doop_multiworker bench_flowlog_tdd_bdx_smoke tdd_exchange bench_flowlog_tdd_bdx_json --print-errorlogs`
- `git diff --check`
- `nm -D build/libwirelog.so.0.30.0 | rg "tdd_exchange_breakdown|wl_columnar_session_get_tdd_exchange|col_session_get_tdd_exchange" || true`

Refs #656