### PR TITLE
Route delta-cb EDB inserts through the incremental path (#662)

### DIFF
--- a/tests/test_diff_integration.c
+++ b/tests/test_diff_integration.c
@@ -77,6 +77,17 @@ noop_cb(const char *r, const int64_t *row, uint32_t nc, void *u)
     (void)u;
 }
 
+static void
+noop_delta_cb(const char *r, const int64_t *row, uint32_t nc, int32_t diff,
+    void *u)
+{
+    (void)r;
+    (void)row;
+    (void)nc;
+    (void)diff;
+    (void)u;
+}
+
 struct rel_ctx {
     const char *target;
     int64_t count;
@@ -1054,6 +1065,46 @@ test_bulk_insert_no_epoch_increment(void)
     printf("(epoch_before=%u epoch_after=%u) ", epoch_before, cs->outer_epoch);
     ASSERT(cs->outer_epoch == epoch_before,
         "bulk insert must not increment outer_epoch");
+
+    teardown(sess, plan, prog);
+    PASS();
+}
+
+/* Test 18b (#662): bulk insert under an installed delta callback must take
+ * the incremental path, mirroring wl_session_remove.  Observable witness: the
+ * outer_epoch counter advances exactly as it would for
+ * col_session_insert_incremental.  Without the symmetric routing in
+ * col_session_insert, this assertion fails (epoch stays at epoch_before),
+ * which is the engine-level signature of the wl_easy_step EXEC report in
+ * issue #662. */
+static void
+test_bulk_insert_with_delta_cb_takes_incremental_path(void)
+{
+    TEST("bulk insert under delta_cb increments outer_epoch (issue #662)");
+
+    wirelog_program_t *prog;
+    wl_plan_t *plan;
+    wl_session_t *sess;
+
+    int rc = make_session(tc_src_base, &prog, &plan, &sess);
+    ASSERT(rc == 0, "session creation failed");
+
+    wl_session_set_delta_cb(sess, noop_delta_cb, NULL);
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t epoch_before = cs->outer_epoch;
+
+    int64_t new_edge[2] = { 3, 4 };
+    rc = wl_session_insert(sess, "edge", new_edge, 1, 2);
+    ASSERT(rc == 0, "bulk insert under delta_cb failed");
+
+    printf("(epoch_before=%u epoch_after=%u) ", epoch_before, cs->outer_epoch);
+    ASSERT(cs->outer_epoch == epoch_before + 1,
+        "bulk insert with delta_cb must reroute to incremental and "
+        "increment outer_epoch");
+    ASSERT(cs->last_inserted_relation != NULL
+        && strcmp(cs->last_inserted_relation, "edge") == 0,
+        "rerouted insert must record last_inserted_relation");
 
     teardown(sess, plan, prog);
     PASS();
@@ -2493,6 +2544,7 @@ main(void)
     test_incremental_then_bulk_falls_back();
     test_bulk_insert_5node_matches_fresh();
     test_bulk_insert_no_epoch_increment();
+    test_bulk_insert_with_delta_cb_takes_incremental_path();
 
     /* Category 4: Incremental Insert + Differential Path */
     printf("\n-- Category 4: Incremental Insert + Differential Path --\n");

--- a/tests/test_wl_easy.c
+++ b/tests/test_wl_easy.c
@@ -1172,6 +1172,89 @@ test_intern_after_step_succeeds(void)
     PASS();
 }
 
