### PR TITLE
tests: lock in compound declaration parsing regression for #660

### DIFF
--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -306,6 +306,73 @@ test_parse_decl_compound_rejects_inline_overflow(void)
     PASS();
 }
 
+static void
+test_parse_decl_compound_issue_660(void)
+{
+    TEST("compound declaration regression from issue #660");
+    PARSE(".decl event(id: int64, payload: point/2 inline)\n"
+        ".decl x_values(id: int64, x: int64)\n"
+        "x_values(id, x) :- event(id, point(x, _)).");
+    ASSERT_PARSED();
+    /* program must have at least 3 children: two .decl nodes and one rule */
+    if (program->child_count < 3) {
+        char buf[80];
+        snprintf(buf, sizeof(buf),
+            "expected at least 3 top-level children, got %u",
+            program->child_count);
+        CLEANUP();
+        FAIL(buf);
+        return;
+    }
+    /* first .decl is 'event'; its second column child must have type_name "point/2 inline" */
+    {
+        const wl_parser_ast_node_t *decl_event = child(program, 0);
+        /* locate the column child whose name is 'payload' */
+        uint32_t i;
+        for (i = 0; i < decl_event->child_count; i++) {
+            const wl_parser_ast_node_t *col = child(decl_event, i);
+            if (col->type_name
+                && strcmp(col->type_name, "point/2 inline") == 0)
+                goto found_inline;
+        }
+        CLEANUP();
+        FAIL(
+            "no column with type_name \"point/2 inline\" found in .decl event");
+        return;
+found_inline:;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_decl_compound_side_modifier(void)
+{
+    TEST("compound declaration side modifier");
+    PARSE(".decl record(id: int64, tag: scope/1 side)");
+    ASSERT_PARSED();
+    if (program->child_count < 1) {
+        CLEANUP();
+        FAIL("expected at least 1 top-level child");
+        return;
+    }
+    {
+        const wl_parser_ast_node_t *decl_record = child(program, 0);
+        uint32_t i;
+        for (i = 0; i < decl_record->child_count; i++) {
+            const wl_parser_ast_node_t *col = child(decl_record, i);
+            if (col->type_name && strcmp(col->type_name, "scope/1 side") == 0)
+                goto found_side;
+        }
+        CLEANUP();
+        FAIL("no column with type_name \"scope/1 side\" found in .decl record");
+        return;
+found_side:;
+    }
+    CLEANUP();
+    PASS();
+}
+
 /* ======================================================================== */
 /* Parser: Input/Output/PrintSize Directives                                */
 /* ======================================================================== */
@@ -1860,6 +1927,8 @@ main(void)
     test_parse_decl_compound_rejects_bad_modifier();
     test_parse_decl_compound_rejects_glued_modifier();
     test_parse_decl_compound_rejects_inline_overflow();
+    test_parse_decl_compound_issue_660();
+    test_parse_decl_compound_side_modifier();
 
     printf("\n--- Directives ---\n");
     test_parse_input_directive();

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -1355,13 +1355,20 @@ make_full_program(const char *source)
 }
 
 /* ======================================================================== */
-/* Phase 2B: Compound Column IR Lowering Tests (Issue #531/#539)            */
+/* Compound Column IR Lowering Tests (Issue #531/#539)                      */
 /*                                                                          */
-/* The parser does not yet accept "f/N inline" / "f/N side" syntax in       */
-/* .decl bodies, so these tests build a program with regular column types   */
-/* and then patch the relation's column metadata before convert_rules() to  */
-/* simulate compound declarations. This isolates the IR lowering path that  */
-/* runs inside build_atom_scan().                                           */
+/* These tests synthesize compound column metadata directly on              */
+/* wirelog_column_t before convert_rules() in order to isolate the IR       */
+/* lowering path that runs inside build_atom_scan(). The parser accepts     */
+/* the "f/N inline" / "f/N side" declaration syntax (see                    */
+/* test_parse_decl_compound_types in test_parser.c), but the synthetic      */
+/* helper is retained because several cases below need either:              */
+/*                                                                          */
+/*   - non-default inline_col_offset values that the parser's natural       */
+/*     prefix-sum (ir/program.c) does not produce for the test schema, or   */
+/*   - parser-unreachable states such as compound_arity = 0 or an           */
+/*     unknown compound_kind enum value, which exist solely to verify       */
+/*     build_atom_scan()'s defense against corrupt IR metadata.             */
 /* ======================================================================== */
 
 static void


### PR DESCRIPTION
## Summary

- Add a regression test in `tests/test_parser.c` that runs the exact source from issue #660 through the parser and asserts the column `type_name` round-trips to `point/2 inline` and `scope/1 side`.
- Refresh the stale comment block in `tests/test_program.c` that claimed the parser does not yet accept `f/N inline` / `f/N side` declaration syntax. The parser has accepted the documented syntax since the compound declaration work landed; the surviving rationale for the synthetic `patch_compound_column` helper is exercising IR cases that either need non-default `inline_col_offset` values or deliberately inject parser-unreachable corrupt metadata states.

No production code changes; tests-and-comments only.

## Test plan

- [x] `meson test -C build test_parser` — two new regression tests pass; no regressions in pre-existing parser tests.
- [x] `meson test -C build test_program` — comment-only change; suite green.
- [x] Full suite `meson test -C build` — 202 OK / 0 Fail / 7 Skipped.

Closes #660