### PR TITLE
Optimize BDX coordinator delta filtering

### DIFF
--- a/tests/test_tdd_recursive.c
+++ b/tests/test_tdd_recursive.c
@@ -122,6 +122,27 @@ count_rows(wl_col_session_t *sess, const char *name)
     return r ? r->nrows : 0;
 }
 
+static int
+relation_rows_equal(wl_col_session_t *left, wl_col_session_t *right,
+    const char *name)
+{
+    col_rel_t *lr = session_find_rel(left, name);
+    col_rel_t *rr = session_find_rel(right, name);
+    if (!lr || !rr)
+        return lr == rr;
+    if (lr->ncols != rr->ncols || lr->nrows != rr->nrows)
+        return 0;
+
+    col_rel_radix_sort_int64(lr);
+    col_rel_radix_sort_int64(rr);
+
+    for (uint32_t c = 0; c < lr->ncols; c++)
+        for (uint32_t r = 0; r < lr->nrows; r++)
+            if (lr->columns[c][r] != rr->columns[c][r])
+                return 0;
+    return 1;
+}
+
 /* ======================================================================== */
 /* Tests                                                                    */
 /* ======================================================================== */
@@ -646,8 +667,7 @@ test_bdx_selfjoin_w2(void)
     int rc1 = wl_session_step(&s1->base);
     int rc2 = wl_session_step(&s2->base);
 
-    uint32_t cnt1 = count_rows(s1, "r");
-    uint32_t cnt2 = count_rows(s2, "r");
+    int equal = relation_rows_equal(s1, s2, "r");
 
     cleanup_session(s1, p1, pr1);
     cleanup_session(s2, p2, pr2);
@@ -656,8 +676,8 @@ test_bdx_selfjoin_w2(void)
         FAIL("session step failed");
         return 1;
     }
-    if (cnt1 != cnt2) {
-        FAIL("BDX W=2 row count differs from W=1");
+    if (!equal) {
+        FAIL("BDX W=2 row set differs from W=1");
         return 1;
     }
     PASS();
@@ -686,8 +706,7 @@ test_bdx_selfjoin_w4(void)
     int rc1 = wl_session_step(&s1->base);
     int rc4 = wl_session_step(&s4->base);
 
-    uint32_t cnt1 = count_rows(s1, "r");
-    uint32_t cnt4 = count_rows(s4, "r");
+    int equal = relation_rows_equal(s1, s4, "r");
 
     cleanup_session(s1, p1, pr1);
     cleanup_session(s4, p4, pr4);
@@ -696,8 +715,49 @@ test_bdx_selfjoin_w4(void)
         FAIL("session step failed");
         return 1;
     }