+static void
+test_delta_cb_multi_round_recursive_insert(void)
+{
+    TEST("delta_cb + recursive insert/step rounds produce expected deltas");
+
+    /* Issue #662: when wl_easy_set_delta_cb has installed a callback, a
+     * subsequent wl_easy_insert must take the same incremental path that
+     * wl_easy_remove already takes, so that arrangement caches are
+     * invalidated and the outer-epoch counter advances.  Without that
+     * symmetry, a second insert+step round on a recursive stratum either
+     * skips the new iteration (no delta surfaces) or trips the join over
+     * stale arrangements and the easy facade reports WIRELOG_ERR_EXEC. */
+    static const char *RECURSIVE_REACH_SRC
+        = ".decl edge(a: int64, b: int64)\n"
+        ".decl reach(a: int64, b: int64)\n"
+        "reach(A, B) :- edge(A, B).\n"
+        "reach(A, C) :- reach(A, B), edge(B, C).\n";
+
+    wl_easy_session_t *s = NULL;
+    if (wl_easy_open(RECURSIVE_REACH_SRC, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    delta_collector_t deltas;
+    memset(&deltas, 0, sizeof(deltas));
+    if (wl_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK) {
+        FAIL("set_delta_cb failed");
+        wl_easy_close(s);
+        return;
+    }
+
+    int64_t e12[2] = { 1, 2 };
+    if (wl_easy_insert(s, "edge", e12, 2) != WIRELOG_OK) {
+        FAIL("insert edge(1,2) failed");
+        wl_easy_close(s);
+        return;
+    }
+    if (wl_easy_step(s) != WIRELOG_OK) {
+        FAIL("first step returned non-OK");
+        wl_easy_close(s);
+        return;
+    }
+    int round1_count = deltas.count;
+    if (round1_count == 0) {
+        FAIL("first step produced no deltas");
+        wl_easy_close(s);
+        return;
+    }
+
+    int64_t e23[2] = { 2, 3 };
+    if (wl_easy_insert(s, "edge", e23, 2) != WIRELOG_OK) {
+        FAIL("insert edge(2,3) failed");
+        wl_easy_close(s);
+        return;
+    }
+    if (wl_easy_step(s) != WIRELOG_OK) {
+        FAIL("second step returned non-OK (issue #662 reproduction)");
+        wl_easy_close(s);
+        return;
+    }
+
+    /* The transitive consequence reach(1,3) must surface as a +1 delta
+     * during round 2.  A bug that suppresses the new iteration (stale
+     * outer_epoch) produces +reach(2,3) but not +reach(1,3); a bug that
+     * trips the join (stale arrangements) returns non-OK above. */
+    bool saw_reach_1_3 = false;
+    for (int i = round1_count; i < deltas.count; i++) {
+        if (strcmp(deltas.relations[i], "reach") == 0
+            && deltas.ncols[i] == 2 && deltas.rows[i][0] == 1
+            && deltas.rows[i][1] == 3 && deltas.diffs[i] == 1) {
+            saw_reach_1_3 = true;
+            break;
+        }
+    }
+    wl_easy_close(s);
+    if (!saw_reach_1_3) {
+        FAIL("expected +reach(1,3) delta in round 2 not seen");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -1208,6 +1291,7 @@ main(void)
     test_print_delta_abort_on_missed_symbol();
     test_cleanup_order_no_use_after_free();
     test_intern_after_step_succeeds();
+    test_delta_cb_multi_round_recursive_insert();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1306,7 +1306,19 @@ col_session_insert(wl_session_t *session, const char *relation,
     if (!session || !relation || !data)
         return EINVAL;
 
-    col_rel_t *r = session_find_rel(COL_SESSION(session), relation);
+    /* Issue #662: When a delta callback is installed, EDB inserts must take
+     * the incremental path so arrangement caches are invalidated and the
+     * outer-epoch counter advances; otherwise a subsequent col_session_step
+     * with delta_cb may run differential operators against stale arrangement
+     * indices and surface as -1/EINVAL.  This mirrors col_session_remove,
+     * which already reroutes to col_session_remove_incremental in the same
+     * condition. */
+    wl_col_session_t *sess = COL_SESSION(session);
+    if (sess->delta_cb != NULL)
+        return col_session_insert_incremental(session, relation, data,
+                   num_rows, num_cols);
+
+    col_rel_t *r = session_find_rel(sess, relation);
     if (!r)
         return ENOENT;
 


### PR DESCRIPTION
## Summary

- `col_session_remove` already reroutes to `col_session_remove_incremental` when a delta callback is installed; `col_session_insert` was missing the symmetric route, so post-cb inserts kept the bulk path that does not invalidate arrangement caches and does not advance `outer_epoch`. Subsequent `col_session_step` calls under the delta path then ran differential operators against stale state and surfaced as `wl_easy_step` returning `WIRELOG_ERR_EXEC` on multi-relation EDB updates (issue #662).
- The fix mirrors the remove-side dispatch in `col_session_insert`. No public API or vtable change; symmetric to existing remove behavior.
- A regression gate in `tests/test_diff_integration.c` asserts that `wl_session_insert` under an installed delta callback advances `outer_epoch` exactly as `col_session_insert_incremental` would. Without the fix the assertion fails (epoch unchanged); with the fix it advances by one. A companion contract test in `tests/test_wl_easy.c` documents the expected user-facing behavior at the `wl_easy_*` surface.

Closes #662

## Test plan

- [x] `meson test -C build` — 202 OK / 0 fail / 7 skipped on the patched branch.
- [x] Verified the new gate test fails on `main` (epoch_after=0) and passes on this branch (epoch_after=1) by reverting the production diff and re-running.
- [x] `tests/test_diff_integration` 54/54, including the existing `outer_epoch` and `last_inserted_relation` invariants.
- [x] `tests/test_wl_easy` 27/27.
- [x] `tests/test_arrangement_incremental_invalidation` and `tests/test_incremental_insertion` unaffected.