-    if (cnt1 != cnt4) {
-        FAIL("BDX W=4 row count differs from W=1");
+    if (!equal) {
+        FAIL("BDX W=4 row set differs from W=1");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_bdx_selfjoin_w4_shuffled_duplicates(void)
+{
+    TEST("BDX self-join W=4 shuffled duplicate edges matches W=1 rows");
+
+    wl_plan_t *p1, *p4;
+    wirelog_program_t *pr1, *pr4;
+    wl_col_session_t *s1 = make_selfjoin_tc_session(1, &p1, &pr1);
+    wl_col_session_t *s4 = make_selfjoin_tc_session(4, &p4, &pr4);
+    if (!s1 || !s4) {
+        FAIL("session creation failed");
+        return 1;
+    }
+
+    int64_t edges[] = {
+        3, 4, 1, 2, 2, 3, 4, 5, 2, 3,
+        1, 2, 5, 6, 3, 4, 6, 7, 4, 5
+    };
+    insert_edges(s1, edges, 10);
+    insert_edges(s4, edges, 10);
+
+    int rc1 = wl_session_step(&s1->base);
+    int rc4 = wl_session_step(&s4->base);
+
+    int equal = relation_rows_equal(s1, s4, "r");
+
+    cleanup_session(s1, p1, pr1);
+    cleanup_session(s4, p4, pr4);
+
+    if (rc1 != 0 || rc4 != 0) {
+        FAIL("session step failed");
+        return 1;
+    }
+    if (!equal) {
+        FAIL("BDX W=4 shuffled duplicate row set differs from W=1");
         return 1;
     }
     PASS();
@@ -883,6 +943,7 @@ main(void)
     test_triple_idb_guard();
     test_bdx_selfjoin_w2();
     test_bdx_selfjoin_w4();
+    test_bdx_selfjoin_w4_shuffled_duplicates();
     test_filt_arr_bench_w1();
     test_filt_arr_bench_w4();
 

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2399,14 +2399,9 @@ tdd_dedup_rel(col_rel_t *r)
  * Merge src (sorted, no overlap with dst) into dst (sorted), maintaining
  * lexicographic sorted order.  O(N + D) where N = dst->nrows, D = src->nrows.
  *
- * Preconditions (caller guarantees):
- *   - dst->columns[] rows are in sorted (lexicographic) order
- *   - src->columns[] rows are in sorted order
- *   - No row appears in both dst and src (guaranteed by bdx_merge_diff)
- *
- * Replaces col_rel_append_all + tdd_dedup_rel(dst) in tdd_bdx_exchange_deltas
- * to keep the coordinator IDB sorted for bdx_merge_diff on the next iteration.
- * Issue #390.
+ * Kept with external linkage for compatibility with the existing non-header
+ * symbol.  The BDX coordinator path no longer calls it because BDX deltas are
+ * not guaranteed to arrive sorted.
  */
 int
 tdd_sorted_merge_append(col_rel_t *dst, col_rel_t *src)
@@ -2451,31 +2446,37 @@ tdd_sorted_merge_append(col_rel_t *dst, col_rel_t *src)
             int64_t a = dst->merge_columns[c][i];
             int64_t b = src->columns[c][j];
             if (a < b) {
-                cmp = -1; break;
+                cmp = -1;
+                break;
             }
             if (a > b) {
-                cmp = 1; break;
+                cmp = 1;
+                break;
             }
         }
         if (cmp <= 0) {
             col_columns_copy_row(dst->columns, wr,
                 (int64_t *const *)dst->merge_columns, i, ncols);
-            i++; wr++;
+            i++;
+            wr++;
         } else {
             col_columns_copy_row(dst->columns, wr,
                 (int64_t *const *)src->columns, j, ncols);
-            j++; wr++;
+            j++;
+            wr++;
         }
     }
     while (i < N) {
         col_columns_copy_row(dst->columns, wr,
             (int64_t *const *)dst->merge_columns, i, ncols);
-        i++; wr++;
+        i++;
+        wr++;
     }
     while (j < D) {
         col_columns_copy_row(dst->columns, wr,
             (int64_t *const *)src->columns, j, ncols);
-        j++; wr++;
+        j++;
+        wr++;
     }
     dst->nrows = total;
     return 0;
@@ -3768,64 +3769,82 @@ tdd_check_convergence(const col_eval_tdd_worker_ctx_t *ctxs, uint32_t W)
 }
 
 /*
- * bdx_row_cmp:
- * Compare row i from relation a with row j from relation b.
- * Both must have the same ncols.  Returns <0, 0, or >0.
+ * bdx_hash_diff:
+ * Remove from delta any row that already exists in base.  This exact
+ * hash-table diff does not require sorted inputs, which matches the current
+ * BDX data flow where worker deltas are appended in partition order and
+ * tdd_dedup_rel() may preserve unsorted encounter order.
  */
-static inline int
-bdx_row_cmp(const col_rel_t *a, uint32_t i,
-    const col_rel_t *b, uint32_t j, uint32_t ncols)
-{
-    for (uint32_t c = 0; c < ncols; c++) {
-        int64_t va = a->columns[c][i];
-        int64_t vb = b->columns[c][j];
-        if (va < vb) return -1;
-        if (va > vb) return 1;
-    }
-    return 0;
-}
-
-/*
- * bdx_merge_diff:
- * Given sorted+deduped 'delta' and sorted+deduped 'base', remove from
- * delta any row that also appears in base.  Operates in-place on delta.
- * Both delta and base must be sorted by the same column order (radix sort).
- */
-static void
-bdx_merge_diff(col_rel_t *delta, const col_rel_t *base)
+static int
+bdx_hash_diff(col_rel_t *delta, const col_rel_t *base)
 {
     if (!delta || delta->nrows == 0 || !base || base->nrows == 0)
-        return;
-    uint32_t ncols = delta->ncols;
-    uint32_t di = 0, bi = 0, wr = 0;
-    while (di < delta->nrows && bi < base->nrows) {
-        int cmp = bdx_row_cmp(delta, di, base, bi, ncols);
-        if (cmp < 0) {
-            /* delta[di] < base[bi]: new row, keep it */
-            if (wr != di) {
-                for (uint32_t c = 0; c < ncols; c++)
-                    delta->columns[c][wr] = delta->columns[c][di];
-            }
-            wr++;
-            di++;
-        } else if (cmp > 0) {
-            bi++;
-        } else {
-            /* duplicate: skip */
-            di++;
-            bi++;
-        }
+        return 0;
+    if (delta->ncols != base->ncols)
+        return EINVAL;
+    if (base->nrows > UINT32_MAX - 1)
+        return ENOMEM;
+
+    size_t target = (size_t)base->nrows * 2;
+    size_t cap_sz = 4;
+    while (cap_sz < target) {
+        if (cap_sz > SIZE_MAX / 2)
+            return ENOMEM;
+        cap_sz <<= 1;
     }
-    /* Remaining delta rows are all > any base row: keep them */
-    while (di < delta->nrows) {
+    if (cap_sz > UINT32_MAX)
+        return ENOMEM;
+
+    uint32_t cap = (uint32_t)cap_sz;
+    uint32_t mask = cap - 1;
+    uint32_t *slots = (uint32_t *)malloc(cap * sizeof(uint32_t));
+    if (!slots)
+        return ENOMEM;
+    memset(slots, 0, cap * sizeof(uint32_t));
+
+    uint32_t ncols = base->ncols;
+    for (uint32_t i = 0; i < base->nrows; i++) {
+        uint64_t h = dedup_row_hash(base, i);
+        uint32_t slot = (uint32_t)(h & mask);
+        while (slots[slot] != 0)
+            slot = (slot + 1) & mask;
+        slots[slot] = i + 1;
+    }
+
+    uint32_t wr = 0;
+    for (uint32_t di = 0; di < delta->nrows; di++) {
+        uint64_t h = dedup_row_hash(delta, di);
+        uint32_t slot = (uint32_t)(h & mask);
+        bool found = false;
+        while (slots[slot] != 0) {
+            uint32_t bi = slots[slot] - 1;
+            bool eq = true;
+            for (uint32_t c = 0; c < ncols; c++) {
+                if (base->columns[c][bi] != delta->columns[c][di]) {
+                    eq = false;
+                    break;
+                }
+            }
+            if (eq) {
+                found = true;
+                break;
+            }
+            slot = (slot + 1) & mask;
+        }
+        if (found)
+            continue;
         if (wr != di) {
-            for (uint32_t c = 0; c < ncols; c++)
-                delta->columns[c][wr] = delta->columns[c][di];
+            col_columns_copy_row(delta->columns, wr,
+                (int64_t *const *)delta->columns, di, ncols);
+            if (delta->timestamps)
+                delta->timestamps[wr] = delta->timestamps[di];
         }
         wr++;
-        di++;
     }
+
+    free(slots);
     delta->nrows = wr;
+    return 0;
 }
 
 /*
@@ -3906,8 +3925,13 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             tdd_dedup_rel(combined);
 
         col_rel_t *coord_idb = session_find_rel(coord, rel_name);
-        if (coord_idb && coord_idb->nrows > 0 && combined->nrows > 0)
-            bdx_merge_diff(combined, coord_idb);
+        if (coord_idb && coord_idb->nrows > 0 && combined->nrows > 0) {
+            rc = bdx_hash_diff(combined, coord_idb);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+        }
 
         if (combined->nrows == 0) {
             col_rel_destroy(combined);
@@ -3925,19 +3949,11 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
                     return rc;
                 }
             }
-            /* Phase 0 optimization (#406): Use sorted merge-append instead of
-             * append-then-sort. Since combined_delta is already deduped
-             * against coord_idb, merge-append maintains sort order in O(N+D)
-             * time instead of O(N log N) full re-sort. */
-            rc = tdd_sorted_merge_append(coord_idb, combined);
+            rc = col_rel_append_all(coord_idb, combined, NULL);
             if (rc != 0) {
                 col_rel_destroy(combined);
                 return rc;
             }
-            /* Dedup any duplicate rows from merge (safety check).
-             * With presort check, this becomes O(N) if already sorted. */
-            if (coord_idb->nrows > 1)
-                tdd_dedup_rel(coord_idb);
         }
 
         /* Step 4: Truncate worker IDB to pre-subpass snapshot */


### PR DESCRIPTION
## Summary

Replaces the BDX coordinator's sorted merge-diff dependency with exact hash-based delta filtering. This matches the measured #656 bottleneck from PR #657: the `tdd-bdx` workload spends exchange time in BDX coordinator merge/dedup/truncate and scatter, not the standard W-by-W gather path.

The new BDX filtering path:

- deduplicates the combined worker delta within itself
- removes rows already present in the coordinator IDB using a hash table with full-row collision checks
- appends only genuinely new rows to the coordinator IDB
- avoids the redundant post-append coordinator dedup pass
- does not require sorted `combined` or sorted coordinator IDB input

The old `tdd_sorted_merge_append` non-header symbol remains present for compatibility, but BDX no longer calls it because BDX deltas are not guaranteed to be sorted.

## Measurements

`./build/bench/bench_flowlog --workload tdd-bdx --data bench/data/graph_100.csv --repeat 3 --format json`

Before, from PR #657 post-merge measurement:

| Workers | Exchange ms | Coordinator ms | Scatter ms | Broadcast ms |
| --- | ---: | ---: | ---: | ---: |
| 4 | 1.8714 | 1.1500 | 0.6811 | 0.0381 |
| 8 | 2.6264 | 1.6820 | 0.8579 | 0.0844 |
| 16 | 3.6515 | 2.3488 | 1.1215 | 0.1783 |

After this PR, repeat 3:

| Workers | Wall ms | Exchange ms | Coordinator ms | Scatter ms | Broadcast ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| 4 | 17.398 | 1.5747 | 0.9888 | 0.5494 | 0.0348 |
| 8 | 16.591 | 2.3076 | 1.6022 | 0.6246 | 0.0788 |
| 16 | 16.380 | 3.3442 | 2.3592 | 0.8032 | 0.1794 |

## Tests

Strengthens BDX coverage so W=2/W=4 self-join tests compare full row sets against W=1, not just counts, and adds a shuffled duplicate-edge case.

Validation run locally:

- `meson compile -C build bench_flowlog test_tdd_recursive test_queue_transport test_doop_multiworker test_tdd_exchange wirelog`
- `meson test -C build tdd_recursive queue_transport doop_multiworker bench_flowlog_tdd_bdx_smoke tdd_exchange bench_flowlog_tdd_bdx_json --print-errorlogs`
- `git diff --check`

Closes #656