### PR TITLE
[codex] Parallelize differential keyed joins

### DIFF
--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -46,6 +46,12 @@ wl_columnar_session_get_tdd_exchange_breakdown_stats(wl_session_t *sess,
 extern void
 wl_columnar_session_get_tdd_worker_width_stats(wl_session_t *sess,
     uint32_t *out_last_active_workers, uint32_t *out_max_active_workers);
+extern void
+wl_columnar_session_get_tdd_decision_stats(wl_session_t *sess,
+    uint32_t *out_recursive_strata, uint32_t *out_executed_strata,
+    uint32_t *out_fallback_strata, uint32_t *out_snapshot_ineligible,
+    uint32_t *out_no_exchange, uint32_t *out_unsafe_plan,
+    uint32_t *out_adaptive_workers, const char **out_last_fallback_reason);
 
 /* ----------------------------------------------------------------
  * Global output format and per-run profiling accumulators (3B-003)
@@ -91,6 +97,14 @@ static uint64_t g_last_tdd_exchange_broadcast_ns = 0;
 static uint64_t g_last_tdd_final_merge_ns = 0;
 static uint32_t g_last_tdd_active_workers = 0;
 static uint32_t g_last_tdd_max_active_workers = 0;
+static uint32_t g_last_tdd_recursive_strata = 0;
+static uint32_t g_last_tdd_executed_strata = 0;
+static uint32_t g_last_tdd_fallback_strata = 0;
+static uint32_t g_last_tdd_fallback_snapshot_ineligible = 0;
+static uint32_t g_last_tdd_fallback_no_exchange = 0;
+static uint32_t g_last_tdd_fallback_unsafe_plan = 0;
+static uint32_t g_last_tdd_fallback_adaptive_workers = 0;
+static const char *g_last_tdd_fallback_reason = "none";
 
 #ifndef WITH_K_FUSION
 #define WITH_K_FUSION 1
@@ -372,6 +386,15 @@ run_pipeline_count(const char *source, uint32_t num_workers, int64_t *out_count,
         &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
     wl_columnar_session_get_tdd_worker_width_stats(sess,
         &g_last_tdd_active_workers, &g_last_tdd_max_active_workers);
+    wl_columnar_session_get_tdd_decision_stats(sess,
+        &g_last_tdd_recursive_strata,
+        &g_last_tdd_executed_strata,
+        &g_last_tdd_fallback_strata,
+        &g_last_tdd_fallback_snapshot_ineligible,
+        &g_last_tdd_fallback_no_exchange,
+        &g_last_tdd_fallback_unsafe_plan,
+        &g_last_tdd_fallback_adaptive_workers,
+        &g_last_tdd_fallback_reason);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -1015,6 +1038,15 @@ run_tdd_bdx_pipeline(const int64_t *rows, uint32_t edge_count,
         &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
     wl_columnar_session_get_tdd_worker_width_stats(sess,
         &g_last_tdd_active_workers, &g_last_tdd_max_active_workers);
+    wl_columnar_session_get_tdd_decision_stats(sess,
+        &g_last_tdd_recursive_strata,
+        &g_last_tdd_executed_strata,
+        &g_last_tdd_fallback_strata,
+        &g_last_tdd_fallback_snapshot_ineligible,
+        &g_last_tdd_fallback_no_exchange,
+        &g_last_tdd_fallback_unsafe_plan,
+        &g_last_tdd_fallback_adaptive_workers,
+        &g_last_tdd_fallback_reason);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -2986,6 +3018,21 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
     printf("  \"tdd_active_workers\": %u,\n", g_last_tdd_active_workers);
     printf("  \"tdd_max_active_workers\": %u,\n",
         g_last_tdd_max_active_workers);
+    printf("  \"tdd_recursive_strata\": %u,\n",
+        g_last_tdd_recursive_strata);
+    printf("  \"tdd_executed_strata\": %u,\n",
+        g_last_tdd_executed_strata);
+    printf("  \"tdd_fallback_strata\": %u,\n",
+        g_last_tdd_fallback_strata);
+    printf("  \"tdd_fallback_reason\": \"%s\",\n",
+        g_last_tdd_fallback_reason);
+    printf("  \"tdd_fallback_reasons\": {\"snapshot_ineligible\": %u, "
+        "\"no_exchange\": %u, \"unsafe_plan\": %u, "
+        "\"adaptive_workers\": %u},\n",
+        g_last_tdd_fallback_snapshot_ineligible,
+        g_last_tdd_fallback_no_exchange,
+        g_last_tdd_fallback_unsafe_plan,
+        g_last_tdd_fallback_adaptive_workers);
     printf("  \"tdd_total_ms\": %.3f,\n",
         (double)g_last_tdd_total_ns / 1e6);
     printf("  \"tdd_total_pct\": %.1f,\n", tdd_total_pct);

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -43,6 +43,9 @@ wl_columnar_session_get_tdd_exchange_breakdown_stats(wl_session_t *sess,
     uint64_t *out_matrix_ns, uint64_t *out_coordinator_ns,
     uint64_t *out_scatter_ns, uint64_t *out_gather_ns,
     uint64_t *out_broadcast_ns);
+extern void
+wl_columnar_session_get_tdd_worker_width_stats(wl_session_t *sess,
+    uint32_t *out_last_active_workers, uint32_t *out_max_active_workers);
 
 /* ----------------------------------------------------------------
  * Global output format and per-run profiling accumulators (3B-003)
@@ -86,6 +89,8 @@ static uint64_t g_last_tdd_exchange_scatter_ns = 0;
 static uint64_t g_last_tdd_exchange_gather_ns = 0;
 static uint64_t g_last_tdd_exchange_broadcast_ns = 0;
 static uint64_t g_last_tdd_final_merge_ns = 0;
+static uint32_t g_last_tdd_active_workers = 0;
+static uint32_t g_last_tdd_max_active_workers = 0;
 
 #ifndef WITH_K_FUSION
 #define WITH_K_FUSION 1
@@ -365,6 +370,8 @@ run_pipeline_count(const char *source, uint32_t num_workers, int64_t *out_count,
         &g_last_tdd_exchange_coordinator_ns,
         &g_last_tdd_exchange_scatter_ns,
         &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
+    wl_columnar_session_get_tdd_worker_width_stats(sess,
+        &g_last_tdd_active_workers, &g_last_tdd_max_active_workers);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -1006,6 +1013,8 @@ run_tdd_bdx_pipeline(const int64_t *rows, uint32_t edge_count,
         &g_last_tdd_exchange_coordinator_ns,
         &g_last_tdd_exchange_scatter_ns,
         &g_last_tdd_exchange_gather_ns, &g_last_tdd_exchange_broadcast_ns);
+    wl_columnar_session_get_tdd_worker_width_stats(sess,
+        &g_last_tdd_active_workers, &g_last_tdd_max_active_workers);
 
     wl_session_destroy(sess);
     wl_plan_free(plan);
@@ -2974,6 +2983,9 @@ output_json_row(const char *wl_name, int32_t edges, uint32_t workers,
         ? 100.0 * tdd_phase_ns / (double)g_last_tdd_total_ns
         : 0.0;
     printf("  \"profiling_wall_ms\": %.3f,\n", g_last_wall_ms);
+    printf("  \"tdd_active_workers\": %u,\n", g_last_tdd_active_workers);
+    printf("  \"tdd_max_active_workers\": %u,\n",
+        g_last_tdd_max_active_workers);
     printf("  \"tdd_total_ms\": %.3f,\n",
         (double)g_last_tdd_total_ns / 1e6);
     printf("  \"tdd_total_pct\": %.1f,\n", tdd_total_pct);

--- a/scripts/run_doop_validation.sh
+++ b/scripts/run_doop_validation.sh
@@ -6,24 +6,33 @@
 #
 # Runs the DOOP Java points-to analysis (zxing dataset, 83MB, 34 CSV files)
 # using the bench_flowlog binary and captures wall time, peak RSS, and tuple
-# count.  Reports PASS/FAIL based on whether DOOP completes without error.
+# count.  Reports PASS/FAIL based on completion plus a tuple-count oracle when
+# one is provided.
 #
 # Usage:
 #   scripts/run_doop_validation.sh [--build-dir DIR] [--workers N]
 #                                  [--repeat N] [--baseline FILE]
+#                                  [--expected-tuples N] [--save-results]
 #
 # Options:
 #   --build-dir DIR   Meson build directory (default: build)
 #   --workers N       Worker thread count (default: 1)
 #   --repeat N        Benchmark repeat count (default: 1)
 #   --baseline FILE   TSV file with baseline metrics for comparison
+#   --expected-tuples N
+#                     Expected DOOP output tuple count. Defaults to
+#                     DOOP_EXPECTED_TUPLES when set; otherwise defaults to
+#                     6276338 for the bundled bench/data/doop zxing dataset.
+#   --save-results    Write a validation TSV under docs/performance
 #
 # Environment:
 #   DOOP_DATA_DIR     Override for DOOP CSV data directory
 #                     (default: bench/data/doop relative to project root)
+#   DOOP_EXPECTED_TUPLES
+#                     Expected DOOP output tuple count
 #
 # Output:
-#   TSV header + one result row printed to stdout.
+#   Benchmark output plus validation summary printed to stdout.
 #   Exit code 0 = DOOP completed successfully (PASS).
 #   Exit code 1 = DOOP failed or binary not found.
 #
@@ -45,6 +54,8 @@ BUILD_DIR="${BUILD_DIR:-build}"
 WORKERS="${WORKERS:-1}"
 REPEAT="${REPEAT:-1}"
 BASELINE_FILE=""
+EXPECTED_TUPLES="${DOOP_EXPECTED_TUPLES:-}"
+SAVE_RESULTS=0
 
 # -------------------------------------------------------------------------
 # Argument parsing
@@ -68,6 +79,14 @@ while [[ $# -gt 0 ]]; do
             BASELINE_FILE="$2"
             shift 2
             ;;
+        --expected-tuples)
+            EXPECTED_TUPLES="$2"
+            shift 2
+            ;;
+        --save-results)
+            SAVE_RESULTS=1
+            shift
+            ;;
         -h|--help)
             head -40 "$0" | grep '^#' | sed 's/^# \?//'
             exit 0
@@ -85,6 +104,7 @@ done
 
 BENCH_BIN="$PROJECT_ROOT/$BUILD_DIR/bench/bench_flowlog"
 DOOP_DATA="${DOOP_DATA_DIR:-$PROJECT_ROOT/bench/data/doop}"
+DEFAULT_DOOP_DATA="$PROJECT_ROOT/bench/data/doop"
 
 # -------------------------------------------------------------------------
 # Pre-flight checks
@@ -96,6 +116,7 @@ echo "Build dir    : $BUILD_DIR"
 echo "Workers      : $WORKERS"
 echo "Repeat       : $REPEAT"
 echo "DOOP data    : $DOOP_DATA"
+echo "Save results : $([[ "$SAVE_RESULTS" -eq 1 ]] && echo yes || echo no)"
 echo ""
 
 # Check bench binary
@@ -116,10 +137,19 @@ fi
 # Count CSV files
 CSV_COUNT=$(find "$DOOP_DATA" -maxdepth 1 -name "*.csv" | wc -l | tr -d ' ')
 echo "DOOP CSV files found: $CSV_COUNT (expected: 34)"
-if [[ "$CSV_COUNT" -lt 34 ]]; then
+if [[ "$CSV_COUNT" -ne 34 ]]; then
     echo "ERROR: expected 34 CSV files, found $CSV_COUNT"
     exit 1
 fi
+
+if [[ -z "$EXPECTED_TUPLES" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
+    EXPECTED_TUPLES=6276338
+fi
+if [[ -n "$EXPECTED_TUPLES" && ! "$EXPECTED_TUPLES" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: expected tuple count must be a non-negative integer"
+    exit 1
+fi
+echo "Expected tuples: ${EXPECTED_TUPLES:-not supplied}"
 
 # Spot-check a key file
 ACTPARAM="$DOOP_DATA/ActualParam.csv"
@@ -142,18 +172,16 @@ echo ""
 echo "Running DOOP benchmark..."
 echo ""
 
-# Print TSV header
-"$BENCH_BIN" --workload doop --data-doop "$DOOP_DATA" \
-             --workers "$WORKERS" --repeat "$REPEAT" \
-             --print-header 2>/dev/null || true
-
 # Run and capture output
+set +e
 BENCH_OUTPUT=$("$BENCH_BIN" \
     --workload doop \
     --data-doop "$DOOP_DATA" \
     --workers "$WORKERS" \
     --repeat "$REPEAT" \
     2>&1)
+BENCH_RC=$?
+set -e
 
 echo "$BENCH_OUTPUT"
 echo ""
@@ -163,14 +191,33 @@ echo ""
 # -------------------------------------------------------------------------
 
 # Expected TSV columns (from bench_flowlog print_header):
-# workload nodes edges workers repeat min_ms median_ms max_ms peak_rss_kb tuples status
+# workload nodes edges workers repeat min_ms median_ms max_ms peak_rss_kb tuples iterations status
 
-STATUS=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $NF}')
-MIN_MS=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $6}')
-MEDIAN_MS=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $7}')
-MAX_MS=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $8}')
-PEAK_RSS_KB=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $9}')
-TUPLES=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $10}')
+DOOP_ROWS=$(echo "$BENCH_OUTPUT" | awk -F '\t' '$1 == "doop" { print }')
+DOOP_ROW_COUNT=$(printf '%s\n' "$DOOP_ROWS" | sed '/^$/d' | wc -l | tr -d ' ')
+if [[ "$DOOP_ROW_COUNT" -ne 1 ]]; then
+    echo "RESULT: FAIL - expected exactly one doop TSV row, found $DOOP_ROW_COUNT"
+    exit 1
+fi
+DOOP_ROW="$DOOP_ROWS"
+FIELD_COUNT=$(awk -F '\t' '{ print NF }' <<< "$DOOP_ROW")
+if [[ "$FIELD_COUNT" -ne 12 ]]; then
+    echo "RESULT: FAIL - expected 12 TSV fields, found $FIELD_COUNT"
+    echo "Row: $DOOP_ROW"
+    exit 1
+fi
+
+NODES=$(awk -F '\t' '{ print $2 }' <<< "$DOOP_ROW")
+EDGES=$(awk -F '\t' '{ print $3 }' <<< "$DOOP_ROW")
+ROW_WORKERS=$(awk -F '\t' '{ print $4 }' <<< "$DOOP_ROW")
+ROW_REPEAT=$(awk -F '\t' '{ print $5 }' <<< "$DOOP_ROW")
+MIN_MS=$(awk -F '\t' '{ print $6 }' <<< "$DOOP_ROW")
+MEDIAN_MS=$(awk -F '\t' '{ print $7 }' <<< "$DOOP_ROW")
+MAX_MS=$(awk -F '\t' '{ print $8 }' <<< "$DOOP_ROW")
+PEAK_RSS_KB=$(awk -F '\t' '{ print $9 }' <<< "$DOOP_ROW")
+TUPLES=$(awk -F '\t' '{ print $10 }' <<< "$DOOP_ROW")
+ITERATIONS=$(awk -F '\t' '{ print $11 }' <<< "$DOOP_ROW")
+STATUS=$(awk -F '\t' '{ print $12 }' <<< "$DOOP_ROW")
 
 # -------------------------------------------------------------------------
 # Report metrics
@@ -179,21 +226,33 @@ TUPLES=$(echo "$BENCH_OUTPUT" | grep '^doop' | awk '{print $10}')
 echo "=== DOOP Validation Results ==="
 echo ""
 echo "Status      : ${STATUS:-UNKNOWN}"
+echo "Exit code   : $BENCH_RC"
 echo "Wall time   : min=${MIN_MS:-?}ms  median=${MEDIAN_MS:-?}ms  max=${MAX_MS:-?}ms"
 echo "Peak RSS    : ${PEAK_RSS_KB:-?} KB"
 echo "Output tuples: ${TUPLES:-?}"
+echo "Iterations  : ${ITERATIONS:-?}"
 echo ""
 
 # -------------------------------------------------------------------------
 # Correctness check
 # -------------------------------------------------------------------------
 
-if [[ "${STATUS:-FAIL}" != "OK" ]]; then
+if [[ "$BENCH_RC" -ne 0 || "${STATUS:-FAIL}" != "OK" ]]; then
     echo "RESULT: FAIL - DOOP did not complete successfully"
     echo ""
     echo "This means the evaluator timed out or produced an error on DOOP."
     echo "Option 2 + CSE must enable DOOP to complete (currently DNF)."
     exit 1
+fi
+
+if [[ -n "$EXPECTED_TUPLES" ]]; then
+    if [[ "$TUPLES" != "$EXPECTED_TUPLES" ]]; then
+        echo "RESULT: FAIL - tuple count mismatch (got $TUPLES, expected $EXPECTED_TUPLES)"
+        exit 1
+    fi
+    echo "Tuple count: MATCH ($TUPLES)"
+else
+    echo "Tuple count: not checked (no oracle supplied)"
 fi
 
 echo "RESULT: PASS - DOOP completed successfully"
@@ -205,13 +264,31 @@ echo ""
 
 if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
     echo "=== Baseline Comparison ==="
-    BASE_STATUS=$(grep '^doop' "$BASELINE_FILE" | awk '{print $NF}')
-    BASE_MEDIAN=$(grep '^doop' "$BASELINE_FILE" | awk '{print $7}')
-    BASE_TUPLES=$(grep '^doop' "$BASELINE_FILE" | awk '{print $10}')
+    BASE_ROWS=$(awk -F '\t' '$1 == "doop" { print }' "$BASELINE_FILE")
+    BASE_ROW_COUNT=$(printf '%s\n' "$BASE_ROWS" | sed '/^$/d' | wc -l | tr -d ' ')
+    if [[ "$BASE_ROW_COUNT" -ne 1 ]]; then
+        echo "RESULT: FAIL - expected exactly one doop baseline row, found $BASE_ROW_COUNT"
+        exit 1
+    fi
+    BASE_ROW="$BASE_ROWS"
+    BASE_FIELD_COUNT=$(awk -F '\t' '{ print NF }' <<< "$BASE_ROW")
+    BASE_MEDIAN=$(awk -F '\t' '{ print $7 }' <<< "$BASE_ROW")
+    BASE_TUPLES=$(awk -F '\t' '{ print $10 }' <<< "$BASE_ROW")
+    if [[ "$BASE_FIELD_COUNT" -ge 12 ]]; then
+        BASE_ITERATIONS=$(awk -F '\t' '{ print $11 }' <<< "$BASE_ROW")
+        BASE_STATUS=$(awk -F '\t' '{ print $12 }' <<< "$BASE_ROW")
+    elif [[ "$BASE_FIELD_COUNT" -eq 11 ]]; then
+        BASE_ITERATIONS=""
+        BASE_STATUS=$(awk -F '\t' '{ print $11 }' <<< "$BASE_ROW")
+    else
+        echo "RESULT: FAIL - expected 11 or more baseline fields, found $BASE_FIELD_COUNT"
+        exit 1
+    fi
 
     echo "Baseline status  : ${BASE_STATUS:-?}"
     echo "Baseline median  : ${BASE_MEDIAN:-?}ms"
     echo "Baseline tuples  : ${BASE_TUPLES:-?}"
+    echo "Baseline iterations: ${BASE_ITERATIONS:-not recorded}"
     echo ""
 
     # Tuple correctness: must match baseline exactly
@@ -221,6 +298,15 @@ if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
         else
             echo "Tuple count: MISMATCH (got $TUPLES, expected $BASE_TUPLES)"
             echo "RESULT: FAIL - Output tuple count does not match baseline"
+            exit 1
+        fi
+    fi
+    if [[ -n "$BASE_ITERATIONS" && -n "$ITERATIONS" && "$BASE_ITERATIONS" != "?" ]]; then
+        if [[ "$ITERATIONS" == "$BASE_ITERATIONS" ]]; then
+            echo "Iterations: MATCH ($ITERATIONS)"
+        else
+            echo "Iterations: MISMATCH (got $ITERATIONS, expected $BASE_ITERATIONS)"
+            echo "RESULT: FAIL - Iteration count does not match baseline"
             exit 1
         fi
     fi
@@ -237,11 +323,15 @@ fi
 # -------------------------------------------------------------------------
 
 RESULTS_DIR="$PROJECT_ROOT/docs/performance"
-if [[ -d "$RESULTS_DIR" ]]; then
+if [[ "$SAVE_RESULTS" -eq 1 ]]; then
+    mkdir -p "$RESULTS_DIR"
     RESULT_FILE="$RESULTS_DIR/doop-validation-$(date +%Y-%m-%d).tsv"
-    echo "workload	nodes	edges	workers	repeat	min_ms	median_ms	max_ms	peak_rss_kb	tuples	status" \
+    printf 'workload\tnodes\tedges\tworkers\trepeat\tmin_ms\tmedian_ms\tmax_ms\tpeak_rss_kb\ttuples\titerations\tstatus\texpected_tuples\n' \
         > "$RESULT_FILE"
-    echo "$BENCH_OUTPUT" | grep '^doop' >> "$RESULT_FILE"
+    printf 'doop\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$NODES" "$EDGES" "$ROW_WORKERS" "$ROW_REPEAT" "$MIN_MS" \
+        "$MEDIAN_MS" "$MAX_MS" "$PEAK_RSS_KB" "$TUPLES" "$ITERATIONS" \
+        "$STATUS" "${EXPECTED_TUPLES:-}" >> "$RESULT_FILE"
     echo "Results saved to: $RESULT_FILE"
 fi
 

--- a/tests/fpga_backend.c
+++ b/tests/fpga_backend.c
@@ -135,6 +135,43 @@ fpga_rowset_append_rows(fpga_rowset_t *rs, const int64_t *data,
     return 0;
 }
 
+static uint32_t
+fpga_join_output_width(const fpga_rowset_t *left, const fpga_rowset_t *right,
+    const wl_plan_op_t *op)
+{
+    return (op && op->project_count > 0 && op->project_indices)
+        ? op->project_count : left->ncols + right->ncols;
+}
+
+static int64_t
+fpga_join_pair_value(const fpga_rowset_t *left, const int64_t *lrow,
+    const fpga_rowset_t *right, const int64_t *rrow, uint32_t idx)
+{
+    if (idx < left->ncols)
+        return lrow[idx];
+    idx -= left->ncols;
+    return idx < right->ncols ? rrow[idx] : 0;
+}
+
+static uint32_t
+fpga_join_project_pair(const fpga_rowset_t *left, const int64_t *lrow,
+    const fpga_rowset_t *right, const int64_t *rrow, const wl_plan_op_t *op,
+    int64_t *out, uint32_t out_cap)
+{
+    uint32_t ci = 0;
+    if (op->project_count > 0 && op->project_indices) {
+        for (uint32_t c = 0; c < op->project_count && ci < out_cap; c++)
+            out[ci++] = fpga_join_pair_value(left, lrow, right, rrow,
+                    op->project_indices[c]);
+        return ci;
+    }
+    for (uint32_t c = 0; c < left->ncols && ci < out_cap; c++)
+        out[ci++] = lrow[c];
+    for (uint32_t c = 0; c < right->ncols && ci < out_cap; c++)
+        out[ci++] = rrow[c];
+    return ci;
+}
+
 static const int64_t *
 fpga_rowset_row(const fpga_rowset_t *rs, uint32_t idx)
 {
@@ -513,8 +550,10 @@ fpga_eval_ops(wl_fpga_session_t *s, const wl_plan_op_t *ops, uint32_t op_count)
             if (op->right_relation)
                 rrel = fpga_find_rel(s, op->right_relation);
             fpga_rowset_t result;
-            uint32_t out_cols = left.ncols
-                + (rrel ? rrel->rows.ncols : 0);
+            uint32_t out_cols = rrel
+                ? fpga_join_output_width(&left, &rrel->rows, op)
+                : ((op->project_count > 0 && op->project_indices)
+                    ? op->project_count : left.ncols);
             fpga_rowset_init(&result, out_cols);
             if (rrel && op->key_count > 0) {
                 for (uint32_t li = 0; li < left.nrows; li++) {
@@ -549,15 +588,9 @@ fpga_eval_ops(wl_fpga_session_t *s, const wl_plan_op_t *ops, uint32_t op_count)
                                 rrow, rrel->rows.ncols))
                                 continue;
                         }
-                        /* Concatenate left + right */
                         int64_t combined[128];
-                        uint32_t ci = 0;
-                        for (uint32_t c = 0; c < left.ncols && ci < 128;
-                            c++)
-                            combined[ci++] = lrow[c];
-                        for (uint32_t c = 0;
-                            c < rrel->rows.ncols && ci < 128; c++)
-                            combined[ci++] = rrow[c];
+                        uint32_t ci = fpga_join_project_pair(&left, lrow,
+                                &rrel->rows, rrow, op, combined, 128);
                         fpga_rowset_append(&result, combined, ci);
                     }
                 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -224,7 +224,7 @@ test('bench_flowlog_tdd_bdx_json', bench_flowlog_json_py3,
      args: [
        bench_flowlog_tdd_json_validator[0],
        bench_flowlog.full_path(),
-       meson.project_source_root() / 'bench/data/graph_10.csv',
+       meson.project_source_root() / 'bench/data/graph_100.csv',
      ],
      depends: bench_flowlog,
      suite: 'bench',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3382,6 +3382,23 @@ test_safe_worker_scaling_exe = executable(
 
 test('safe_worker_scaling', test_safe_worker_scaling_exe)
 
+test_workers_as_cap_exe = executable(
+  'test_workers_as_cap',
+  files('test_workers_as_cap.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('workers_as_cap', test_workers_as_cap_exe)
+
 # ============================================================================
 # Queue Transport Equivalence and Stress Tests (Issue #410)
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3335,6 +3335,23 @@ test_tdd_decision_stats_exe = executable(
 
 test('tdd_decision_stats', test_tdd_decision_stats_exe)
 
+test_constant_filter_pushdown_exe = executable(
+  'test_constant_filter_pushdown',
+  files('test_constant_filter_pushdown.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('constant_filter_pushdown', test_constant_filter_pushdown_exe)
+
 # ============================================================================
 # Safe Worker Scaling Tests (Issue #409)
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2055,6 +2055,23 @@ test_join_limit_exe = executable(
 
 test('join_limit', test_join_limit_exe)
 
+test_join_overflow_exe = executable(
+  'test_join_overflow',
+  files('test_join_overflow.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('join_overflow', test_join_overflow_exe)
+
 # ============================================================================
 # WL_MAX_WORKERS Clamping Tests (Issue #398)
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3318,6 +3318,23 @@ test_tdd_multiworker_exe = executable(
 
 test('tdd_multiworker', test_tdd_multiworker_exe)
 
+test_tdd_decision_stats_exe = executable(
+  'test_tdd_decision_stats',
+  files('test_tdd_decision_stats.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('tdd_decision_stats', test_tdd_decision_stats_exe)
+
 # ============================================================================
 # Safe Worker Scaling Tests (Issue #409)
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2164,6 +2164,15 @@ test_diff_arrangement_exe = executable(
 
 test('diff_arrangement', test_diff_arrangement_exe)
 
+test_diff_arrangement_deep_copy_buckets_exe = executable(
+  'test_diff_arrangement_deep_copy_buckets',
+  files('test_diff_arrangement_deep_copy_buckets.c'),
+  '../wirelog/columnar/diff_arrangement.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+
+test('diff_arrangement_deep_copy_buckets', test_diff_arrangement_deep_copy_buckets_exe)
+
 # ============================================================================
 # Multi-Worker K-Fusion Validation Tests (Issue #260)
 # ============================================================================

--- a/tests/test_constant_filter_pushdown.c
+++ b/tests/test_constant_filter_pushdown.c
@@ -1,0 +1,137 @@
+/*
+ * test_constant_filter_pushdown.c - explicit equality pushdown regression
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct count_ctx {
+    const char *relation;
+    int64_t count;
+} count_ctx_t;
+
+static void
+count_relation_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    count_ctx_t *ctx = (count_ctx_t *)user_data;
+    (void)row;
+    (void)ncols;
+    if (ctx->relation && relation && strcmp(ctx->relation, relation) == 0)
+        ctx->count++;
+}
+
+static wl_plan_t *
+build_plan(const char *src)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0)
+        return NULL;
+    return plan;
+}
+
+static int
+run_case(const char *rule)
+{
+    char src[512];
+    snprintf(src, sizeof(src),
+        ".decl a(s: int32)\n"
+        ".decl b(t: int32)\n"
+        ".decl out(s: int32, t: int32)\n"
+        "%s\n",
+        rule);
+
+    wl_plan_t *plan = build_plan(src);
+    if (!plan)
+        return 1;
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    wl_col_session_t *col_session = (wl_col_session_t *)session;
+    col_session->join_output_limit = 3000;
+
+    const uint32_t rows = 2000;
+    int64_t *a_rows = (int64_t *)calloc(rows, sizeof(int64_t));
+    int64_t *b_rows = (int64_t *)calloc(rows, sizeof(int64_t));
+    if (!a_rows || !b_rows) {
+        free(a_rows);
+        free(b_rows);
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    for (uint32_t i = 0; i < rows; i++) {
+        a_rows[i] = (int64_t)i;
+        b_rows[i] = (int64_t)i;
+    }
+    b_rows[7] = 7;
+
+    rc = wl_session_insert(session, "a", a_rows, rows, 1);
+    if (rc == 0)
+        rc = wl_session_insert(session, "b", b_rows, rows, 1);
+
+    count_ctx_t ctx = { "out", 0 };
+    if (rc == 0)
+        rc = wl_session_snapshot(session, count_relation_cb, &ctx);
+
+    free(a_rows);
+    free(b_rows);
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+
+    return rc == 0 && ctx.count == rows ? 0 : 1;
+}
+
+static int
+expect(const char *name, int ok)
+{
+    if (ok) {
+        printf("%s ... PASS\n", name);
+        return 0;
+    }
+    printf("%s ... FAIL\n", name);
+    return 1;
+}
+
+int
+main(void)
+{
+    int failed = 0;
+
+    failed += expect("explicit var-constant equality pushed before join",
+            run_case("out(s, t) :- a(s), b(t), t = 7.") == 0);
+    failed += expect("explicit constant-var equality pushed before join",
+            run_case("out(s, t) :- a(s), b(t), 7 = t.") == 0);
+
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_diff_arrangement_deep_copy_buckets.c
+++ b/tests/test_diff_arrangement_deep_copy_buckets.c
@@ -1,0 +1,50 @@
+/*
+ * test_diff_arrangement_deep_copy_buckets.c - deep-copy bucket sizing
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "wirelog/columnar/diff_arrangement.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+static int
+expect(const char *name, int ok)
+{
+    if (ok) {
+        printf("%s ... PASS\n", name);
+        return 0;
+    }
+    printf("%s ... FAIL\n", name);
+    return 1;
+}
+
+int
+main(void)
+{
+    uint32_t key_cols[] = { 0 };
+    col_diff_arrangement_t *arr
+        = col_diff_arrangement_create(key_cols, 1, 0);
+    if (!arr)
+        return expect("create arrangement", 0);
+
+    int failed = 0;
+    failed += expect("grow creates more buckets than chain capacity",
+            col_diff_arrangement_ensure_ht_capacity(arr, 8000) == 0
+            && arr->nbuckets > arr->ht_cap);
+
+    uint32_t bucket = arr->nbuckets - 1;
+    arr->ht_head[bucket] = 1234;
+
+    col_diff_arrangement_t *copy = col_diff_arrangement_deep_copy(arr);
+    failed += expect("deep copy preserves high bucket head",
+            copy && copy->nbuckets == arr->nbuckets
+            && copy->ht_cap == arr->ht_cap
+            && copy->ht_head[bucket] == 1234);
+
+    col_diff_arrangement_destroy(copy);
+    col_diff_arrangement_destroy(arr);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_diff_join.c
+++ b/tests/test_diff_join.c
@@ -150,6 +150,95 @@ run_standard_join(wl_col_session_t *sess, col_rel_t *left)
 }
 
 static col_rel_t *
+run_projected_join(wl_col_session_t *sess, col_rel_t *left, bool diff)
+{
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"k"};
+    char *rkeys[] = {"k"};
+    uint32_t project_indices[] = {1, 3};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.project_indices = project_indices;
+    op.project_count = 2;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, false);
+
+    int rc = diff ? col_op_join_diff(&op, &stack, sess)
+                  : col_op_join(&op, &stack, sess);
+    if (rc != 0)
+        return NULL;
+    eval_entry_t result = eval_stack_pop(&stack);
+    if (!result.owned)
+        return NULL;
+    return result.rel;
+}
+
+static col_rel_t *
+run_projected_join_with_indices(wl_col_session_t *sess, col_rel_t *left,
+    const uint32_t *project_indices, uint32_t project_count, bool materialized)
+{
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"k"};
+    char *rkeys[] = {"k"};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.project_indices = project_indices;
+    op.project_count = project_count;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+    op.materialized = materialized;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, false);
+
+    int rc = col_op_join(&op, &stack, sess);
+    if (rc != 0)
+        return NULL;
+    eval_entry_t result = eval_stack_pop(&stack);
+    if (!result.owned)
+        return NULL;
+    return result.rel;
+}
+
+static col_rel_t *
+run_projected_unary_join(wl_col_session_t *sess, col_rel_t *left)
+{
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"k"};
+    char *rkeys[] = {"k"};
+    uint32_t project_indices[] = {1, 2};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.project_indices = project_indices;
+    op.project_count = 2;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, false);
+
+    int rc = col_op_join(&op, &stack, sess);
+    if (rc != 0)
+        return NULL;
+    eval_entry_t result = eval_stack_pop(&stack);
+    if (!result.owned)
+        return NULL;
+    return result.rel;
+}
+
+static col_rel_t *
 run_cross_join(wl_col_session_t *sess, col_rel_t *left)
 {
     wl_plan_op_t op = {0};
@@ -169,6 +258,57 @@ run_cross_join(wl_col_session_t *sess, col_rel_t *left)
     if (!result.owned)
         return NULL;
     return result.rel;
+}
+
+static col_rel_t *
+make_project_left_rel(void)
+{
+    const char *cn[] = {"k", "v"};
+    col_rel_t *left = make_rel("left", 2, cn);
+    if (!left)
+        return NULL;
+    int64_t row1[] = {1, 10};
+    int64_t row2[] = {2, 20};
+    if (col_rel_append_row(left, row1) != 0
+        || col_rel_append_row(left, row2) != 0) {
+        col_rel_destroy(left);
+        return NULL;
+    }
+    return left;
+}
+
+static col_rel_t *
+make_project_right_rel(void)
+{
+    const char *cn[] = {"k", "r"};
+    col_rel_t *right = make_rel("right", 2, cn);
+    if (!right)
+        return NULL;
+    int64_t row1[] = {1, 100};
+    int64_t row2[] = {2, 200};
+    if (col_rel_append_row(right, row1) != 0
+        || col_rel_append_row(right, row2) != 0) {
+        col_rel_destroy(right);
+        return NULL;
+    }
+    return right;
+}
+
+static col_rel_t *
+make_project_unary_right_rel(void)
+{
+    const char *cn[] = {"k"};
+    col_rel_t *right = make_rel("right", 1, cn);
+    if (!right)
+        return NULL;
+    int64_t row1[] = {1};
+    int64_t row2[] = {2};
+    if (col_rel_append_row(right, row1) != 0
+        || col_rel_append_row(right, row2) != 0) {
+        col_rel_destroy(right);
+        return NULL;
+    }
+    return right;
 }
 
 static col_rel_t *
@@ -996,6 +1136,121 @@ test_diff_arr_entry_cleanup(void)
 }
 
 static void
+test_projected_join_emits_projected_columns(void)
+{
+    TEST("projected join emits projected columns");
+
+    wl_col_session_t *sess = make_mock_session();
+    col_rel_t *left = make_project_left_rel();
+    col_rel_t *right = make_project_right_rel();
+    ASSERT_TRUE(left && right, "relations allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    col_rel_t *out = run_projected_join(sess, left, false);
+    ASSERT_TRUE(out != NULL, "projected join output");
+    ASSERT_TRUE(out->ncols == 2, "projected column count");
+    ASSERT_TRUE(out->nrows == 2, "projected row count");
+    int64_t expected1[] = {10, 100};
+    int64_t expected2[] = {20, 200};
+    ASSERT_TRUE(output_contains_row(out, expected1), "contains first row");
+    ASSERT_TRUE(output_contains_row(out, expected2), "contains second row");
+
+    col_rel_destroy(out);
+    col_rel_destroy(left);
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
+test_projected_diff_join_emits_projected_columns(void)
+{
+    TEST("projected diff join emits projected columns");
+
+    wl_col_session_t *sess = make_mock_session();
+    col_rel_t *left = make_project_left_rel();
+    col_rel_t *right = make_project_right_rel();
+    ASSERT_TRUE(left && right, "relations allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    col_rel_t *out = run_projected_join(sess, left, true);
+    ASSERT_TRUE(out != NULL, "projected diff join output");
+    ASSERT_TRUE(out->ncols == 2, "projected column count");
+    ASSERT_TRUE(out->nrows == 2, "projected row count");
+    int64_t expected1[] = {10, 100};
+    int64_t expected2[] = {20, 200};
+    ASSERT_TRUE(output_contains_row(out, expected1), "contains first row");
+    ASSERT_TRUE(output_contains_row(out, expected2), "contains second row");
+
+    col_rel_destroy(out);
+    col_rel_destroy(left);
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
+test_projected_unary_join_emits_projected_columns(void)
+{
+    TEST("projected unary join emits projected columns");
+
+    wl_col_session_t *sess = make_mock_session();
+    col_rel_t *left = make_project_left_rel();
+    col_rel_t *right = make_project_unary_right_rel();
+    ASSERT_TRUE(left && right, "relations allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    col_rel_t *out = run_projected_unary_join(sess, left);
+    ASSERT_TRUE(out != NULL, "projected unary join output");
+    ASSERT_TRUE(out->ncols == 2, "projected column count");
+    ASSERT_TRUE(out->nrows == 2, "projected row count");
+    int64_t expected1[] = {10, 1};
+    int64_t expected2[] = {20, 2};
+    ASSERT_TRUE(output_contains_row(out, expected1), "contains first row");
+    ASSERT_TRUE(output_contains_row(out, expected2), "contains second row");
+
+    col_rel_destroy(out);
+    col_rel_destroy(left);
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
+test_projected_materialized_join_does_not_reuse_wrong_shape(void)
+{
+    TEST("projected materialized join does not reuse wrong shape");
+
+    wl_col_session_t *sess = make_mock_session();
+    col_rel_t *left1 = make_project_left_rel();
+    col_rel_t *left2 = make_project_left_rel();
+    col_rel_t *right = make_project_right_rel();
+    ASSERT_TRUE(left1 && left2 && right, "relations allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    uint32_t first_projection[] = {1, 3};
+    col_rel_t *out1 = run_projected_join_with_indices(sess, left1,
+            first_projection, 2, true);
+    ASSERT_TRUE(out1 != NULL, "first projected materialized join output");
+    ASSERT_TRUE(out1->ncols == 2, "first projected column count");
+
+    uint32_t second_projection[] = {3};
+    col_rel_t *out2 = run_projected_join_with_indices(sess, left2,
+            second_projection, 1, true);
+    ASSERT_TRUE(out2 != NULL, "second projected materialized join output");
+    ASSERT_TRUE(out2->ncols == 1, "second projected column count");
+    ASSERT_TRUE(out2->nrows == 2, "second projected row count");
+    int64_t expected1[] = {100};
+    int64_t expected2[] = {200};
+    ASSERT_TRUE(output_contains_row(out2, expected1), "contains first row");
+    ASSERT_TRUE(output_contains_row(out2, expected2), "contains second row");
+
+    col_rel_destroy(out1);
+    col_rel_destroy(out2);
+    col_rel_destroy(left1);
+    col_rel_destroy(left2);
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
 test_direct_standard_join_matches_serial_with_workers(void)
 {
     TEST("direct standard join matches serial output with workers");
@@ -1108,6 +1363,10 @@ main(void)
     test_force_full_mode();
     test_delta_substitution();
     test_diff_arr_entry_cleanup();
+    test_projected_join_emits_projected_columns();
+    test_projected_diff_join_emits_projected_columns();
+    test_projected_unary_join_emits_projected_columns();
+    test_projected_materialized_join_does_not_reuse_wrong_shape();
     test_direct_standard_join_matches_serial_with_workers();
     test_parallel_cross_join_matches_serial();
 

--- a/tests/test_diff_join.c
+++ b/tests/test_diff_join.c
@@ -82,6 +82,7 @@ destroy_mock_session(wl_col_session_t *s)
     }
     free(s->arr_entries);
     col_session_free_diff_arrangements(s);
+    col_mat_cache_clear(&s->mat_cache);
     session_rel_free_hash(s);
     delta_pool_destroy(s->delta_pool);
     free(s);
@@ -1251,6 +1252,53 @@ test_projected_materialized_join_does_not_reuse_wrong_shape(void)
 }
 
 static void
+test_materialized_join_cleans_owned_left(void)
+{
+    TEST("materialized join cleans owned left");
+
+    wl_col_session_t *sess = make_mock_session();
+    col_rel_t *left = make_project_left_rel();
+    col_rel_t *right = make_project_right_rel();
+    ASSERT_TRUE(left && right, "relations allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"k"};
+    char *rkeys[] = {"k"};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+    op.materialized = true;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, true);
+    int rc = col_op_join(&op, &stack, sess);
+    ASSERT_TRUE(rc == 0, "materialized join output");
+    eval_entry_t out = eval_stack_pop(&stack);
+    ASSERT_TRUE(out.rel != NULL, "result relation exists");
+    ASSERT_TRUE(!out.owned, "materialized result is cache-owned");
+    ASSERT_TRUE(out.rel->nrows == 2, "materialized row count");
+
+    col_rel_t *left_hit = make_project_left_rel();
+    ASSERT_TRUE(left_hit != NULL, "cache-hit left allocated");
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left_hit, true);
+    rc = col_op_join(&op, &stack, sess);
+    ASSERT_TRUE(rc == 0, "materialized cache hit output");
+    eval_entry_t hit = eval_stack_pop(&stack);
+    ASSERT_TRUE(hit.rel == out.rel, "cache hit reuses cached result");
+    ASSERT_TRUE(!hit.owned, "cache-hit result is cache-owned");
+    ASSERT_TRUE(hit.rel->nrows == 2, "cache-hit row count");
+
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
 test_direct_standard_join_matches_serial_with_workers(void)
 {
     TEST("direct standard join matches serial output with workers");
@@ -1367,6 +1415,7 @@ main(void)
     test_projected_diff_join_emits_projected_columns();
     test_projected_unary_join_emits_projected_columns();
     test_projected_materialized_join_does_not_reuse_wrong_shape();
+    test_materialized_join_cleans_owned_left();
     test_direct_standard_join_matches_serial_with_workers();
     test_parallel_cross_join_matches_serial();
 

--- a/tests/test_diff_join.c
+++ b/tests/test_diff_join.c
@@ -48,6 +48,9 @@
 static int tests_passed = 0;
 static int tests_failed = 0;
 
+static col_rel_t *
+make_rel(const char *name, uint32_t ncols, const char *const *col_names);
+
 /* ========================================================================
  * Helpers
  * ======================================================================== */
@@ -65,6 +68,7 @@ make_mock_session(void)
 static void
 destroy_mock_session(wl_col_session_t *s)
 {
+    wl_workqueue_destroy(s->wq);
     for (uint32_t i = 0; i < s->nrels; i++) {
         col_rel_free_contents(s->rels[i]);
         free(s->rels[i]);
@@ -81,6 +85,90 @@ destroy_mock_session(wl_col_session_t *s)
     session_rel_free_hash(s);
     delta_pool_destroy(s->delta_pool);
     free(s);
+}
+
+static col_rel_t *
+make_large_left_rel(void)
+{
+    const char *cn[] = {"k", "v"};
+    col_rel_t *left = make_rel("left", 2, cn);
+    if (!left)
+        return NULL;
+    for (int64_t i = 0; i < 20000; i++) {
+        int64_t row[] = {i % 8, i};
+        if (col_rel_append_row(left, row) != 0) {
+            col_rel_destroy(left);
+            return NULL;
+        }
+    }
+    return left;
+}
+
+static col_rel_t *
+make_large_right_rel(void)
+{
+    const char *cn[] = {"k", "r"};
+    col_rel_t *right = make_rel("right", 2, cn);
+    if (!right)
+        return NULL;
+    for (int64_t k = 0; k < 8; k++) {
+        int64_t row1[] = {k, 100 + k};
+        int64_t row2[] = {k, 200 + k};
+        if (col_rel_append_row(right, row1) != 0
+            || col_rel_append_row(right, row2) != 0) {
+            col_rel_destroy(right);
+            return NULL;
+        }
+    }
+    return right;
+}
+
+static col_rel_t *
+run_standard_join(wl_col_session_t *sess, col_rel_t *left)
+{
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"k"};
+    char *rkeys[] = {"k"};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, false);
+
+    int rc = col_op_join(&op, &stack, sess);
+    if (rc != 0)
+        return NULL;
+    eval_entry_t result = eval_stack_pop(&stack);
+    if (!result.owned)
+        return NULL;
+    return result.rel;
+}
+
+static col_rel_t *
+run_cross_join(wl_col_session_t *sess, col_rel_t *left)
+{
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 0;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    eval_stack_push(&stack, left, false);
+
+    int rc = col_op_join(&op, &stack, sess);
+    if (rc != 0)
+        return NULL;
+    eval_entry_t result = eval_stack_pop(&stack);
+    if (!result.owned)
+        return NULL;
+    return result.rel;
 }
 
 static col_rel_t *
@@ -907,6 +995,94 @@ test_diff_arr_entry_cleanup(void)
     PASS;
 }
 
+static void
+test_direct_standard_join_matches_serial_with_workers(void)
+{
+    TEST("direct standard join matches serial output with workers");
+
+    wl_col_session_t *serial = make_mock_session();
+    wl_col_session_t *parallel = make_mock_session();
+    parallel->num_workers = 4;
+    parallel->wq = wl_workqueue_create(parallel->num_workers);
+    ASSERT_TRUE(parallel->wq != NULL, "workqueue create");
+
+    col_rel_t *serial_left = make_large_left_rel();
+    col_rel_t *parallel_left = make_large_left_rel();
+    col_rel_t *serial_right = make_large_right_rel();
+    col_rel_t *parallel_right = make_large_right_rel();
+    ASSERT_TRUE(serial_left && parallel_left && serial_right && parallel_right,
+        "relations allocated");
+    ASSERT_TRUE(session_add_rel(serial, serial_right) == 0,
+        "serial right registered");
+    ASSERT_TRUE(session_add_rel(parallel, parallel_right) == 0,
+        "parallel right registered");
+
+    col_rel_t *serial_out = run_standard_join(serial, serial_left);
+    col_rel_t *parallel_out = run_standard_join(parallel, parallel_left);
+    ASSERT_TRUE(serial_out && parallel_out, "join outputs");
+    ASSERT_TRUE(serial_out->nrows == parallel_out->nrows, "row count");
+    ASSERT_TRUE(serial_out->ncols == parallel_out->ncols, "column count");
+    for (uint32_t r = 0; r < serial_out->nrows; r++) {
+        for (uint32_t c = 0; c < serial_out->ncols; c++) {
+            ASSERT_TRUE(col_rel_get(serial_out, r, c)
+                == col_rel_get(parallel_out, r, c),
+                "worker-enabled output preserves deterministic row order");
+        }
+    }
+
+    col_rel_destroy(serial_out);
+    col_rel_destroy(parallel_out);
+    col_rel_destroy(serial_left);
+    col_rel_destroy(parallel_left);
+    destroy_mock_session(serial);
+    destroy_mock_session(parallel);
+    PASS;
+}
+
+static void
+test_parallel_cross_join_matches_serial(void)
+{
+    TEST("parallel cross join matches serial output");
+
+    wl_col_session_t *serial = make_mock_session();
+    wl_col_session_t *parallel = make_mock_session();
+    parallel->num_workers = 4;
+    parallel->wq = wl_workqueue_create(parallel->num_workers);
+    ASSERT_TRUE(parallel->wq != NULL, "workqueue create");
+
+    col_rel_t *serial_left = make_large_left_rel();
+    col_rel_t *parallel_left = make_large_left_rel();
+    col_rel_t *serial_right = make_large_right_rel();
+    col_rel_t *parallel_right = make_large_right_rel();
+    ASSERT_TRUE(serial_left && parallel_left && serial_right && parallel_right,
+        "relations allocated");
+    ASSERT_TRUE(session_add_rel(serial, serial_right) == 0,
+        "serial right registered");
+    ASSERT_TRUE(session_add_rel(parallel, parallel_right) == 0,
+        "parallel right registered");
+
+    col_rel_t *serial_out = run_cross_join(serial, serial_left);
+    col_rel_t *parallel_out = run_cross_join(parallel, parallel_left);
+    ASSERT_TRUE(serial_out && parallel_out, "join outputs");
+    ASSERT_TRUE(serial_out->nrows == parallel_out->nrows, "row count");
+    ASSERT_TRUE(serial_out->ncols == parallel_out->ncols, "column count");
+    for (uint32_t r = 0; r < serial_out->nrows; r++) {
+        for (uint32_t c = 0; c < serial_out->ncols; c++) {
+            ASSERT_TRUE(col_rel_get(serial_out, r, c)
+                == col_rel_get(parallel_out, r, c),
+                "parallel cross output preserves deterministic row order");
+        }
+    }
+
+    col_rel_destroy(serial_out);
+    col_rel_destroy(parallel_out);
+    col_rel_destroy(serial_left);
+    col_rel_destroy(parallel_left);
+    destroy_mock_session(serial);
+    destroy_mock_session(parallel);
+    PASS;
+}
+
 /* ========================================================================
  * MAIN
  * ======================================================================== */
@@ -932,6 +1108,8 @@ main(void)
     test_force_full_mode();
     test_delta_substitution();
     test_diff_arr_entry_cleanup();
+    test_direct_standard_join_matches_serial_with_workers();
+    test_parallel_cross_join_matches_serial();
 
     printf("\n=== Results: %d/%d passed ===\n",
         tests_passed, tests_passed + tests_failed);

--- a/tests/test_join_overflow.c
+++ b/tests/test_join_overflow.c
@@ -1,0 +1,248 @@
+#define _GNU_SOURCE
+
+/*
+ * test_join_overflow.c - join overflow failure semantics
+ *
+ * Verifies that join output limit overflow fails closed instead of publishing
+ * partial join results.
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+            return 1;                         \
+        } while (0)
+
+static void
+noop_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)user_data;
+}
+
+static int
+create_session_from_source(const char *src, uint32_t workers,
+    wirelog_program_t **out_prog, wl_plan_t **out_plan, wl_session_t **out_sess)
+{
+    *out_prog = NULL;
+    *out_plan = NULL;
+    *out_sess = NULL;
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return rc;
+    }
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);
+    if (rc != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return rc;
+    }
+
+    *out_prog = prog;
+    *out_plan = plan;
+    *out_sess = sess;
+    return 0;
+}
+
+static int
+run_snapshot_with_limit(const char *src, uint32_t workers, const char *limit,
+    bool diff_enabled)
+{
+    setenv("WIRELOG_JOIN_OUTPUT_LIMIT", limit, 1);
+
+    wirelog_program_t *prog = NULL;
+    wl_plan_t *plan = NULL;
+    wl_session_t *sess = NULL;
+    int rc = create_session_from_source(src, workers, &prog, &plan, &sess);
+    if (rc == 0)
+        ((wl_col_session_t *)sess)->diff_enabled = diff_enabled;
+    if (rc == 0)
+        rc = wl_session_load_facts(sess, prog);
+    if (rc == 0)
+        rc = wl_session_snapshot(sess, noop_tuple_cb, NULL);
+
+    if (sess)
+        wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    unsetenv("WIRELOG_JOIN_OUTPUT_LIMIT");
+    return rc;
+}
+
+static int
+run_incremental_snapshot_with_limit(const char *src, const char *limit,
+    const char *relation, const int64_t *rows, uint32_t num_rows,
+    uint32_t num_cols)
+{
+    setenv("WIRELOG_JOIN_OUTPUT_LIMIT", limit, 1);
+
+    wirelog_program_t *prog = NULL;
+    wl_plan_t *plan = NULL;
+    wl_session_t *sess = NULL;
+    int rc = create_session_from_source(src, 1, &prog, &plan, &sess);
+    if (rc == 0)
+        ((wl_col_session_t *)sess)->diff_enabled = true;
+    if (rc == 0)
+        rc = wl_session_snapshot(sess, noop_tuple_cb, NULL);
+    if (rc == 0)
+        rc = col_session_insert_incremental(sess, relation, rows, num_rows,
+                num_cols);
+    if (rc == 0)
+        rc = wl_session_snapshot(sess, noop_tuple_cb, NULL);
+
+    if (sess)
+        wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    unsetenv("WIRELOG_JOIN_OUTPUT_LIMIT");
+    return rc;
+}
+
+static int
+test_keyed_join_overflow(void)
+{
+    TEST("keyed join overflow returns EOVERFLOW");
+
+    const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(x: int32, z: int32)\n"
+        ".decl r(x: int32, z: int32)\n"
+        "a(1, 100). a(1, 101).\n"
+        "b(1, 10). b(1, 11).\n"
+        "r(x, z) :- a(x, _), b(x, z).\n";
+
+    int rc = run_snapshot_with_limit(src, 1, "1", false);
+    if (rc != EOVERFLOW) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected EOVERFLOW, got %d", rc);
+        FAIL(msg);
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_unary_join_overflow(void)
+{
+    TEST("unary join overflow returns EOVERFLOW");
+
+    const char *src = ".decl a(x: int32)\n"
+        ".decl b(x: int32, y: int32)\n"
+        ".decl r(x: int32, y: int32)\n"
+        "a(1).\n"
+        "b(1, 10). b(1, 11).\n"
+        "r(x, y) :- b(x, y), a(x).\n";
+
+    int rc = run_snapshot_with_limit(src, 1, "1", false);
+    if (rc != EOVERFLOW) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected EOVERFLOW, got %d", rc);
+        FAIL(msg);
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_diff_join_overflow(void)
+{
+    TEST("differential join overflow returns EOVERFLOW");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
+    int64_t rows[] = { 1, 2, 2, 3, 3, 4 };
+
+    int rc = run_incremental_snapshot_with_limit(src, "1", "edge", rows, 3, 2);
+    if (rc != EOVERFLOW) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected EOVERFLOW, got %d", rc);
+        FAIL(msg);
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_k_fusion_worker_limit_overflow(void)
+{
+    TEST("K-fusion worker limit overflow returns EOVERFLOW");
+
+    const char *src = ".decl r(x: int32, y: int32)\n"
+        "r(1, 1). r(1, 2). r(2, 1). r(2, 2).\n"
+        "r(a, e) :- r(a, b), r(b, c), r(c, d), r(d, e).\n";
+
+    int rc = run_snapshot_with_limit(src, 8, "64", false);
+    if (rc != EOVERFLOW) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "expected EOVERFLOW, got %d", rc);
+        FAIL(msg);
+    }
+    PASS();
+    return 0;
+}
+
+int
+main(void)
+{
+    printf("=== test_join_overflow ===\n");
+
+    test_keyed_join_overflow();
+    test_unary_join_overflow();
+    test_diff_join_overflow();
+    test_k_fusion_worker_limit_overflow();
+
+    printf("\nPassed: %d/%d\n", tests_passed, tests_run);
+    printf("Failed: %d/%d\n", tests_failed, tests_run);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_k_fusion_e2e.c
+++ b/tests/test_k_fusion_e2e.c
@@ -93,8 +93,8 @@ count_tuples_cb(const char *relation, const int64_t *row, uint32_t ncols,
  * ---------------------------------------------------------------- */
 
 static int
-run_program(const char *src, const char *tracked_rel, int64_t *out_count,
-    uint32_t *out_iters)
+run_program_with_workers(const char *src, const char *tracked_rel,
+    uint32_t workers, int64_t *out_count, uint32_t *out_iters)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -113,7 +113,7 @@ run_program(const char *src, const char *tracked_rel, int64_t *out_count,
     }
 
     wl_session_t *sess = NULL;
-    rc = wl_session_create(wl_backend_columnar(), plan, 1, &sess);
+    rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);
     if (rc != 0) {
         wl_plan_free(plan);
         wirelog_program_free(prog);
@@ -146,6 +146,13 @@ run_program(const char *src, const char *tracked_rel, int64_t *out_count,
     wl_plan_free(plan);
     wirelog_program_free(prog);
     return 0;
+}
+
+static int
+run_program(const char *src, const char *tracked_rel, int64_t *out_count,
+    uint32_t *out_iters)
+{
+    return run_program_with_workers(src, tracked_rel, 1, out_count, out_iters);
 }
 
 /* ================================================================
@@ -537,6 +544,30 @@ test_k2_all_inactive_branches_preserve_target_schema(void)
 }
 
 /* ================================================================
+ * Test 11: W>1, K below parallel threshold uses the same semantics
+ *
+ * K=2 is below WL_KFUSION_MIN_PARALLEL_K. A multi-worker session should
+ * still produce the same closure while using the serial K-fusion evaluator
+ * instead of allocating branch worker sessions.
+ * ================================================================ */
+static void
+test_k2_multiworker_threshold_serial_semantics(void)
+{
+    TEST("K=2 W=8 threshold serial path preserves closure");
+
+    const char *src = ".decl r(x: int32, y: int32)\n"
+        "r(1, 2). r(2, 3). r(3, 4).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
+
+    int64_t count = 0;
+    int rc = run_program_with_workers(src, "r", 8, &count, NULL);
+    ASSERT(rc == 0, "K=2 W=8 program execution failed");
+    ASSERT(count == 6, "K=2 W=8 should produce 6 tuples");
+
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 
@@ -555,6 +586,7 @@ main(void)
     test_k2_multi_rule_union_cspa_pattern();
     test_k2_multi_rule_union_unique_contributions();
     test_k2_all_inactive_branches_preserve_target_schema();
+    test_k2_multiworker_threshold_serial_semantics();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_k_fusion_e2e.c
+++ b/tests/test_k_fusion_e2e.c
@@ -18,6 +18,7 @@
  */
 
 #include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/ir/program.h"
 #include "../wirelog/passes/fusion.h"
@@ -466,6 +467,76 @@ test_k2_multi_rule_union_unique_contributions(void)
 }
 
 /* ================================================================
+ * Test 10: All inactive K-fusion branches keep target schema
+ *
+ * In iteration > 0, FORCE_DELTA branches whose delta relation is absent
+ * are inactive. The parallel K-fusion path should short-circuit without
+ * allocating worker sessions, but the produced empty relation must still
+ * carry the target relation's column count.
+ * ================================================================ */
+static void
+test_k2_all_inactive_branches_preserve_target_schema(void)
+{
+    TEST("K=2 all inactive branches preserve target schema");
+
+    wl_col_session_t sess;
+    memset(&sess, 0, sizeof(sess));
+    sess.num_workers = 2;
+    sess.current_iteration = 1;
+
+    col_rel_t *target = col_rel_new_auto("out", 3);
+    ASSERT(target != NULL, "target relation allocation failed");
+    int rc = session_add_rel(&sess, target);
+    ASSERT(rc == 0, "target relation registration failed");
+
+    wl_plan_op_t branch0[] = {
+        {
+            .op = WL_PLAN_OP_VARIABLE,
+            .relation_name = "r",
+            .delta_mode = WL_DELTA_FORCE_DELTA,
+        },
+    };
+    wl_plan_op_t branch1[] = {
+        {
+            .op = WL_PLAN_OP_VARIABLE,
+            .relation_name = "r",
+            .delta_mode = WL_DELTA_FORCE_DELTA,
+        },
+    };
+    wl_plan_op_t *k_ops[] = { branch0, branch1 };
+    uint32_t k_counts[] = { 1, 1 };
+    wl_plan_op_k_fusion_t meta = {
+        .k = 2,
+        .k_ops = k_ops,
+        .k_op_counts = k_counts,
+    };
+    wl_plan_op_t op = {
+        .op = WL_PLAN_OP_K_FUSION,
+        .relation_name = "out",
+        .opaque_data = &meta,
+    };
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    rc = col_op_k_fusion(&op, &stack, &sess);
+    ASSERT(rc == 0, "K-fusion all-inactive path failed");
+    ASSERT(stack.top == 1, "K-fusion should push one empty result");
+
+    eval_entry_t result = eval_stack_pop(&stack);
+    ASSERT(result.rel != NULL, "K-fusion result missing");
+    ASSERT(result.owned, "K-fusion empty result should be owned");
+    ASSERT(result.rel->nrows == 0, "K-fusion result should be empty");
+    ASSERT(result.rel->ncols == 3, "empty result must keep target schema");
+    col_rel_destroy(result.rel);
+    eval_stack_drain(&stack);
+
+    col_rel_destroy(target);
+    free(sess.rels);
+    session_rel_free_hash(&sess);
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 
@@ -483,6 +554,7 @@ main(void)
     test_k2_single_self_loop();
     test_k2_multi_rule_union_cspa_pattern();
     test_k2_multi_rule_union_unique_contributions();
+    test_k2_all_inactive_branches_preserve_target_schema();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -7,6 +7,7 @@
 
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/backend.h"
+#include "../wirelog/columnar/columnar_nanoarrow.h"
 #include "../wirelog/ir/program.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/jpp.h"
@@ -29,30 +30,30 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                    \
-    do {                                              \
-        test_count++;                                 \
-        printf("TEST %d: %s ... ", test_count, name); \
-    } while (0)
+        do {                                              \
+            test_count++;                                 \
+            printf("TEST %d: %s ... ", test_count, name); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                  \
-    do {                           \
-        fail_count++;              \
-        printf("FAIL: %s\n", msg); \
-    } while (0)
+        do {                           \
+            fail_count++;              \
+            printf("FAIL: %s\n", msg); \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond)) {    \
-            FAIL(msg);    \
-            return;       \
-        }                 \
-    } while (0)
+        do {                  \
+            if (!(cond)) {    \
+                FAIL(msg);    \
+                return;       \
+            }                 \
+        } while (0)
 
 /* ----------------------------------------------------------------
  * Snapshot counting callback
@@ -64,7 +65,7 @@ struct count_ctx {
 
 static void
 count_cb(const char *relation, const int64_t *row, uint32_t ncols,
-         void *user_data)
+    void *user_data)
 {
     struct count_ctx *ctx = (struct count_ctx *)user_data;
     ctx->count++;
@@ -83,10 +84,10 @@ test_tc_plan_generation(void)
     TEST("TC plan generation");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      "edge(1, 2). edge(2, 3). edge(3, 4).\n"
-                      ".decl tc(x: int32, y: int32)\n"
-                      "tc(x, y) :- edge(x, y).\n"
-                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -112,7 +113,7 @@ test_tc_plan_generation(void)
                 && strcmp(plan->strata[s].relations[r].name, "tc") == 0) {
                 found_tc = 1;
                 ASSERT(plan->strata[s].relations[r].op_count > 0,
-                       "tc has no ops");
+                    "tc has no ops");
             }
         }
     }
@@ -142,10 +143,10 @@ test_tc_end_to_end(void)
     TEST("TC end-to-end columnar session");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      "edge(1, 2). edge(2, 3). edge(3, 4).\n"
-                      ".decl tc(x: int32, y: int32)\n"
-                      "tc(x, y) :- edge(x, y).\n"
-                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -176,6 +177,156 @@ test_tc_end_to_end(void)
     ASSERT(ctx.count == 6, "expected 6 TC tuples");
 
     wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_join_project_fusion_plan_shape(void)
+{
+    TEST("JOIN project fusion plan shape");
+
+    const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl r(x: int32, z: int32)\n"
+        "r(x, z) :- a(x, y), b(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    const wl_plan_relation_t *rp = NULL;
+    for (uint32_t s = 0; s < plan->stratum_count && !rp; s++) {
+        for (uint32_t r = 0; r < plan->strata[s].relation_count; r++) {
+            const wl_plan_relation_t *cand = &plan->strata[s].relations[r];
+            if (cand->name && strcmp(cand->name, "r") == 0) {
+                rp = cand;
+                break;
+            }
+        }
+    }
+    ASSERT(rp != NULL, "relation r not found");
+
+    const wl_plan_op_t *join = NULL;
+    for (uint32_t i = 0; i < rp->op_count; i++) {
+        ASSERT(rp->ops[i].op != WL_PLAN_OP_MAP,
+            "pure join projection should not leave MAP");
+        if (rp->ops[i].op == WL_PLAN_OP_JOIN)
+            join = &rp->ops[i];
+    }
+    ASSERT(join != NULL, "JOIN not found");
+    ASSERT(join->project_count == 2, "JOIN should carry projection width");
+    ASSERT(join->project_indices != NULL, "JOIN projection indices missing");
+    ASSERT(join->project_indices[0] == 0, "first projected column should be x");
+    ASSERT(join->project_indices[1] == 3,
+        "second projected column should be z");
+
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_join_project_fusion_keeps_computed_map(void)
+{
+    TEST("JOIN project fusion keeps computed MAP");
+
+    const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl r(x: int32, z: int32)\n"
+        "r(x + 1, z) :- a(x, y), b(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    bool found_map = false;
+    for (uint32_t s = 0; s < plan->stratum_count; s++) {
+        for (uint32_t r = 0; r < plan->strata[s].relation_count; r++) {
+            const wl_plan_relation_t *rp = &plan->strata[s].relations[r];
+            if (!rp->name || strcmp(rp->name, "r") != 0)
+                continue;
+            for (uint32_t i = 0; i < rp->op_count; i++)
+                if (rp->ops[i].op == WL_PLAN_OP_MAP)
+                    found_map = true;
+        }
+    }
+    ASSERT(found_map, "computed projection should keep MAP");
+
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_k_fusion_sequences_fuse_join_project(void)
+{
+    TEST("K_FUSION sequences fuse JOIN project");
+
+    const char *src = ".decl p(x: int32, y: int32)\n"
+        "p(1, 2).\n"
+        "p(x, z) :- p(x, y), p(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    const wl_plan_op_k_fusion_t *kf = NULL;
+    for (uint32_t s = 0; s < plan->stratum_count && !kf; s++) {
+        for (uint32_t r = 0; r < plan->strata[s].relation_count && !kf; r++) {
+            const wl_plan_relation_t *rel = &plan->strata[s].relations[r];
+            if (!rel->name || strcmp(rel->name, "p") != 0)
+                continue;
+            for (uint32_t i = 0; i < rel->op_count; i++) {
+                if (rel->ops[i].op == WL_PLAN_OP_K_FUSION) {
+                    kf = (const wl_plan_op_k_fusion_t *)
+                        rel->ops[i].opaque_data;
+                    break;
+                }
+            }
+        }
+    }
+    ASSERT(kf != NULL, "K_FUSION not found");
+    ASSERT(kf->k >= 2, "K_FUSION should contain delta copies");
+
+    for (uint32_t d = 0; d < kf->k; d++) {
+        bool projected_join = false;
+        for (uint32_t i = 0; i < kf->k_op_counts[d]; i++) {
+            const wl_plan_op_t *op = &kf->k_ops[d][i];
+            ASSERT(op->op != WL_PLAN_OP_MAP,
+                "pure projection MAP should be fused inside K_FUSION");
+            if (op->op == WL_PLAN_OP_JOIN && op->project_count == 2
+                && op->project_indices)
+                projected_join = true;
+        }
+        ASSERT(projected_join, "projected JOIN not found in K_FUSION copy");
+    }
+
     wl_plan_free(plan);
     wirelog_program_free(prog);
     PASS();
@@ -217,10 +368,13 @@ main(void)
 
     test_tc_plan_generation();
     test_tc_end_to_end();
+    test_join_project_fusion_plan_shape();
+    test_join_project_fusion_keeps_computed_map();
+    test_k_fusion_sequences_fuse_join_project();
     test_plan_free_null();
     test_load_facts_null_safe();
 
     printf("\n%d tests: %d passed, %d failed\n", test_count, pass_count,
-           fail_count);
+        fail_count);
     return fail_count > 0 ? 1 : 0;
 }

--- a/tests/test_tdd_decision_stats.c
+++ b/tests/test_tdd_decision_stats.c
@@ -1,0 +1,176 @@
+/*
+ * test_tdd_decision_stats.c - recursive TDD planner decision counters
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void
+wl_columnar_session_get_tdd_decision_stats(wl_session_t *sess,
+    uint32_t *out_recursive_strata, uint32_t *out_executed_strata,
+    uint32_t *out_fallback_strata, uint32_t *out_snapshot_ineligible,
+    uint32_t *out_no_exchange, uint32_t *out_unsafe_plan,
+    uint32_t *out_adaptive_workers, const char **out_last_fallback_reason);
+
+typedef struct decision_stats {
+    uint32_t recursive;
+    uint32_t executed;
+    uint32_t fallback;
+    uint32_t snapshot_ineligible;
+    uint32_t no_exchange;
+    uint32_t unsafe_plan;
+    uint32_t adaptive_workers;
+    const char *last_reason;
+} decision_stats_t;
+
+typedef struct count_ctx {
+    int64_t count;
+} count_ctx_t;
+
+static int
+run_bdx_mode(decision_stats_t *stats, int use_step);
+
+static void
+count_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    count_ctx_t *ctx = (count_ctx_t *)user_data;
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    ctx->count++;
+}
+
+static int
+run_bdx(decision_stats_t *stats)
+{
+    return run_bdx_mode(stats, 0);
+}
+
+static int
+run_bdx_step(decision_stats_t *stats)
+{
+    return run_bdx_mode(stats, 1);
+}
+
+static int
+run_bdx_mode(decision_stats_t *stats, int use_step)
+{
+    const char *source =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl r(x: int32, y: int32)\n"
+        "r(x, y) :- edge(x, y).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(source, &err);
+    if (!prog)
+        return 1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0 || !plan)
+        return 1;
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
+    if (rc != 0 || !sess) {
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    int64_t rows[200];
+    for (uint32_t i = 0; i < 100; i++) {
+        rows[i * 2] = (int64_t)i;
+        rows[i * 2 + 1] = (int64_t)i + 1;
+    }
+    rc = wl_session_insert(sess, "edge", rows, 100, 2);
+    if (rc == 0 && use_step) {
+        rc = wl_session_step(sess);
+    } else if (rc == 0) {
+        count_ctx_t ctx = { 0 };
+        rc = wl_session_snapshot(sess, count_cb, &ctx);
+    }
+    if (rc == 0) {
+        wl_columnar_session_get_tdd_decision_stats(sess,
+            &stats->recursive, &stats->executed, &stats->fallback,
+            &stats->snapshot_ineligible, &stats->no_exchange,
+            &stats->unsafe_plan, &stats->adaptive_workers,
+            &stats->last_reason);
+    }
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    return rc == 0 ? 0 : 1;
+}
+
+static int
+expect(const char *name, int ok)
+{
+    if (ok) {
+        printf("%s ... PASS\n", name);
+        return 0;
+    }
+    printf("%s ... FAIL\n", name);
+    return 1;
+}
+
+int
+main(void)
+{
+    int failed = 0;
+    decision_stats_t stats;
+
+    memset(&stats, 0, sizeof(stats));
+    setenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER", "1", 1);
+    failed += expect("TDD execution counted", run_bdx(&stats) == 0
+            && stats.recursive == 1
+            && stats.executed == 1
+            && stats.fallback == 0
+            && stats.adaptive_workers == 0
+            && stats.last_reason
+            && strcmp(stats.last_reason, "none") == 0);
+
+    memset(&stats, 0, sizeof(stats));
+    setenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER", "1000000000", 1);
+    failed += expect("adaptive fallback counted", run_bdx(&stats) == 0
+            && stats.recursive == 1
+            && stats.executed == 0
+            && stats.fallback == 1
+            && stats.adaptive_workers == 1
+            && stats.last_reason
+            && strcmp(stats.last_reason, "adaptive_workers") == 0);
+
+    memset(&stats, 0, sizeof(stats));
+    setenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER", "1000000000", 1);
+    failed += expect("session step leaves snapshot stats untouched",
+            run_bdx_step(&stats) == 0
+            && stats.recursive == 0
+            && stats.executed == 0
+            && stats.fallback == 0
+            && stats.adaptive_workers == 0
+            && stats.last_reason
+            && strcmp(stats.last_reason, "none") == 0);
+
+    unsetenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER");
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -794,6 +794,90 @@ test_hash_table_independent(void)
     return 0;
 }
 
+static int
+test_shared_view_relation_destroy(void)
+{
+    TEST("worker shared-view relation destroy does not free coordinator data");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    int64_t rows[] = { 1, 2, 2, 3, 3, 4, 4, 5 };
+    if (insert_edges(coord, rows, 4) != 0) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("insert edges");
+        return 1;
+    }
+
+    col_rel_t *src = session_find_rel(coord, "edge");
+    if (!src) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("source relation missing");
+        return 1;
+    }
+
+    col_rel_t *view = col_rel_new_auto("edge", src->ncols);
+    if (!view) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("view allocation");
+        return 1;
+    }
+    if (col_rel_install_shared_view(view, src) != 0) {
+        col_rel_destroy(view);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("shared view install");
+        return 1;
+    }
+
+    col_rel_t *parts[] = { view };
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    if (col_worker_session_create(coord, 0, parts, 1, &worker) != 0) {
+        col_rel_destroy(view);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("worker create");
+        return 1;
+    }
+
+    col_rel_t *worker_rel = session_find_rel(&worker, "edge");
+    if (!worker_rel || worker_rel->columns[0] != src->columns[0]) {
+        col_worker_session_destroy(&worker);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("worker relation is not a shared view");
+        return 1;
+    }
+
+    for (int i = 0; i < 16; i++) {
+        if (col_rel_install_shared_view(worker_rel, src) != 0) {
+            col_worker_session_destroy(&worker);
+            cleanup_coordinator(coord, plan, prog);
+            FAIL("shared view refresh");
+            return 1;
+        }
+    }
+
+    col_worker_session_destroy(&worker);
+
+    col_rel_t *coord_rel = session_find_rel(coord, "edge");
+    int ok = coord_rel && coord_rel->nrows == 4
+        && coord_rel->columns[0][0] == 1
+        && coord_rel->columns[1][3] == 5;
+
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("coordinator relation corrupted");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 /* ======================================================================== */
 /* Issue #535: RDF Named-Graph column propagation tests                     */
 /* ======================================================================== */
@@ -1053,6 +1137,7 @@ main(void)
     test_find_rel_returns_partition();
     test_invalid_args();
     test_hash_table_independent();
+    test_shared_view_relation_destroy();
     test_join_output_limit_scaling();
     test_rdf_graph_column_propagates_to_col_rel();
     test_rdf_no_graph_column_defaults_to_false();

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -707,6 +707,51 @@ test_join_output_limit_scaling(void)
         return 1;
     }
 
+    /* --- max W=4, active W=2: worker gets 1/2 of limit --- */
+    plan = NULL;
+    prog = NULL;
+    wl_col_session_t *coord_active = make_coordinator(&plan, &prog);
+    if (!coord_active) {
+        FAIL("coordinator creation active W=2");
+        return 1;
+    }
+    coord_active->num_workers = 4;
+    coord_active->tdd_active_workers = 2;
+    coord_active->join_output_limit = 8000;
+    coord_active->tdd_budget_per_party = 1800;
+    atomic_store_explicit(&coord_active->mem_ledger.total_budget, 9000,
+        memory_order_relaxed);
+
+    int64_t rows_active[] = { 1, 2, 3, 4 };
+    insert_edges(coord_active, rows_active, 2);
+
+    col_rel_t **parts_active = NULL;
+    partition_rel(coord_active, "edge", 2, &parts_active);
+
+    wl_col_session_t active_workers[2];
+    memset(active_workers, 0, sizeof(active_workers));
+    for (uint32_t w = 0; w < 2; w++) {
+        col_rel_t *wp[1] = { parts_active[w] };
+        parts_active[w] = NULL;
+        col_worker_session_create(coord_active, w, wp, 1, &active_workers[w]);
+        if (active_workers[w].join_output_limit != 4000)
+            ok = 0;
+        uint64_t worker_budget = atomic_load_explicit(
+            &active_workers[w].mem_ledger.total_budget, memory_order_relaxed);
+        if (worker_budget != 3000)
+            ok = 0;
+    }
+    free(parts_active);
+
+    for (uint32_t w = 0; w < 2; w++)
+        col_worker_session_destroy(&active_workers[w]);
+    cleanup_coordinator(coord_active, plan, prog);
+
+    if (!ok) {
+        FAIL("active W=2: worker should get active-width limits");
+        return 1;
+    }
+
     /* --- W=2: zero limit stays zero (disabled) --- */
     plan = NULL;
     prog = NULL;

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -878,6 +878,214 @@ test_shared_view_relation_destroy(void)
     return 0;
 }
 
+static int
+test_session_add_rel_replaces_by_name(void)
+{
+    TEST("session_add_rel replaces same-name relation");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    col_rel_t *old_edge = session_find_rel(coord, "edge");
+    if (!old_edge) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("edge relation missing");
+        return 1;
+    }
+    uint32_t nrels_before = coord->nrels;
+
+    col_rel_t *replacement = col_rel_new_auto("edge", 2);
+    if (!replacement) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replacement allocation");
+        return 1;
+    }
+    int64_t row[] = { 42, 99 };
+    if (col_rel_append_row(replacement, row) != 0) {
+        col_rel_destroy(replacement);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replacement row append");
+        return 1;
+    }
+
+    if (session_add_rel(coord, replacement) != 0) {
+        col_rel_destroy(replacement);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replace relation");
+        return 1;
+    }
+
+    col_rel_t *found = session_find_rel(coord, "edge");
+    int ok = coord->nrels == nrels_before && found == replacement
+        && found->nrows == 1 && found->columns[0][0] == 42
+        && found->columns[1][0] == 99;
+
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("same-name relation was not replaced");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_session_add_rel_reuses_removed_slot(void)
+{
+    TEST("session_add_rel reuses removed relation slot");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    col_rel_t *edge = session_find_rel(coord, "edge");
+    if (!edge) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("initial relation lookup");
+        return 1;
+    }
+
+    col_rel_t *temp = col_rel_new_auto("$d$path", 2);
+    if (!temp) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("temp relation allocation");
+        return 1;
+    }
+    if (session_add_rel(coord, temp) != 0) {
+        col_rel_destroy(temp);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("temp relation add");
+        return 1;
+    }
+
+    uint32_t nrels_before = coord->nrels;
+    session_remove_rel(coord, "$d$path");
+    if (session_find_rel(coord, "$d$path") != NULL) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("removed relation still found");
+        return 1;
+    }
+
+    col_rel_t *replacement = col_rel_new_auto("$d$path", 2);
+    if (!replacement) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replacement allocation");
+        return 1;
+    }
+
+    if (session_add_rel(coord, replacement) != 0) {
+        col_rel_destroy(replacement);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("hole reuse add");
+        return 1;
+    }
+
+    col_rel_t *found = session_find_rel(coord, "$d$path");
+    int ok = coord->nrels == nrels_before && found == replacement
+        && session_find_rel(coord, "edge") == edge;
+
+    for (int i = 0; i < 8 && ok; i++) {
+        session_remove_rel(coord, "$d$path");
+        col_rel_t *next = col_rel_new_auto("$d$path", 2);
+        if (!next) {
+            ok = 0;
+            break;
+        }
+        if (session_add_rel(coord, next) != 0) {
+            col_rel_destroy(next);
+            ok = 0;
+            break;
+        }
+        ok = coord->nrels == nrels_before
+            && session_find_rel(coord, "$d$path") == next
+            && session_find_rel(coord, "edge") == edge;
+    }
+
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("removed slot was not reused safely");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
+test_session_add_rel_invalidates_filter_cache(void)
+{
+    TEST("session_add_rel invalidates filtered relation cache");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+
+    coord->filt_cache = (col_filt_cache_entry_t *)calloc(
+        1, sizeof(col_filt_cache_entry_t));
+    if (!coord->filt_cache) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("filter cache allocation");
+        return 1;
+    }
+    coord->filt_cache_cap = 1;
+    coord->filt_cache_count = 1;
+    coord->filt_cache[0].rel_name = (char *)malloc(5);
+    coord->filt_cache[0].filter_data = (uint8_t *)malloc(1);
+    coord->filt_cache[0].filtered = col_rel_new_auto("$rfilter_cache", 2);
+    if (!coord->filt_cache[0].rel_name
+        || !coord->filt_cache[0].filter_data
+        || !coord->filt_cache[0].filtered) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("filter cache entry allocation");
+        return 1;
+    }
+    memcpy(coord->filt_cache[0].rel_name, "edge", 5);
+    coord->filt_cache[0].filter_data[0] = 7;
+    coord->filt_cache[0].filter_size = 1;
+    coord->filt_cache[0].filter_hash = 123;
+    coord->filt_cache[0].source_nrows = 1;
+
+    col_rel_t *replacement = col_rel_new_auto("edge", 2);
+    if (!replacement) {
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replacement allocation");
+        return 1;
+    }
+
+    if (session_add_rel(coord, replacement) != 0) {
+        col_rel_destroy(replacement);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replace relation");
+        return 1;
+    }
+
+    int ok = coord->filt_cache_count == 0
+        && session_find_rel(coord, "edge") == replacement;
+
+    cleanup_coordinator(coord, plan, prog);
+
+    if (!ok) {
+        FAIL("filtered relation cache was not invalidated");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 /* ======================================================================== */
 /* Issue #535: RDF Named-Graph column propagation tests                     */
 /* ======================================================================== */
@@ -1138,6 +1346,9 @@ main(void)
     test_invalid_args();
     test_hash_table_independent();
     test_shared_view_relation_destroy();
+    test_session_add_rel_replaces_by_name();
+    test_session_add_rel_reuses_removed_slot();
+    test_session_add_rel_invalidates_filter_cache();
     test_join_output_limit_scaling();
     test_rdf_graph_column_propagates_to_col_rel();
     test_rdf_no_graph_column_defaults_to_false();

--- a/tests/test_workers_as_cap.c
+++ b/tests/test_workers_as_cap.c
@@ -1,0 +1,90 @@
+/*
+ * test_workers_as_cap.c - workers=N is an upper bound, not eager allocation
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+
+static wl_plan_t *
+build_plan(void)
+{
+    const char *src =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(x, y) :- edge(x, y).\n"
+        "reach(x, z) :- reach(x, y), edge(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    return rc == 0 ? plan : NULL;
+}
+
+static int
+expect(const char *name, int ok)
+{
+    if (ok) {
+        printf("%s ... PASS\n", name);
+        return 0;
+    }
+    printf("%s ... FAIL\n", name);
+    return 1;
+}
+
+int
+main(void)
+{
+    int failed = 0;
+    wl_plan_t *plan = build_plan();
+    failed += expect("plan builds", plan != NULL);
+    if (!plan)
+        return 1;
+
+    wl_session_t *base = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, 8, &base);
+    failed += expect("session accepts max worker cap", rc == 0 && base != NULL);
+    if (rc != 0 || !base) {
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    wl_col_session_t *sess = (wl_col_session_t *)base;
+    failed += expect("workqueue is not eagerly allocated",
+            sess->num_workers == 8 && sess->wq == NULL
+            && sess->wq_workers == 0);
+    failed += expect("TDD worker slots are not eagerly allocated",
+            sess->tdd_workers == NULL && sess->tdd_workers_cap == 0
+            && sess->tdd_workers_count == 0);
+
+    rc = wl_columnar_session_ensure_workqueue(sess, 3);
+    failed += expect("workqueue allocates selected active width",
+            rc == 0 && sess->wq != NULL && sess->wq_workers == 3);
+    rc = wl_columnar_session_ensure_tdd_worker_slots(sess, 3);
+    failed += expect("TDD slots allocate selected active width",
+            rc == 0 && sess->tdd_workers != NULL
+            && sess->tdd_workers_cap == 3
+            && sess->tdd_workers_count == 0);
+
+    wl_session_destroy(base);
+    wl_plan_free(plan);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/validate_bench_flowlog_tdd_json.py
+++ b/tests/validate_bench_flowlog_tdd_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os
 import subprocess
 import sys
 
@@ -16,6 +17,9 @@ def main():
     if len(sys.argv) != 3:
         print("usage: validate_bench_flowlog_tdd_json.py BENCH_FLOWLOG DATA")
         return 2
+
+    env = os.environ.copy()
+    env.pop("WIRELOG_RADIX_BENCH_LOG", None)
 
     proc = subprocess.run(
         [
@@ -35,11 +39,15 @@ def main():
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     if proc.returncode != 0:
         print(proc.stdout, end="")
         print(proc.stderr, end="", file=sys.stderr)
         return proc.returncode
+
+    if "[radix-bench" in proc.stderr:
+        raise AssertionError("radix benchmark logs should be opt-in")
 
     row = extract_json(proc.stdout)
     tdd_phase = row.get("tdd_phase_ms")

--- a/wirelog/columnar/diff_arrangement.c
+++ b/wirelog/columnar/diff_arrangement.c
@@ -95,7 +95,7 @@ col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
         return NULL;
 
     copy->key_cols = malloc(arr->key_count * sizeof(uint32_t));
-    copy->ht_head = malloc(arr->ht_cap * sizeof(uint32_t));
+    copy->ht_head = malloc(arr->nbuckets * sizeof(uint32_t));
     copy->ht_next = malloc(arr->ht_cap * sizeof(uint32_t));
 
     if (!copy->key_cols || !copy->ht_head || !copy->ht_next) {
@@ -107,7 +107,7 @@ col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
     }
 
     memcpy(copy->key_cols, arr->key_cols, arr->key_count * sizeof(uint32_t));
-    memcpy(copy->ht_head, arr->ht_head, arr->ht_cap * sizeof(uint32_t));
+    memcpy(copy->ht_head, arr->ht_head, arr->nbuckets * sizeof(uint32_t));
     memcpy(copy->ht_next, arr->ht_next, arr->ht_cap * sizeof(uint32_t));
 
     copy->key_count = arr->key_count;

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4885,6 +4885,15 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             W = 1;
     }
     W = tdd_choose_active_workers(sp, coord, W, replicate_mode);
+    if (W <= 1 && (coord->last_inserted_relation != NULL
+        || coord->total_iterations == 0)) {
+        tdd_record_active_workers(coord, 1);
+        uint32_t saved_total_iterations = coord->total_iterations;
+        int seq_rc = col_eval_stratum(sp, coord, stratum_idx);
+        if (seq_rc == 0 && saved_total_iterations > 0)
+            coord->total_iterations += saved_total_iterations;
+        return seq_rc;
+    }
 
     col_rel_t **owner_fallback_saved = NULL;
     bool owner_adaptive_fallback = false;

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -24,6 +24,9 @@
 #include <string.h>
 #include <xxhash.h>
 
+#define TDD_OWNER_FALLBACK_MIN_ITER 31u
+#define TDD_OWNER_FALLBACK_DELTA_ROWS 512u
+
 /* ======================================================================== */
 /* Hash-Set Dedup for TDD Workers (Issue #361)                               */
 /* ======================================================================== */
@@ -101,6 +104,21 @@ dedup_set_insert(col_rel_t *r, uint64_t h)
     r->dedup_slots[pos] = h;
     r->dedup_count++;
     return true;
+}
+
+static inline bool
+dedup_set_contains(const col_rel_t *r, uint64_t h)
+{
+    if (!r || !r->dedup_slots || r->dedup_cap == 0)
+        return false;
+    uint32_t mask = r->dedup_cap - 1;
+    uint32_t pos = (uint32_t)(h & mask);
+    while (r->dedup_slots[pos] != 0) {
+        if (r->dedup_slots[pos] == h)
+            return true;
+        pos = (pos + 1) & mask;
+    }
+    return false;
 }
 
 /* Initialize dedup set from existing rows [0..nrows). */
@@ -1843,6 +1861,31 @@ tdd_replicate_workers(wl_col_session_t *coord)
  *      exchange; deltas are heap-allocated (col_rel_new_like) so they
  *      remain valid across delta_pool_reset.
  */
+static void tdd_dedup_rel(col_rel_t *r);
+static int bdx_hash_diff(col_rel_t *delta, const col_rel_t *base);
+static int tdd_hashset_diff(col_rel_t *delta, const col_rel_t *base);
+static int
+tdd_worker_publish_delta(col_eval_tdd_worker_ctx_t *ctx,
+    wl_col_session_t *sess, col_rel_t *delta, uint32_t rel_idx,
+    uint32_t eff_iter);
+
+static int
+tdd_install_empty_delta_on_workers(wl_col_session_t *coord,
+    const char *dname, uint32_t ncols, uint32_t W)
+{
+    for (uint32_t w = 0; w < W; w++) {
+        col_rel_t *empty = col_rel_new_auto(dname, ncols);
+        if (!empty)
+            return ENOMEM;
+        int rc = session_add_rel(&coord->tdd_workers[w], empty);
+        if (rc != 0) {
+            col_rel_destroy(empty);
+            return rc;
+        }
+    }
+    return 0;
+}
+
 static void
 tdd_worker_subpass_fn(void *arg)
 {
@@ -1870,7 +1913,9 @@ tdd_worker_subpass_fn(void *arg)
      * a TDD worker sub-pass.  Broadcast $d$<rel> may be >= local partition
      * size, so the normal "delta < full" guard must be bypassed. */
     bool saved_tdd_subpass = sess->tdd_subpass_active;
+    bool saved_outbound_only = sess->tdd_outbound_only_active;
     sess->tdd_subpass_active = true;
+    sess->tdd_outbound_only_active = ctx->outbound_only;
     sess->current_iteration = eff_iter;
 
     /* Free per-sub-pass delta arrangements (eval.c:429) */
@@ -1889,6 +1934,7 @@ tdd_worker_subpass_fn(void *arg)
         if (all_empty) {
             ctx->all_empty_delta = true;
             sess->tdd_subpass_active = saved_tdd_subpass;
+            sess->tdd_outbound_only_active = saved_outbound_only;
             sess->diff_operators_active = saved_diff;
             TDD_WORKER_RETURN();
         }
@@ -1899,6 +1945,7 @@ tdd_worker_subpass_fn(void *arg)
     if (!snap) {
         ctx->rc = ENOMEM;
         sess->tdd_subpass_active = saved_tdd_subpass;
+        sess->tdd_outbound_only_active = saved_outbound_only;
         sess->diff_operators_active = saved_diff;
         TDD_WORKER_RETURN();
     }
@@ -1906,6 +1953,8 @@ tdd_worker_subpass_fn(void *arg)
         col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
         snap[ri] = r ? r->nrows : 0;
     }
+
+    bool any_new = false;
 
     /* Evaluate all relation plans (eval.c:505-604) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -1923,6 +1972,7 @@ tdd_worker_subpass_fn(void *arg)
             ctx->rc = rc;
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
+            sess->tdd_outbound_only_active = saved_outbound_only;
             sess->diff_operators_active = saved_diff;
             TDD_WORKER_RETURN();
         }
@@ -1940,6 +1990,76 @@ tdd_worker_subpass_fn(void *arg)
         }
 
         col_rel_t *target = session_find_rel(sess, rp->name);
+        if (ctx->outbound_only) {
+            const char *dname = sp->relations[ri].delta_name;
+            col_rel_t *delta = col_rel_new_like(dname, result.rel);
+            if (!delta) {
+                if (result.owned)
+                    col_rel_destroy(result.rel);
+                ctx->rc = ENOMEM;
+                free(snap);
+                sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
+                sess->diff_operators_active = saved_diff;
+                TDD_WORKER_RETURN();
+            }
+            int rc = col_rel_append_all(delta, result.rel, sess->eval_arena);
+            if (result.owned)
+                col_rel_destroy(result.rel);
+            if (rc != 0) {
+                col_rel_destroy(delta);
+                ctx->rc = rc;
+                free(snap);
+                sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
+                sess->diff_operators_active = saved_diff;
+                TDD_WORKER_RETURN();
+            }
+            if (target && target->nrows > 0) {
+                rc = bdx_hash_diff(delta, target);
+                if (rc != 0) {
+                    col_rel_destroy(delta);
+                    ctx->rc = rc;
+                    free(snap);
+                    sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
+                    sess->diff_operators_active = saved_diff;
+                    TDD_WORKER_RETURN();
+                }
+            }
+            if (sess->coordinator && delta->nrows > 0) {
+                col_rel_t *coord_target = session_find_rel(
+                    sess->coordinator, rp->name);
+                if (coord_target && coord_target->nrows > 0) {
+                    rc = tdd_hashset_diff(delta, coord_target);
+                    if (rc != 0) {
+                        col_rel_destroy(delta);
+                        ctx->rc = rc;
+                        free(snap);
+                        sess->tdd_subpass_active = saved_tdd_subpass;
+                        sess->tdd_outbound_only_active = saved_outbound_only;
+                        sess->diff_operators_active = saved_diff;
+                        TDD_WORKER_RETURN();
+                    }
+                }
+            }
+            if (delta->nrows > 1)
+                tdd_dedup_rel(delta);
+            bool produced = delta->nrows > 0;
+            rc = tdd_worker_publish_delta(ctx, sess, delta, ri, eff_iter);
+            if (rc != 0) {
+                ctx->rc = rc;
+                free(snap);
+                sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
+                sess->diff_operators_active = saved_diff;
+                TDD_WORKER_RETURN();
+            }
+            if (produced)
+                any_new = true;
+            continue;
+        }
+
         if (!target) {
             col_rel_t *copy;
             if (result.owned) {
@@ -1951,6 +2071,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = ENOMEM;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -1962,6 +2083,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = ENOMEM;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -1971,6 +2093,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = rc;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -1981,6 +2104,7 @@ tdd_worker_subpass_fn(void *arg)
                 ctx->rc = rc;
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
                 sess->diff_operators_active = saved_diff;
                 TDD_WORKER_RETURN();
             }
@@ -1994,6 +2118,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = rc;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -2005,6 +2130,7 @@ tdd_worker_subpass_fn(void *arg)
                 ctx->rc = rc;
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
                 sess->diff_operators_active = saved_diff;
                 TDD_WORKER_RETURN();
             }
@@ -2026,7 +2152,6 @@ tdd_worker_subpass_fn(void *arg)
 
     /* Consolidate + produce deltas (eval.c:621-713).
      * Use col_rel_new_like (heap) so deltas survive delta_pool_reset. */
-    bool any_new = false;
     for (uint32_t ri = 0; ri < nrels; ri++) {
         col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
         if (!r || snap[ri] >= r->nrows)
@@ -2040,6 +2165,7 @@ tdd_worker_subpass_fn(void *arg)
             ctx->rc = ENOMEM;
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
+            sess->tdd_outbound_only_active = saved_outbound_only;
             sess->diff_operators_active = saved_diff;
             TDD_WORKER_RETURN();
         }
@@ -2057,6 +2183,7 @@ tdd_worker_subpass_fn(void *arg)
                 ctx->rc = ENOMEM;
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
                 sess->diff_operators_active = saved_diff;
                 TDD_WORKER_RETURN();
             }
@@ -2096,6 +2223,7 @@ tdd_worker_subpass_fn(void *arg)
             ctx->rc = rc2;
             free(snap);
             sess->tdd_subpass_active = saved_tdd_subpass;
+            sess->tdd_outbound_only_active = saved_outbound_only;
             sess->diff_operators_active = saved_diff;
             TDD_WORKER_RETURN();
         }
@@ -2109,6 +2237,7 @@ tdd_worker_subpass_fn(void *arg)
                 ctx->rc = ENOMEM;
                 free(snap);
                 sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
                 sess->diff_operators_active = saved_diff;
                 TDD_WORKER_RETURN();
             }
@@ -2129,6 +2258,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = ENOMEM;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -2148,6 +2278,7 @@ tdd_worker_subpass_fn(void *arg)
                     ctx->rc = ENOMEM;
                     free(snap);
                     sess->tdd_subpass_active = saved_tdd_subpass;
+                    sess->tdd_outbound_only_active = saved_outbound_only;
                     sess->diff_operators_active = saved_diff;
                     TDD_WORKER_RETURN();
                 }
@@ -2175,6 +2306,7 @@ tdd_worker_subpass_fn(void *arg)
 
     ctx->any_new = any_new;
     sess->tdd_subpass_active = saved_tdd_subpass;
+    sess->tdd_outbound_only_active = saved_outbound_only;
     sess->diff_operators_active = saved_diff;
     ctx->runtime_ns = now_ns() - worker_t0;
 #undef TDD_WORKER_RETURN
@@ -2516,6 +2648,44 @@ tdd_preregister_idb_on_workers(const wl_plan_stratum_t *sp,
 /* Forward declaration — defined below tdd_exchange_deltas. */
 static int tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W);
+static void tdd_dedup_rel(col_rel_t *r);
+static int bdx_hash_diff(col_rel_t *delta, const col_rel_t *base);
+
+static int
+tdd_worker_publish_delta(col_eval_tdd_worker_ctx_t *ctx,
+    wl_col_session_t *sess, col_rel_t *delta, uint32_t rel_idx,
+    uint32_t eff_iter)
+{
+    if (delta->nrows == 0) {
+        col_rel_destroy(delta);
+        return 0;
+    }
+
+    delta->timestamps = (col_delta_timestamp_t *)calloc(
+        delta->nrows, sizeof(col_delta_timestamp_t));
+    if (!delta->timestamps) {
+        col_rel_destroy(delta);
+        return ENOMEM;
+    }
+    for (uint32_t ti = 0; ti < delta->nrows; ti++) {
+        delta->timestamps[ti].iteration = eff_iter;
+        delta->timestamps[ti].stratum = ctx->stratum_idx;
+        delta->timestamps[ti].worker = (uint16_t)sess->worker_id;
+        delta->timestamps[ti].multiplicity = 1;
+    }
+
+    if (sess->coordinator && sess->coordinator->delta_queue) {
+        int rc = wl_mpsc_enqueue(sess->coordinator->delta_queue,
+                sess->worker_id, delta, ctx->stratum_idx, rel_idx);
+        if (rc != 0) {
+            col_rel_destroy(delta);
+            return ENOMEM;
+        }
+    } else {
+        ctx->delta_rels[rel_idx] = delta;
+    }
+    return 0;
+}
 
 /*
  * tdd_broadcast_relation_delta:
@@ -3064,6 +3234,164 @@ stratum_max_idb_body_atoms(const wl_plan_stratum_t *sp)
     return max_count;
 }
 
+static uint32_t
+tdd_parse_col_index(const char *key)
+{
+    if (!key || key[0] != 'c' || key[1] != 'o' || key[2] != 'l')
+        return UINT32_MAX;
+    char *end = NULL;
+    unsigned long v = strtoul(key + 3, &end, 10);
+    if (end == key + 3 || *end != '\0' || v > UINT32_MAX)
+        return UINT32_MAX;
+    return (uint32_t)v;
+}
+
+static bool
+tdd_find_relation_exchange_key(const wl_plan_stratum_t *sp, const char *name,
+    const uint32_t **key_cols, uint32_t *key_count)
+{
+    *key_cols = NULL;
+    *key_count = 0;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        if (strcmp(sp->relations[ri].name, name) != 0)
+            continue;
+        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+            if (sp->relations[ri].ops[oi].op != WL_PLAN_OP_EXCHANGE)
+                continue;
+            const wl_plan_op_exchange_t *meta =
+                (const wl_plan_op_exchange_t *)
+                sp->relations[ri].ops[oi].opaque_data;
+            if (!meta || !meta->key_col_idxs || meta->key_col_count == 0)
+                return false;
+            *key_cols = meta->key_col_idxs;
+            *key_count = meta->key_col_count;
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+static bool
+tdd_key_names_match_exchange(const char *const *keys, uint32_t key_count,
+    const uint32_t *exchange_cols, uint32_t exchange_count)
+{
+    if (!keys || !exchange_cols || key_count == 0
+        || key_count != exchange_count)
+        return false;
+    for (uint32_t k = 0; k < key_count; k++) {
+        uint32_t idx = tdd_parse_col_index(keys[k]);
+        if (idx == UINT32_MAX)
+            return false;
+        bool found = false;
+        for (uint32_t x = 0; x < exchange_count; x++) {
+            if (exchange_cols[x] == idx) {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return false;
+    }
+    return true;
+}
+
+static bool
+tdd_ops_single_idb_keys_exchange_aligned(const wl_plan_op_t *ops,
+    uint32_t op_count, const wl_plan_stratum_t *sp)
+{
+    bool stack_has_idb = false;
+    const char *stack_idb_name = NULL;
+
+    for (uint32_t oi = 0; oi < op_count; oi++) {
+        const wl_plan_op_t *op = &ops[oi];
+        if (op->op == WL_PLAN_OP_VARIABLE) {
+            if (is_stratum_idb(sp, op->relation_name)) {
+                stack_has_idb = true;
+                stack_idb_name = op->relation_name;
+            } else {
+                stack_has_idb = false;
+                stack_idb_name = NULL;
+            }
+        } else if (op->op == WL_PLAN_OP_JOIN && op->right_relation) {
+            bool right_idb = is_stratum_idb(sp, op->right_relation);
+            if (stack_has_idb && stack_idb_name) {
+                const uint32_t *xkey = NULL;
+                uint32_t xkey_count = 0;
+                if (!tdd_find_relation_exchange_key(sp, stack_idb_name,
+                    &xkey, &xkey_count))
+                    return false;
+                if (!tdd_key_names_match_exchange(op->left_keys,
+                    op->key_count, xkey, xkey_count))
+                    return false;
+            }
+            if (right_idb) {
+                const uint32_t *xkey = NULL;
+                uint32_t xkey_count = 0;
+                if (!tdd_find_relation_exchange_key(sp, op->right_relation,
+                    &xkey, &xkey_count))
+                    return false;
+                if (!tdd_key_names_match_exchange(op->right_keys,
+                    op->key_count, xkey, xkey_count))
+                    return false;
+                stack_has_idb = true;
+                stack_idb_name = op->right_relation;
+            }
+        }
+    }
+    return true;
+}
+
+bool
+tdd_stratum_single_idb_join_keys_exchange_aligned(
+    const wl_plan_stratum_t *sp)
+{
+    if (tdd_stratum_has_idb_self_join(sp))
+        return false;
+
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rel = &sp->relations[ri];
+
+        if (!tdd_ops_single_idb_keys_exchange_aligned(
+                rel->ops, rel->op_count, sp))
+            return false;
+
+        for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+            if (rel->ops[oi].op == WL_PLAN_OP_K_FUSION
+                && rel->ops[oi].opaque_data) {
+                const wl_plan_op_k_fusion_t *kf =
+                    (const wl_plan_op_k_fusion_t *)rel->ops[oi].opaque_data;
+                for (uint32_t ki = 0; ki < kf->k; ki++) {
+                    if (!tdd_ops_single_idb_keys_exchange_aligned(
+                            kf->k_ops[ki], kf->k_op_counts[ki], sp))
+                        return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool
+tdd_stratum_exchange_keys_are_multi_column(const wl_plan_stratum_t *sp)
+{
+    bool saw_exchange = false;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+            if (sp->relations[ri].ops[oi].op != WL_PLAN_OP_EXCHANGE)
+                continue;
+            const wl_plan_op_exchange_t *meta =
+                (const wl_plan_op_exchange_t *)
+                sp->relations[ri].ops[oi].opaque_data;
+            if (!meta || meta->key_col_count < 2)
+                return false;
+            saw_exchange = true;
+            break;
+        }
+    }
+    return saw_exchange;
+}
+
 /*
  * tdd_stratum_has_idb_self_join:
  * Returns true if any rule in the stratum has a JOIN where BOTH the left
@@ -3288,7 +3616,8 @@ tdd_stratum_idb_self_join_exchange_aligned(const wl_plan_stratum_t *sp,
  * The hash-partitioned delta exchange maintains the partition invariant.
  */
 static int
-tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord)
+tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
+    bool partition_edb)
 {
     tdd_cleanup_workers(coord);
 
@@ -3331,24 +3660,26 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord)
     const uint32_t *edb_part_keys = NULL;
     uint32_t edb_part_key_count = 0;
 
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
-            if (sp->relations[ri].ops[oi].op == WL_PLAN_OP_EXCHANGE) {
-                const wl_plan_op_exchange_t *meta =
-                    (const wl_plan_op_exchange_t *)
-                    sp->relations[ri].ops[oi].opaque_data;
-                if (meta && meta->edb_rel_name
-                    && meta->edb_key_col_idxs
-                    && meta->edb_key_col_count > 0) {
-                    edb_part_name = meta->edb_rel_name;
-                    edb_part_keys = meta->edb_key_col_idxs;
-                    edb_part_key_count = meta->edb_key_col_count;
+    if (partition_edb) {
+        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+            for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+                if (sp->relations[ri].ops[oi].op == WL_PLAN_OP_EXCHANGE) {
+                    const wl_plan_op_exchange_t *meta =
+                        (const wl_plan_op_exchange_t *)
+                        sp->relations[ri].ops[oi].opaque_data;
+                    if (meta && meta->edb_rel_name
+                        && meta->edb_key_col_idxs
+                        && meta->edb_key_col_count > 0) {
+                        edb_part_name = meta->edb_rel_name;
+                        edb_part_keys = meta->edb_key_col_idxs;
+                        edb_part_key_count = meta->edb_key_col_count;
+                    }
+                    break;
                 }
-                break;
             }
+            if (edb_part_name)
+                break;
         }
-        if (edb_part_name)
-            break;
     }
 
     /* Issue #535 hardening: if only one of the two co-partitioned sides carries
@@ -3847,6 +4178,133 @@ bdx_hash_diff(col_rel_t *delta, const col_rel_t *base)
     return 0;
 }
 
+static int
+tdd_hashset_diff(col_rel_t *delta, const col_rel_t *base)
+{
+    if (!delta || delta->nrows == 0 || !base || base->nrows == 0)
+        return 0;
+    if (delta->ncols != base->ncols)
+        return EINVAL;
+    if (!base->dedup_slots)
+        return bdx_hash_diff(delta, base);
+
+    uint32_t wr = 0;
+    for (uint32_t di = 0; di < delta->nrows; di++) {
+        uint64_t h = dedup_row_hash(delta, di);
+        if (dedup_set_contains(base, h))
+            continue;
+        if (wr != di) {
+            col_columns_copy_row(delta->columns, wr,
+                (int64_t *const *)delta->columns, di, delta->ncols);
+            if (delta->timestamps)
+                delta->timestamps[wr] = delta->timestamps[di];
+        }
+        wr++;
+    }
+    delta->nrows = wr;
+    return 0;
+}
+
+static void
+tdd_dedup_set_insert_rel(col_rel_t *target, const col_rel_t *rows)
+{
+    if (!target || !target->dedup_slots || !rows)
+        return;
+    for (uint32_t row = 0; row < rows->nrows; row++) {
+        uint64_t h = dedup_row_hash(rows, row);
+        dedup_set_insert(target, h);
+    }
+}
+
+static void
+tdd_clear_relation_dedup_set(col_rel_t *r)
+{
+    if (!r)
+        return;
+    free(r->dedup_slots);
+    r->dedup_slots = NULL;
+    r->dedup_cap = 0;
+    r->dedup_count = 0;
+}
+
+static col_rel_t **
+tdd_save_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord)
+{
+    col_rel_t **saved = (col_rel_t **)calloc(
+        sp->relation_count, sizeof(col_rel_t *));
+    if (!saved)
+        return NULL;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
+        if (!r || r->ncols == 0)
+            continue;
+        saved[ri] = col_rel_new_auto(r->name, r->ncols);
+        if (!saved[ri])
+            goto fail;
+        if (r->nrows > 0 && col_rel_append_all(saved[ri], r, NULL) != 0)
+            goto fail;
+    }
+    return saved;
+
+fail:
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++)
+        col_rel_destroy(saved[ri]);
+    free(saved);
+    return NULL;
+}
+
+static int
+tdd_restore_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
+    col_rel_t **saved)
+{
+    if (!saved)
+        return 0;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const char *name = sp->relations[ri].name;
+        col_rel_t *r = session_find_rel(coord, name);
+        if (!r) {
+            int alloc_rc = col_rel_alloc(&r, name);
+            if (alloc_rc != 0)
+                return alloc_rc;
+            alloc_rc = session_add_rel(coord, r);
+            if (alloc_rc != 0) {
+                col_rel_destroy(r);
+                return alloc_rc;
+            }
+        }
+        r->nrows = 0;
+        r->sorted_nrows = 0;
+        r->run_count = 0;
+        memset(r->run_ends, 0, sizeof(r->run_ends));
+        free(r->timestamps);
+        r->timestamps = NULL;
+        tdd_clear_relation_dedup_set(r);
+        if (saved[ri] && saved[ri]->ncols > 0) {
+            if (r->ncols == 0) {
+                int rc = col_rel_set_schema(r, saved[ri]->ncols,
+                        (const char *const *)saved[ri]->col_names);
+                if (rc != 0)
+                    return rc;
+            }
+            int rc = col_rel_append_all(r, saved[ri], NULL);
+            if (rc != 0)
+                return rc;
+        }
+        col_session_invalidate_arrangements(&coord->base, name);
+    }
+    return 0;
+}
+
+static void
+tdd_free_saved_coord_idb(const wl_plan_stratum_t *sp, col_rel_t **saved)
+{
+    if (!saved)
+        return;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++)
+        col_rel_destroy(saved[ri]);
+    free(saved);
+}
+
 /*
  * tdd_bdx_exchange_deltas:
  * Broadcast-Delta with Hash-Exchange Output (BDX) for Category C strata
@@ -3926,7 +4384,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
 
         col_rel_t *coord_idb = session_find_rel(coord, rel_name);
         if (coord_idb && coord_idb->nrows > 0 && combined->nrows > 0) {
-            rc = bdx_hash_diff(combined, coord_idb);
+            rc = tdd_hashset_diff(combined, coord_idb);
             if (rc != 0) {
                 col_rel_destroy(combined);
                 return rc;
@@ -3954,6 +4412,8 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
                 col_rel_destroy(combined);
                 return rc;
             }
+            tdd_dedup_set_insert_rel(coord_idb, combined);
+            col_session_invalidate_arrangements(&coord->base, rel_name);
         }
 
         /* Step 4: Truncate worker IDB to pre-subpass snapshot */
@@ -4060,6 +4520,191 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
     return 0;
 }
 
+static int
+tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W,
+    bool *out_any_accepted, uint32_t *out_accepted_rows)
+{
+    uint32_t nrels = sp->relation_count;
+    int rc = 0;
+    if (out_any_accepted)
+        *out_any_accepted = false;
+    if (out_accepted_rows)
+        *out_accepted_rows = 0;
+
+    for (uint32_t ri = 0; ri < nrels; ri++) {
+        const char *dname = sp->relations[ri].delta_name;
+        const char *rel_name = sp->relations[ri].name;
+        uint64_t prepare_t0 = now_ns();
+
+        for (uint32_t w = 0; w < W; w++)
+            session_remove_rel(&coord->tdd_workers[w], dname);
+
+        uint32_t total = 0, ncols = 0;
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *d = ctxs[w].delta_rels[ri];
+            if (d && d->nrows > 0) {
+                total += d->nrows;
+                if (ncols == 0)
+                    ncols = d->ncols;
+            }
+        }
+        if (total == 0) {
+            for (uint32_t w = 0; w < W; w++) {
+                col_rel_destroy(ctxs[w].delta_rels[ri]);
+                ctxs[w].delta_rels[ri] = NULL;
+            }
+            coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
+            continue;
+        }
+
+        col_rel_t *combined = col_rel_new_auto(dname, ncols);
+        if (!combined)
+            return ENOMEM;
+
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *d = ctxs[w].delta_rels[ri];
+            ctxs[w].delta_rels[ri] = NULL;
+            if (d && d->nrows > 0)
+                rc = col_rel_append_all(combined, d, NULL);
+            col_rel_destroy(d);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+        }
+
+        if (combined->nrows > 1)
+            tdd_dedup_rel(combined);
+
+        col_rel_t *coord_idb = session_find_rel(coord, rel_name);
+        if (coord_idb && coord_idb->nrows > 0 && combined->nrows > 0) {
+            rc = tdd_hashset_diff(combined, coord_idb);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+        }
+        if (combined->nrows == 0) {
+            rc = tdd_install_empty_delta_on_workers(coord, dname, ncols, W);
+            col_rel_destroy(combined);
+            coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
+            if (rc != 0)
+                return rc;
+            continue;
+        }
+        if (out_any_accepted)
+            *out_any_accepted = true;
+        if (out_accepted_rows)
+            *out_accepted_rows += combined->nrows;
+
+        if (coord_idb) {
+            if (coord_idb->ncols == 0 && combined->ncols > 0) {
+                rc = col_rel_set_schema(coord_idb, combined->ncols,
+                        (const char *const *)combined->col_names);
+                if (rc != 0) {
+                    col_rel_destroy(combined);
+                    return rc;
+                }
+            }
+            rc = col_rel_append_all(coord_idb, combined, NULL);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+            tdd_dedup_set_insert_rel(coord_idb, combined);
+            col_session_invalidate_arrangements(&coord->base, rel_name);
+        }
+        coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
+
+        const uint32_t *key_cols = NULL;
+        uint32_t key_count = 0;
+        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+            if (sp->relations[ri].ops[oi].op == WL_PLAN_OP_EXCHANGE) {
+                const wl_plan_op_exchange_t *meta =
+                    (const wl_plan_op_exchange_t *)
+                    sp->relations[ri].ops[oi].opaque_data;
+                if (meta && meta->key_col_count > 0) {
+                    key_cols = meta->key_col_idxs;
+                    key_count = meta->key_col_count;
+                }
+                break;
+            }
+        }
+        uint32_t default_key[] = { 0 };
+        if (!key_cols || key_count == 0) {
+            key_cols = default_key;
+            key_count = 1;
+        }
+
+        uint64_t scatter_t0 = now_ns();
+        col_rel_t **parts = (col_rel_t **)calloc(W, sizeof(col_rel_t *));
+        if (!parts) {
+            col_rel_destroy(combined);
+            return ENOMEM;
+        }
+        rc = col_rel_exchange_partition(combined, key_cols, key_count, W,
+                parts);
+        col_rel_destroy(combined);
+        if (rc != 0) {
+            for (uint32_t w = 0; w < W; w++)
+                col_rel_destroy(parts[w]);
+            free(parts);
+            return rc;
+        }
+
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *part = parts[w];
+            parts[w] = NULL;
+            if (!part || part->nrows == 0) {
+                col_rel_destroy(part);
+                continue;
+            }
+
+            col_rel_t *widb = session_find_rel(
+                &coord->tdd_workers[w], rel_name);
+            if (widb) {
+                if (widb->ncols == 0 && part->ncols > 0) {
+                    rc = col_rel_set_schema(widb, part->ncols,
+                            (const char *const *)part->col_names);
+                    if (rc != 0) {
+                        col_rel_destroy(part);
+                        break;
+                    }
+                }
+                rc = col_rel_append_all(widb, part, NULL);
+                if (rc != 0) {
+                    col_rel_destroy(part);
+                    break;
+                }
+                if (widb->dedup_slots) {
+                    for (uint32_t row = 0; row < part->nrows; row++) {
+                        uint64_t h = dedup_row_hash(part, row);
+                        dedup_set_insert(widb, h);
+                    }
+                }
+                col_session_invalidate_arrangements(
+                    &coord->tdd_workers[w].base, rel_name);
+            }
+
+            rc = session_add_rel(&coord->tdd_workers[w], part);
+            if (rc != 0) {
+                col_rel_destroy(part);
+                break;
+            }
+        }
+
+        for (uint32_t w = 0; w < W; w++)
+            col_rel_destroy(parts[w]);
+        free(parts);
+        coord->tdd_exchange_scatter_ns += now_ns() - scatter_t0;
+        if (rc != 0)
+            return rc;
+    }
+
+    return 0;
+}
+
 /*
  * col_eval_stratum_tdd_recursive:
  * Coordinator-driven semi-naive fixed-point for recursive strata.
@@ -4143,23 +4788,56 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
      *     - Stratum is not exchange-aligned AND has >2 IDB body atoms (BDX unsafe).
      *
      * Issue #388: Optional W=1 fallback for replicate mode only. */
+    bool has_idb_self_join = tdd_stratum_has_idb_self_join(sp);
     bool self_join_mode = tdd_stratum_idb_self_join_exchange_aligned(sp, coord);
-    bool bdx_mode = tdd_stratum_has_idb_self_join(sp) && !self_join_mode;
-    bool replicate_mode = (coord->last_inserted_relation == NULL)
-        || (!self_join_mode && stratum_max_idb_body_atoms(sp) > 2);
+    bool owner_exchange_mode = !has_idb_self_join
+        && stratum_max_idb_body_atoms(sp) <= 1
+        && tdd_stratum_exchange_keys_are_multi_column(sp)
+        && tdd_stratum_single_idb_join_keys_exchange_aligned(sp);
+    bool bdx_mode = has_idb_self_join && !self_join_mode;
+    bool replicate_mode = !owner_exchange_mode
+        && ((coord->last_inserted_relation == NULL)
+        || (!self_join_mode && stratum_max_idb_body_atoms(sp) > 2));
     bdx_mode = bdx_mode && !replicate_mode;
     if (replicate_mode) {
         const char *env = getenv("WIRELOG_TDD_REPLICATE_W1");
         if (env && env[0] == '1')
             W = 1;
     }
+
+    col_rel_t **owner_fallback_saved = NULL;
+    bool owner_adaptive_fallback = false;
+    if (owner_exchange_mode) {
+        owner_fallback_saved = tdd_save_coord_idb(sp, coord);
+        if (!owner_fallback_saved) {
+            coord->tdd_total_ns += now_ns() - tdd_total_t0;
+            return ENOMEM;
+        }
+    }
+
     if (replicate_mode)
         rc = tdd_replicate_workers(coord);
     else
-        rc = tdd_init_workers_hybrid(sp, coord);
+        rc = tdd_init_workers_hybrid(sp, coord, true);
     if (rc != 0) {
+        tdd_free_saved_coord_idb(sp, owner_fallback_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
         return rc;
+    }
+
+    if (owner_exchange_mode) {
+        for (uint32_t ri = 0; ri < nrels; ri++) {
+            col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
+            if (r && !r->dedup_slots) {
+                rc = dedup_set_init_from_rel(r);
+                if (rc != 0) {
+                    tdd_cleanup_workers(coord);
+                    tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+                    coord->tdd_total_ns += now_ns() - tdd_total_t0;
+                    return rc;
+                }
+            }
+        }
     }
 
     /* Pre-register empty IDB on each worker */
@@ -4414,6 +5092,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 ctxs[w].any_new = false;
                 ctxs[w].all_empty_delta = false;
                 ctxs[w].force_diff = bdx_mode;
+                ctxs[w].outbound_only = owner_exchange_mode;
                 ctxs[w].runtime_ns = 0;
                 ctxs[w].rc = 0;
             }
@@ -4527,7 +5206,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * any_new flags is both necessary and sufficient for fixed-point
              * detection.
              */
-            if (tdd_check_convergence(ctxs, W)) {
+            if (!owner_exchange_mode && tdd_check_convergence(ctxs, W)) {
                 coord->tdd_convergence_ns += now_ns() - convergence_t0;
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
@@ -4542,9 +5221,15 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * Issue #372: pass self_join_mode so asymmetric strata broadcast
              * deltas to all workers (each holds 1/W IDB, needs full delta). */
             int brc;
+            bool owner_any_accepted = false;
+            uint32_t owner_accepted_rows = 0;
             {
                 uint64_t t0 = now_ns();
-                if (bdx_mode)
+                coord->current_iteration = eff_iter;
+                if (owner_exchange_mode)
+                    brc = tdd_owner_exchange_deltas(sp, coord, ctxs, W,
+                            &owner_any_accepted, &owner_accepted_rows);
+                else if (bdx_mode)
                     brc = tdd_bdx_exchange_deltas(sp, coord, ctxs, W,
                             bdx_snap);
                 else
@@ -4560,8 +5245,29 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 goto done;
             }
 
-            outer_any_new = true;
-            final_eff_iter = eff_iter;
+            /* Linear owner-mode can be slower than the sequential recursive
+             * evaluator on high-diameter, tiny-frontier workloads: every
+             * sub-pass pays a W-worker barrier and an exchange for only a few
+             * accepted rows.  Bail out early and replay the stratum through
+             * the existing single-threaded evaluator when that shape is
+             * detected. */
+            if (owner_exchange_mode
+                && eff_iter >= TDD_OWNER_FALLBACK_MIN_ITER
+                && owner_accepted_rows > 0
+                && owner_accepted_rows < TDD_OWNER_FALLBACK_DELTA_ROWS) {
+                owner_adaptive_fallback = true;
+                converged = true;
+                break;
+            }
+
+            if (owner_exchange_mode && !owner_any_accepted) {
+                converged = true;
+                break;
+            }
+
+            outer_any_new = owner_exchange_mode ? owner_any_accepted : true;
+            if (outer_any_new)
+                final_eff_iter = eff_iter;
         } /* end sub loop */
 
         if (stride_all_skipped)
@@ -4585,6 +5291,20 @@ done:
     }
     free(bdx_snap);
     coord->diff_operators_active = saved_diff;
+
+    if (owner_adaptive_fallback && rc == 0) {
+        rc = tdd_restore_coord_idb(sp, coord, owner_fallback_saved);
+        tdd_cleanup_workers(coord);
+        tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+        coord->tdd_total_ns += now_ns() - tdd_total_t0;
+        if (rc != 0)
+            return rc;
+        coord->frontier_ops->reset_stratum_frontier(coord, stratum_idx,
+            coord->outer_epoch);
+        return col_eval_stratum(sp, coord, stratum_idx);
+    }
+    tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+
     /* Issue #416: Accumulate instead of assign so total_iterations stays > 0
      * after any completed evaluation.  Assigning final_eff_iter (which is 0
      * when a replicate-mode stratum converges with no new tuples) would
@@ -4597,9 +5317,9 @@ done:
         tdd_record_recursive_convergence(coord, sp, stratum_idx,
             rule_id_base, final_eff_iter);
 
-        if (bdx_mode) {
-            /* BDX mode: coordinator IDB is already maintained (monotonic
-             * growth via tdd_bdx_exchange_deltas).  Just dedup final. */
+        if (bdx_mode || owner_exchange_mode) {
+            /* Coordinator-owned modes maintain IDB monotonically during
+             * exchange.  Just dedup final. */
             uint64_t merge_t0 = now_ns();
             for (uint32_t ri = 0; ri < nrels; ri++) {
                 col_rel_t *r = session_find_rel(coord,

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4903,8 +4903,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             W = 1;
     }
     W = tdd_choose_active_workers(sp, coord, W, replicate_mode);
-    if (W <= 1 && (coord->last_inserted_relation != NULL
-        || coord->total_iterations == 0)) {
+    if (W <= 1) {
         tdd_record_active_workers(coord, 1);
         if (coord->tdd_decision_tracking_active) {
             if (coord->tdd_executed_strata > 0)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1606,6 +1606,7 @@ tdd_cleanup_workers(wl_col_session_t *coord)
         memset(&coord->tdd_workers[w], 0, sizeof(wl_col_session_t));
     }
     coord->tdd_workers_count = 0;
+    coord->tdd_active_workers = 0;
 }
 
 /*
@@ -1618,11 +1619,13 @@ tdd_cleanup_workers(wl_col_session_t *coord)
  * On failure, any partially-created workers are destroyed.
  */
 static int
-tdd_init_workers(wl_col_session_t *coord)
+tdd_init_workers(wl_col_session_t *coord, uint32_t W)
 {
     tdd_cleanup_workers(coord);
 
-    uint32_t W = coord->num_workers;
+    if (W == 0 || W > coord->num_workers)
+        return EINVAL;
+    coord->tdd_active_workers = W;
     uint32_t nrels = coord->nrels;
 
     /* No relations: create empty worker sessions */
@@ -1747,11 +1750,13 @@ tdd_init_workers(wl_col_session_t *coord)
  * and 3-body recursive rules where IDB appears in the middle of the join.
  */
 static int
-tdd_replicate_workers(wl_col_session_t *coord)
+tdd_replicate_workers(wl_col_session_t *coord, uint32_t W)
 {
     tdd_cleanup_workers(coord);
 
-    uint32_t W = coord->num_workers;
+    if (W == 0 || W > coord->num_workers)
+        return EINVAL;
+    coord->tdd_active_workers = W;
     uint32_t nrels = coord->nrels;
 
     /* No relations: create empty worker sessions */
@@ -3617,11 +3622,13 @@ tdd_stratum_idb_self_join_exchange_aligned(const wl_plan_stratum_t *sp,
  */
 static int
 tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
-    bool partition_edb)
+    bool partition_edb, uint32_t W)
 {
     tdd_cleanup_workers(coord);
 
-    uint32_t W = coord->num_workers;
+    if (W == 0 || W > coord->num_workers)
+        return EINVAL;
+    coord->tdd_active_workers = W;
     uint32_t nrels = coord->nrels;
 
     if (nrels == 0) {
@@ -4823,9 +4830,9 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     }
 
     if (replicate_mode)
-        rc = tdd_replicate_workers(coord);
+        rc = tdd_replicate_workers(coord, W);
     else
-        rc = tdd_init_workers_hybrid(sp, coord, true);
+        rc = tdd_init_workers_hybrid(sp, coord, true, W);
     if (rc != 0) {
         tdd_free_saved_coord_idb(sp, owner_fallback_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
@@ -5372,7 +5379,7 @@ col_eval_stratum_tdd_nonrecursive(const wl_plan_stratum_t *sp,
     int rc;
 
     /* Phase 1: PARTITION — partition all coordinator relations to workers */
-    rc = tdd_init_workers(coord);
+    rc = tdd_init_workers(coord, W);
     if (rc != 0)
         return rc;
 

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4687,6 +4687,13 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
                     &coord->tdd_workers[w].base, rel_name);
             }
 
+            free(part->name);
+            part->name = wl_strdup(dname);
+            if (!part->name) {
+                col_rel_destroy(part);
+                rc = ENOMEM;
+                break;
+            }
             rc = session_add_rel(&coord->tdd_workers[w], part);
             if (rc != 0) {
                 col_rel_destroy(part);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1609,6 +1609,14 @@ tdd_cleanup_workers(wl_col_session_t *coord)
     coord->tdd_active_workers = 0;
 }
 
+static void
+tdd_record_active_workers(wl_col_session_t *coord, uint32_t W)
+{
+    coord->tdd_last_active_workers = W;
+    if (W > coord->tdd_max_active_workers)
+        coord->tdd_max_active_workers = W;
+}
+
 /*
  * tdd_init_workers:
  * Partition all coordinator relations across W worker sessions.
@@ -1626,6 +1634,7 @@ tdd_init_workers(wl_col_session_t *coord, uint32_t W)
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
     coord->tdd_active_workers = W;
+    tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
 
     /* No relations: create empty worker sessions */
@@ -1757,6 +1766,7 @@ tdd_replicate_workers(wl_col_session_t *coord, uint32_t W)
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
     coord->tdd_active_workers = W;
+    tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
 
     /* No relations: create empty worker sessions */
@@ -3629,6 +3639,7 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
     coord->tdd_active_workers = W;
+    tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
 
     if (nrels == 0) {
@@ -5435,8 +5446,10 @@ col_eval_stratum_tdd_nonrecursive(const wl_plan_stratum_t *sp,
     int rc;
 
     W = tdd_choose_active_workers(sp, coord, W, false);
-    if (W <= 1)
+    if (W <= 1) {
+        tdd_record_active_workers(coord, 1);
         return col_eval_stratum(sp, coord, stratum_idx);
+    }
 
     /* Phase 1: PARTITION — partition all coordinator relations to workers */
     rc = tdd_init_workers(coord, W);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1633,6 +1633,12 @@ tdd_init_workers(wl_col_session_t *coord, uint32_t W)
 
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
+    int ensure_rc = wl_columnar_session_ensure_workqueue(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
+    ensure_rc = wl_columnar_session_ensure_tdd_worker_slots(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
     coord->tdd_active_workers = W;
     tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
@@ -1765,6 +1771,12 @@ tdd_replicate_workers(wl_col_session_t *coord, uint32_t W)
 
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
+    int ensure_rc = wl_columnar_session_ensure_workqueue(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
+    ensure_rc = wl_columnar_session_ensure_tdd_worker_slots(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
     coord->tdd_active_workers = W;
     tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
@@ -3638,6 +3650,12 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
 
     if (W == 0 || W > coord->num_workers)
         return EINVAL;
+    int ensure_rc = wl_columnar_session_ensure_workqueue(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
+    ensure_rc = wl_columnar_session_ensure_tdd_worker_slots(coord, W);
+    if (ensure_rc != 0)
+        return ensure_rc;
     coord->tdd_active_workers = W;
     tdd_record_active_workers(coord, W);
     uint32_t nrels = coord->nrels;
@@ -5560,7 +5578,7 @@ col_eval_stratum_tdd(const wl_plan_stratum_t *sp,
         return EINVAL;
 
     /* Single-worker fast path: zero overhead delegation */
-    if (coord->num_workers <= 1 || !coord->tdd_workers)
+    if (coord->num_workers <= 1)
         return col_eval_stratum(sp, coord, stratum_idx);
 
     if (!sp->is_recursive)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4888,6 +4888,15 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     if (W <= 1 && (coord->last_inserted_relation != NULL
         || coord->total_iterations == 0)) {
         tdd_record_active_workers(coord, 1);
+        if (coord->tdd_decision_tracking_active) {
+            if (coord->tdd_executed_strata > 0)
+                coord->tdd_executed_strata--;
+            coord->tdd_fallback_strata++;
+            coord->tdd_last_fallback_reason =
+                WL_COLUMNAR_INTERNAL_TDD_FALLBACK_ADAPTIVE_WORKERS;
+            coord->tdd_fallback_reason_counts[
+                WL_COLUMNAR_INTERNAL_TDD_FALLBACK_ADAPTIVE_WORKERS]++;
+        }
         uint32_t saved_total_iterations = coord->total_iterations;
         int seq_rc = col_eval_stratum(sp, coord, stratum_idx);
         if (seq_rc == 0 && saved_total_iterations > 0)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4106,6 +4106,61 @@ tdd_check_convergence(const col_eval_tdd_worker_ctx_t *ctxs, uint32_t W)
     return true;
 }
 
+static uint64_t
+tdd_estimate_stratum_work_rows(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord)
+{
+    uint64_t stratum_rows = 0;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
+        if (r)
+            stratum_rows += r->nrows;
+    }
+
+    uint64_t input_rows = 0;
+    for (uint32_t ri = 0; ri < coord->nrels; ri++) {
+        col_rel_t *r = coord->rels[ri];
+        if (r)
+            input_rows += r->nrows;
+    }
+    return input_rows > stratum_rows ? input_rows : stratum_rows;
+}
+
+static uint32_t
+tdd_choose_active_workers(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, uint32_t max_workers, bool replicate_mode)
+{
+    if (max_workers <= 1)
+        return 1;
+
+    const char *env = getenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER");
+    uint64_t rows_per_worker = 4096;
+    if (env && env[0] != '\0') {
+        char *endp = NULL;
+        errno = 0;
+        unsigned long long v = strtoull(env, &endp, 10);
+        if (endp != env && *endp == '\0' && errno != ERANGE && v > 0)
+            rows_per_worker = (uint64_t)v;
+    }
+
+    uint64_t rows = tdd_estimate_stratum_work_rows(sp, coord);
+    uint32_t active = 1;
+    if (rows > 0) {
+        uint64_t wanted = (rows + rows_per_worker - 1) / rows_per_worker;
+        if (wanted > UINT32_MAX)
+            wanted = UINT32_MAX;
+        active = (uint32_t)wanted;
+    }
+
+    if (replicate_mode && active > 8)
+        active = 8;
+    if (active < 1)
+        active = 1;
+    if (active > max_workers)
+        active = max_workers;
+    return active;
+}
+
 /*
  * bdx_hash_diff:
  * Remove from delta any row that already exists in base.  This exact
@@ -4818,6 +4873,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         if (env && env[0] == '1')
             W = 1;
     }
+    W = tdd_choose_active_workers(sp, coord, W, replicate_mode);
 
     col_rel_t **owner_fallback_saved = NULL;
     bool owner_adaptive_fallback = false;
@@ -5377,6 +5433,10 @@ col_eval_stratum_tdd_nonrecursive(const wl_plan_stratum_t *sp,
 {
     uint32_t W = coord->num_workers;
     int rc;
+
+    W = tdd_choose_active_workers(sp, coord, W, false);
+    if (W <= 1)
+        return col_eval_stratum(sp, coord, stratum_idx);
 
     /* Phase 1: PARTITION — partition all coordinator relations to workers */
     rc = tdd_init_workers(coord, W);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1002,6 +1002,7 @@ typedef struct wl_col_session_t {
      * always uses the broadcast delta (which may be >= local partition size).
      * False everywhere else, including retraction paths. */
     bool tdd_subpass_active;
+    bool tdd_outbound_only_active;
     /* Side-relation compound arena (Issue #559): heap-allocated session-local
      * compound-term arena.  Owned by the coordinator; created in
      * col_session_create and freed in col_session_destroy.  Worker sessions
@@ -1611,6 +1612,11 @@ stratum_max_idb_body_atoms(const wl_plan_stratum_t *sp);
 bool
 tdd_stratum_idb_self_join_exchange_aligned(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord);
+bool
+tdd_stratum_single_idb_join_keys_exchange_aligned(
+    const wl_plan_stratum_t *sp);
+bool
+tdd_stratum_exchange_keys_are_multi_column(const wl_plan_stratum_t *sp);
 int
 col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
     uint32_t stratum_idx);
@@ -1766,6 +1772,7 @@ typedef struct {
     bool any_new;                  /* OUT: produced >=1 new tuple     */
     bool all_empty_delta;          /* OUT: all FORCE_DELTA empty, skipped */
     bool force_diff;               /* IN: enable diff from eff_iter 0 (BDX) */
+    bool outbound_only;            /* IN: emit deltas without local IDB append */
     col_rel_t **delta_rels;        /* OUT: produced deltas [nrels], coord frees */
     uint64_t runtime_ns;           /* OUT: worker sub-pass wall runtime */
     int rc;                        /* OUT: return code                */

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -117,6 +117,16 @@ now_ns(void)
  * available physical memory (see wl_col_session_t.join_output_limit). */
 #define COL_JOIN_OUTPUT_LIMIT_DEFAULT (50u * 1000u * 1000u) /* 50M rows */
 
+typedef enum wl_columnar_internal_tdd_fallback_reason {
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE = 0,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NON_RECURSIVE,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_SNAPSHOT_INELIGIBLE,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NO_EXCHANGE,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_ADAPTIVE_WORKERS,
+    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_REASON_COUNT
+} wl_columnar_internal_tdd_fallback_reason_t;
+
 /* ======================================================================== */
 /* Column-Major Allocation Helpers (Phase C, Issue #332)                    */
 /* ======================================================================== */
@@ -862,6 +872,13 @@ typedef struct wl_col_session_t {
     uint64_t tdd_exchange_gather_ns;
     uint64_t tdd_exchange_broadcast_ns;
     uint64_t tdd_final_merge_ns;
+    uint32_t tdd_recursive_strata;
+    uint32_t tdd_executed_strata;
+    uint32_t tdd_fallback_strata;
+    uint32_t tdd_fallback_reason_counts[
+        WL_COLUMNAR_INTERNAL_TDD_FALLBACK_REASON_COUNT];
+    wl_columnar_internal_tdd_fallback_reason_t tdd_last_fallback_reason;
+    bool tdd_decision_tracking_active;
     /* Phase 4: tracks which relation was just inserted via
      * col_session_insert_incremental, enables affected-stratum skip
      * optimization. Borrowed pointer; lifetime: until next session_step.

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -881,9 +881,10 @@ typedef struct wl_col_session_t {
      * instead of full re-derivation. Cleared after eval completes. */
     bool delta_seeded;
     /* Multi-worker support (issue #99).
-     * Stored from col_session_create num_workers parameter.
-     * When > 1, sess->wq is created at session init for parallel K-fusion.
-     * When == 1, K-fusion evaluates copies sequentially (no thread overhead). */
+     * Stored from col_session_create num_workers parameter as a maximum worker
+     * width. Adaptive TDD may dispatch fewer active workers for a stratum or
+     * sub-pass. When > 1, sess->wq is created at session init for parallel
+     * K-fusion. When == 1, K-fusion evaluates copies sequentially. */
     uint32_t num_workers;
     /* Dynamic join output limit (Issue #221).
      * Maximum output rows per single join operation. Computed at session init
@@ -984,6 +985,7 @@ typedef struct wl_col_session_t {
      * Owned by coordinator; worker sessions set tdd_workers = NULL. */
     struct wl_col_session_t *tdd_workers; /* owned array [num_workers] */
     uint32_t tdd_workers_count;         /* number of initialized workers */
+    uint32_t tdd_active_workers;        /* current adaptive TDD width */
     /* Per-party memory budget for TDD replicate-mode (Issue #416).
      * = total_ram*75% / (num_workers+1): the share that keeps aggregate
      * usage within 75% RAM when coordinator + W workers each hold a full

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -776,7 +776,8 @@ typedef struct wl_col_session_t {
      * Configurable via WL_MAT_CACHE_EVICT_THRESHOLD_PERCENT env var [1,100],
      * default = 90% of limit */
     size_t cache_evict_threshold;
-    wl_work_queue_t *wq; /* reusable thread pool for K-fusion     */
+    wl_work_queue_t *wq; /* lazily sized reusable worker pool     */
+    uint32_t wq_workers; /* current thread count in wq            */
     /* Profiling counters (3B-003): accumulated across all strata/iters  */
     uint64_t
         consolidation_ns; /* time in col_op_consolidate_incremental_delta */
@@ -899,9 +900,9 @@ typedef struct wl_col_session_t {
     bool delta_seeded;
     /* Multi-worker support (issue #99).
      * Stored from col_session_create num_workers parameter as a maximum worker
-     * width. Adaptive TDD may dispatch fewer active workers for a stratum or
-     * sub-pass. When > 1, sess->wq is created at session init for parallel
-     * K-fusion. When == 1, K-fusion evaluates copies sequentially. */
+     * width. Adaptive TDD and K-fusion may dispatch fewer active workers for a
+     * stratum/operator. Workqueue threads and TDD worker slots are allocated
+     * lazily for the selected active width, so workers=N means "use up to N". */
     uint32_t num_workers;
     /* Dynamic join output limit (Issue #221).
      * Maximum output rows per single join operation. Computed at session init
@@ -997,10 +998,11 @@ typedef struct wl_col_session_t {
      * to prevent double-free of the coordinator's entries array. */
     wl_frontier_progress_t progress;
     /* Distributed stratum evaluator state (Issue #318).
-     * Worker sessions created once at col_session_create for multi-worker use.
-     * NULL when num_workers <= 1 (single-worker fast path).
-     * Owned by coordinator; worker sessions set tdd_workers = NULL. */
-    struct wl_col_session_t *tdd_workers; /* owned array [num_workers] */
+     * Worker session slots allocated lazily for the selected active width.
+     * NULL when no TDD stratum has used workers yet. Owned by coordinator;
+     * worker sessions set tdd_workers = NULL. */
+    struct wl_col_session_t *tdd_workers; /* owned array [tdd_workers_cap] */
+    uint32_t tdd_workers_cap;           /* allocated slots in tdd_workers */
     uint32_t tdd_workers_count;         /* number of initialized workers */
     uint32_t tdd_active_workers;        /* current adaptive TDD width */
     uint32_t tdd_last_active_workers;   /* last selected TDD width */
@@ -1626,6 +1628,12 @@ col_eval_stratum_multiworker(const wl_plan_stratum_t *sp,
 int
 col_eval_stratum_tdd(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord, uint32_t stratum_idx);
+int
+wl_columnar_session_ensure_workqueue(wl_col_session_t *sess,
+    uint32_t active_workers);
+int
+wl_columnar_session_ensure_tdd_worker_slots(wl_col_session_t *sess,
+    uint32_t active_workers);
 bool
 tdd_stratum_has_idb_self_join(const wl_plan_stratum_t *sp);
 uint32_t

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -986,6 +986,8 @@ typedef struct wl_col_session_t {
     struct wl_col_session_t *tdd_workers; /* owned array [num_workers] */
     uint32_t tdd_workers_count;         /* number of initialized workers */
     uint32_t tdd_active_workers;        /* current adaptive TDD width */
+    uint32_t tdd_last_active_workers;   /* last selected TDD width */
+    uint32_t tdd_max_active_workers;    /* max selected width this eval */
     /* Per-party memory budget for TDD replicate-mode (Issue #416).
      * = total_ram*75% / (num_workers+1): the share that keeps aggregate
      * usage within 75% RAM when coordinator + W workers each hold a full

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2532,6 +2532,10 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
 #ifdef WL_PROFILE
             sess->profile.join_cache_hit_ns += now_ns() - _t0_join;
 #endif
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left_e.rel);
             return eval_stack_push_delta(stack, cached, false,
                        left_e.is_delta || used_right_delta);
         }
@@ -2939,8 +2943,6 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     free(tmp);
     free(lk);
     free(rk);
-    if (left_e.owned)
-        col_rel_destroy(left);
     /* Propagate delta flag: result is a delta if left was delta OR we used
      * right-delta. This ensures subsequent JOINs in the same rule plan know
      * whether to apply right-delta (they should NOT if we already used one). */
@@ -2961,8 +2963,12 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
 #endif
         if (right_filtered)
             col_rel_destroy(right_filtered);
+        if (left_e.owned)
+            col_rel_destroy(left);
         return eval_stack_push_delta(stack, out, false, result_is_delta);
     }
+    if (left_e.owned)
+        col_rel_destroy(left);
 #ifdef WL_PROFILE
     if (out->nrows == 0)
         sess->profile.join_empty_out++;
@@ -6116,9 +6122,14 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
     if (op->materialized && !projected_join) {
         col_rel_t *cached
             = col_mat_cache_lookup(&sess->mat_cache, left_e.rel, right);
-        if (cached)
+        if (cached) {
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left_e.rel);
             return eval_stack_push_delta(stack, cached, false,
                        left_e.is_delta || used_right_delta);
+        }
     }
 
     uint32_t kc = op->key_count;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2185,9 +2185,29 @@ typedef struct {
     const col_rel_t *left;
     const col_rel_t *right;
     col_rel_t *out;
+    const uint32_t *project_indices;
+    uint32_t project_count;
     uint64_t begin;
     uint64_t end;
 } col_join_cross_ctx_t;
+
+static uint32_t
+col_join_output_width(const col_rel_t *left, const col_rel_t *right,
+    const wl_plan_op_t *op)
+{
+    return (op && op->project_count > 0 && op->project_indices)
+        ? op->project_count : left->ncols + right->ncols;
+}
+
+static int64_t
+col_join_pair_value(const col_rel_t *left, uint32_t lr, const col_rel_t *right,
+    uint32_t rr, uint32_t idx)
+{
+    if (idx < left->ncols)
+        return left->columns[idx][lr];
+    idx -= left->ncols;
+    return idx < right->ncols ? right->columns[idx][rr] : 0;
+}
 
 static void
 col_join_cross_fill_worker_fn(void *arg)
@@ -2203,10 +2223,16 @@ col_join_cross_fill_worker_fn(void *arg)
     uint32_t rpos = (uint32_t)(ctx->begin % right_rows);
     while (oi < ctx->end) {
         uint32_t rr = right->nrows - 1u - rpos;
-        for (uint32_t c = 0; c < left->ncols; c++)
-            out->columns[c][oi] = left->columns[c][lr];
-        for (uint32_t c = 0; c < right->ncols; c++)
-            out->columns[left->ncols + c][oi] = right->columns[c][rr];
+        if (ctx->project_count > 0 && ctx->project_indices) {
+            for (uint32_t c = 0; c < ctx->project_count; c++)
+                out->columns[c][oi] = col_join_pair_value(left, lr, right, rr,
+                        ctx->project_indices[c]);
+        } else {
+            for (uint32_t c = 0; c < left->ncols; c++)
+                out->columns[c][oi] = left->columns[c][lr];
+            for (uint32_t c = 0; c < right->ncols; c++)
+                out->columns[left->ncols + c][oi] = right->columns[c][rr];
+        }
         oi++;
         rpos++;
         if (rpos == right->nrows) {
@@ -2218,7 +2244,8 @@ col_join_cross_fill_worker_fn(void *arg)
 
 static int
 col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
-    const col_rel_t *right, col_rel_t **outp, int *out_overflow)
+    const col_rel_t *right, const wl_plan_op_t *op, col_rel_t **outp,
+    int *out_overflow)
 {
     if (!sess || !left || !right || !outp || !*outp)
         return EINVAL;
@@ -2235,7 +2262,8 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
         return ENOMEM;
 
     uint32_t nrows = (uint32_t)emit_total;
-    col_rel_t *out = col_rel_new_auto("$join", left->ncols + right->ncols);
+    col_rel_t *out = col_rel_new_auto("$join",
+            col_join_output_width(left, right, op));
     if (!out)
         return ENOMEM;
     col_join_attach_ledger(sess, out);
@@ -2265,6 +2293,8 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
         ctxs[w].left = left;
         ctxs[w].right = right;
         ctxs[w].out = out;
+        ctxs[w].project_indices = op ? op->project_indices : NULL;
+        ctxs[w].project_count = op ? op->project_count : 0;
         ctxs[w].begin = begin;
         ctxs[w].end = end;
         if (wl_workqueue_submit(sess->wq, col_join_cross_fill_worker_fn,
@@ -2316,25 +2346,39 @@ col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
 
 static int
 col_join_append_pair(col_rel_t *out, const col_rel_t *left, uint32_t lr,
-    const col_rel_t *right, uint32_t rr, int64_t *fallback_row)
+    const col_rel_t *right, uint32_t rr, const uint32_t *project_indices,
+    uint32_t project_count, int64_t *fallback_row)
 {
     if (out->nrows < out->capacity) {
         uint32_t out_row = out->nrows;
         if (out->timestamps)
             memset(&out->timestamps[out_row], 0,
                 sizeof(col_delta_timestamp_t));
-        for (uint32_t c = 0; c < left->ncols; c++)
-            out->columns[c][out_row] = left->columns[c][lr];
-        for (uint32_t c = 0; c < right->ncols; c++)
-            out->columns[left->ncols + c][out_row] = right->columns[c][rr];
+        if (project_count > 0 && project_indices) {
+            for (uint32_t c = 0; c < project_count; c++)
+                out->columns[c][out_row] = col_join_pair_value(left, lr, right,
+                        rr, project_indices[c]);
+        } else {
+            for (uint32_t c = 0; c < left->ncols; c++)
+                out->columns[c][out_row] = left->columns[c][lr];
+            for (uint32_t c = 0; c < right->ncols; c++)
+                out->columns[left->ncols + c][out_row]
+                    = right->columns[c][rr];
+        }
         out->nrows++;
         return 0;
     }
 
-    for (uint32_t c = 0; c < left->ncols; c++)
-        fallback_row[c] = left->columns[c][lr];
-    for (uint32_t c = 0; c < right->ncols; c++)
-        fallback_row[left->ncols + c] = right->columns[c][rr];
+    if (project_count > 0 && project_indices) {
+        for (uint32_t c = 0; c < project_count; c++)
+            fallback_row[c] = col_join_pair_value(left, lr, right, rr,
+                    project_indices[c]);
+    } else {
+        for (uint32_t c = 0; c < left->ncols; c++)
+            fallback_row[c] = left->columns[c][lr];
+        for (uint32_t c = 0; c < right->ncols; c++)
+            fallback_row[left->ncols + c] = right->columns[c][rr];
+    }
     return col_rel_append_row(out, fallback_row);
 }
 
@@ -2355,9 +2399,10 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         /* If right relation doesn't exist, join produces empty result (cross-product with nothing).
          * Similar to ANTIJOIN logic (which keeps all left rows on missing right).
          * This can occur in generated plans where optional relations may not exist. */
+        uint32_t empty_cols = (op->project_count > 0 && op->project_indices)
+            ? op->project_count : left_e.rel->ncols;
         col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool,
-                sess->eval_arena, "$join_empty",
-                left_e.rel->ncols);
+                sess->eval_arena, "$join_empty", empty_cols);
         if (!out) {
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
@@ -2403,7 +2448,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
              * FORCE_DELTA required but delta absent/empty. Short-circuit to
              * empty result — this rule copy produces no tuples from this
              * permutation (correct semi-naive, issue #85). */
-            uint32_t ocols = left_e.rel->ncols + right->ncols;
+            uint32_t ocols = col_join_output_width(left_e.rel, right, op);
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
             col_rel_t *empty = col_rel_new_auto("$join_empty", ocols);
@@ -2479,7 +2524,8 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
      * Works with both stable (borrowed) and worker-owned relations since
      * the cache key is based on content hash, not ownership. This enables
      * cache reuse in K-fusion worker sessions, eliminating redundant joins. */
-    if (op->materialized) {
+    bool projected_join = op->project_count > 0 && op->project_indices;
+    if (op->materialized && !projected_join) {
         col_rel_t *cached
             = col_mat_cache_lookup(&sess->mat_cache, left_e.rel, right);
         if (cached) {
@@ -2512,9 +2558,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
     }
 
-    /* Output: all left cols + all right cols (including key duplication).
-     * Downstream MAP will project the desired output columns. */
-    uint32_t ocols = left->ncols + right->ncols;
+    uint32_t ocols = col_join_output_width(left, right, op);
     col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
             "$join", ocols);
     if (!out) {
@@ -2609,10 +2653,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         /* Probe: iterate non-unary side, test membership in hash set. */
         int join_rc = 0;
         for (uint32_t pr = 0; pr < probe->nrows && join_rc == 0; pr++) {
-            int64_t prow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(probe, pr, prow_buf);
-            const int64_t *prow = prow_buf;
-            int64_t pkey = prow[probe_kcol];
+            int64_t pkey = probe->columns[probe_kcol][pr];
             /* Inline FNV-1a hash for single int64 value */
             uint32_t h = 2166136261u;
             uint64_t v = (uint64_t)pkey;
@@ -2628,17 +2669,10 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                     = col_rel_get(build, bi, build_kcol);
                 if (pkey != bkey)
                     continue;
-                /* Match: emit output in [left cols | right cols] order. */
-                if (right_is_unary) {
-                    /* probe=left, build=right: [prow | bkey] */
-                    memcpy(tmp, prow, sizeof(int64_t) * probe->ncols);
-                    tmp[probe->ncols] = bkey;
-                } else {
-                    /* probe=right, build=left: [bkey | prow] */
-                    tmp[0] = bkey;
-                    memcpy(tmp + 1, prow, sizeof(int64_t) * probe->ncols);
-                }
-                join_rc = col_rel_append_row(out, tmp);
+                uint32_t lr = right_is_unary ? pr : bi;
+                uint32_t rr = right_is_unary ? bi : pr;
+                join_rc = col_join_append_pair(out, left, lr, right, rr,
+                        op->project_indices, op->project_count, tmp);
                 if (join_rc != 0) {
                     fprintf(stderr,
                         "ERROR: col_rel_append_row failed with rc=%d at "
@@ -2784,7 +2818,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         int join_rc = 0;
         int join_overflow = 0;
         if (kc == 0 && col_join_should_parallelize_cross(sess, left, right)) {
-            join_rc = col_join_parallel_cross(sess, left, right, &out,
+            join_rc = col_join_parallel_cross(sess, left, right, op, &out,
                     &join_overflow);
             if (join_rc == EINVAL)
                 join_rc = 0;
@@ -2803,7 +2837,8 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                         if (col_join_keys_match_rel(left, lr, lk, right, rr, rk,
                             kc)) {
                             join_rc = col_join_append_pair(out, left, lr, right,
-                                    rr, tmp);
+                                    rr, op->project_indices, op->project_count,
+                                    tmp);
                             if (join_rc != 0) {
                                 fprintf(stderr,
                                     "ERROR: col_rel_append_row failed in "
@@ -2840,7 +2875,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                             kc))
                             continue;
                         join_rc = col_join_append_pair(out, left, lr, right, rr,
-                                tmp);
+                                op->project_indices, op->project_count, tmp);
                         if (join_rc != 0) {
                             fprintf(stderr,
                                 "ERROR: col_rel_append_row failed in ephemeral "
@@ -2909,14 +2944,15 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     /* Propagate delta flag: result is a delta if left was delta OR we used
      * right-delta. This ensures subsequent JOINs in the same rule plan know
      * whether to apply right-delta (they should NOT if we already used one). */
-    bool result_is_delta = left_e.is_delta || used_right_delta;
+    bool result_is_delta = projected_join ? false
+        : (left_e.is_delta || used_right_delta);
 
     /* Populate materialization cache when hint is set.
      * Works with both stable and worker-owned relations.
      * Cache takes ownership of out; we push a borrowed reference.
      * This enables K-fusion workers to cache and reuse intermediate joins,
      * reducing redundant computation across the K worker copies. */
-    if (op->materialized) {
+    if (op->materialized && !projected_join) {
         col_mat_cache_insert(&sess->mat_cache, left, right, out);
 #ifdef WL_PROFILE
         if (out->nrows == 0)
@@ -5974,9 +6010,10 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
 
     col_rel_t *right = session_find_rel(sess, op->right_relation);
     if (!right) {
+        uint32_t empty_cols = (op->project_count > 0 && op->project_indices)
+            ? op->project_count : left_e.rel->ncols;
         col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool,
-                sess->eval_arena,
-                "$join_diff_empty", left_e.rel->ncols);
+                sess->eval_arena, "$join_diff_empty", empty_cols);
         if (!out) {
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
@@ -6006,7 +6043,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             used_right_delta = true;
         } else if (sess->current_iteration > 0 || sess->delta_seeded
             || sess->retraction_seeded) {
-            uint32_t ocols = left_e.rel->ncols + right->ncols;
+            uint32_t ocols = col_join_output_width(left_e.rel, right, op);
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
             col_rel_t *empty = col_rel_new_auto("$join_diff_empty", ocols);
@@ -6075,7 +6112,8 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     /* Materialization cache check */
-    if (op->materialized) {
+    bool projected_join = op->project_count > 0 && op->project_indices;
+    if (op->materialized && !projected_join) {
         col_rel_t *cached
             = col_mat_cache_lookup(&sess->mat_cache, left_e.rel, right);
         if (cached)
@@ -6104,7 +6142,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
     }
 
-    uint32_t ocols = left->ncols + right->ncols;
+    uint32_t ocols = col_join_output_width(left, right, op);
     col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
             "$join_diff", ocols);
     if (!out) {
@@ -6155,10 +6193,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         uint32_t indexed = darr->indexed_rows;
         uint32_t nbk = darr->nbuckets;
         for (uint32_t rr = indexed; rr < right->nrows; rr++) {
-            int64_t rrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(right, rr, rrow_buf);
-            const int64_t *rrow = rrow_buf;
-            uint32_t h = hash_int64_keys_fast(rrow, rk, kc) & (nbk - 1);
+            uint32_t h = col_join_hash_rel_keys(right, rr, rk, kc) & (nbk - 1);
             darr->ht_next[rr] = darr->ht_head[h];
             darr->ht_head[h] = rr + 1; /* 1-based; 0 = end of chain */
         }
@@ -6167,22 +6202,14 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
 
         /* Probe left against the persistent diff arrangement hash table */
         for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
-            int64_t lrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(left, lr, lrow_buf);
-            const int64_t *lrow = lrow_buf;
-            uint32_t h = hash_int64_keys_fast(lrow, lk, kc) & (nbk - 1);
+            uint32_t h = col_join_hash_rel_keys(left, lr, lk, kc) & (nbk - 1);
             for (uint32_t e = darr->ht_head[h]; e != 0;
                 e = darr->ht_next[e - 1]) {
                 uint32_t rr = e - 1;
-                int64_t rrow_buf[COL_STACK_MAX];
-                col_rel_row_copy_out(right, rr, rrow_buf);
-                const int64_t *rrow = rrow_buf;
-                if (!keys_match_fast(lrow, lk, rrow, rk, kc))
+                if (!col_join_keys_match_rel(left, lr, lk, right, rr, rk, kc))
                     continue;
-                memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
-                memcpy(tmp + left->ncols, rrow,
-                    sizeof(int64_t) * right->ncols);
-                join_rc = col_rel_append_row(out, tmp);
+                join_rc = col_join_append_pair(out, left, lr, right, rr,
+                        op->project_indices, op->project_count, tmp);
                 if (join_rc != 0)
                     break;
                 if ((sess->join_output_limit > 0
@@ -6227,32 +6254,21 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             return ENOMEM;
         }
         for (uint32_t rr = 0; rr < right->nrows; rr++) {
-            int64_t rrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(right, rr, rrow_buf);
-            const int64_t *rrow = rrow_buf;
-            uint32_t h
-                = hash_int64_keys_fast(rrow, rk, kc) & (nbuckets_ep - 1);
+            uint32_t h = col_join_hash_rel_keys(right, rr, rk, kc)
+                & (nbuckets_ep - 1);
             ht_next_ep[rr] = ht_head_ep[h];
             ht_head_ep[h] = rr + 1;
         }
         for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
-            int64_t lrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(left, lr, lrow_buf);
-            const int64_t *lrow = lrow_buf;
-            uint32_t h
-                = hash_int64_keys_fast(lrow, lk, kc) & (nbuckets_ep - 1);
+            uint32_t h = col_join_hash_rel_keys(left, lr, lk, kc)
+                & (nbuckets_ep - 1);
             for (uint32_t e = ht_head_ep[h]; e != 0;
                 e = ht_next_ep[e - 1]) {
                 uint32_t rr = e - 1;
-                int64_t rrow_buf[COL_STACK_MAX];
-                col_rel_row_copy_out(right, rr, rrow_buf);
-                const int64_t *rrow = rrow_buf;
-                if (!keys_match_fast(lrow, lk, rrow, rk, kc))
+                if (!col_join_keys_match_rel(left, lr, lk, right, rr, rk, kc))
                     continue;
-                memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
-                memcpy(tmp + left->ncols, rrow,
-                    sizeof(int64_t) * right->ncols);
-                join_rc = col_rel_append_row(out, tmp);
+                join_rc = col_join_append_pair(out, left, lr, right, rr,
+                        op->project_indices, op->project_count, tmp);
                 if (join_rc != 0)
                     break;
                 if ((sess->join_output_limit > 0
@@ -6283,11 +6299,12 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
     free(tmp);
     free(lk);
     free(rk);
-    bool result_is_delta = left_e.is_delta || used_right_delta;
+    bool result_is_delta = projected_join ? false
+        : (left_e.is_delta || used_right_delta);
 
     /* Materialization cache: insert BEFORE destroying left, because
      * col_mat_cache_key_content dereferences left to compute content hash. */
-    if (op->materialized) {
+    if (op->materialized && !projected_join) {
         col_mat_cache_insert(&sess->mat_cache, left, right, out);
         if (left_e.owned)
             col_rel_destroy(left);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2109,6 +2109,235 @@ apply_right_filter_cached(wl_col_session_t *sess,
 
 /* --- JOIN ---------------------------------------------------------------- */
 
+#define WL_JOIN_PAR_MIN_LEFT_ROWS_DEFAULT 4096u
+
+static uint32_t
+col_join_parallel_min_left_rows(void)
+{
+    const char *env = getenv("WIRELOG_JOIN_PAR_MIN_LEFT_ROWS");
+    if (!env || env[0] == '\0')
+        return WL_JOIN_PAR_MIN_LEFT_ROWS_DEFAULT;
+
+    char *endp = NULL;
+    errno = 0;
+    unsigned long v = strtoul(env, &endp, 10);
+    if (endp == env || *endp != '\0' || errno == ERANGE || v > UINT32_MAX)
+        return WL_JOIN_PAR_MIN_LEFT_ROWS_DEFAULT;
+    return (uint32_t)v;
+}
+
+static bool
+col_join_should_parallelize_rows(const wl_col_session_t *sess,
+    const col_rel_t *left, const col_rel_t *right)
+{
+    if (!sess || !left || !right)
+        return false;
+    if (sess->coordinator || !sess->wq || sess->num_workers <= 1)
+        return false;
+    uint32_t min_left = col_join_parallel_min_left_rows();
+    if (min_left == 0)
+        min_left = 1;
+    return left->nrows >= min_left
+           && left->nrows >= sess->num_workers * min_left;
+}
+
+static bool
+col_join_should_parallelize_cross(const wl_col_session_t *sess,
+    const col_rel_t *left, const col_rel_t *right)
+{
+    if (!col_join_should_parallelize_rows(sess, left, right))
+        return false;
+    if (right->nrows != 0 && left->nrows > UINT64_MAX / right->nrows)
+        return false;
+    uint64_t total = (uint64_t)left->nrows * right->nrows;
+    return sess->join_output_limit == 0 || total < sess->join_output_limit;
+}
+
+static void
+col_join_attach_ledger(wl_col_session_t *sess, col_rel_t *rel)
+{
+    if (!sess || !rel || rel->mem_ledger)
+        return;
+    rel->mem_ledger = &sess->mem_ledger;
+    if (rel->capacity > 0 && rel->ncols > 0)
+        wl_mem_ledger_alloc(rel->mem_ledger, WL_MEM_SUBSYS_RELATION,
+            (uint64_t)rel->capacity * rel->ncols * sizeof(int64_t));
+}
+
+static int
+col_join_reserve_exact(col_rel_t *rel, uint32_t nrows)
+{
+    if (!rel)
+        return EINVAL;
+    if (nrows <= rel->capacity)
+        return 0;
+    uint32_t old_cap = rel->capacity;
+    if (col_columns_realloc(rel->columns, rel->ncols, nrows) != 0)
+        return ENOMEM;
+    rel->capacity = nrows;
+    if (rel->mem_ledger && rel->ncols > 0)
+        wl_mem_ledger_alloc(rel->mem_ledger, WL_MEM_SUBSYS_RELATION,
+            (uint64_t)(nrows - old_cap) * rel->ncols * sizeof(int64_t));
+    return 0;
+}
+
+typedef struct {
+    const col_rel_t *left;
+    const col_rel_t *right;
+    col_rel_t *out;
+    uint64_t begin;
+    uint64_t end;
+} col_join_cross_ctx_t;
+
+static void
+col_join_cross_fill_worker_fn(void *arg)
+{
+    col_join_cross_ctx_t *ctx = (col_join_cross_ctx_t *)arg;
+    const col_rel_t *left = ctx->left;
+    const col_rel_t *right = ctx->right;
+    col_rel_t *out = ctx->out;
+    uint64_t right_rows = right->nrows;
+
+    uint64_t oi = ctx->begin;
+    uint32_t lr = (uint32_t)(ctx->begin / right_rows);
+    uint32_t rpos = (uint32_t)(ctx->begin % right_rows);
+    while (oi < ctx->end) {
+        uint32_t rr = right->nrows - 1u - rpos;
+        for (uint32_t c = 0; c < left->ncols; c++)
+            out->columns[c][oi] = left->columns[c][lr];
+        for (uint32_t c = 0; c < right->ncols; c++)
+            out->columns[left->ncols + c][oi] = right->columns[c][rr];
+        oi++;
+        rpos++;
+        if (rpos == right->nrows) {
+            rpos = 0;
+            lr++;
+        }
+    }
+}
+
+static int
+col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
+    const col_rel_t *right, col_rel_t **outp, int *out_overflow)
+{
+    if (!sess || !left || !right || !outp || !*outp)
+        return EINVAL;
+    if (!sess->wq || sess->num_workers <= 1 || right->nrows == 0)
+        return EINVAL;
+
+    uint64_t total = (uint64_t)left->nrows * (uint64_t)right->nrows;
+    uint64_t emit_total = total;
+    if (sess->join_output_limit > 0 && emit_total >= sess->join_output_limit) {
+        emit_total = sess->join_output_limit;
+        *out_overflow = 1;
+    }
+    if (emit_total > UINT32_MAX)
+        return ENOMEM;
+
+    uint32_t nrows = (uint32_t)emit_total;
+    col_rel_t *out = col_rel_new_auto("$join", left->ncols + right->ncols);
+    if (!out)
+        return ENOMEM;
+    col_join_attach_ledger(sess, out);
+    if (col_join_reserve_exact(out, nrows) != 0) {
+        col_rel_destroy(out);
+        return ENOMEM;
+    }
+    out->nrows = nrows;
+
+    uint32_t W = sess->num_workers;
+    col_join_cross_ctx_t *ctxs = (col_join_cross_ctx_t *)calloc(
+        W, sizeof(col_join_cross_ctx_t));
+    if (!ctxs) {
+        col_rel_destroy(out);
+        return ENOMEM;
+    }
+
+    uint64_t chunk = (emit_total + W - 1u) / W;
+    int rc = 0;
+    for (uint32_t w = 0; w < W; w++) {
+        uint64_t begin = (uint64_t)w * chunk;
+        uint64_t end = begin + chunk;
+        if (begin > emit_total)
+            begin = emit_total;
+        if (end > emit_total)
+            end = emit_total;
+        ctxs[w].left = left;
+        ctxs[w].right = right;
+        ctxs[w].out = out;
+        ctxs[w].begin = begin;
+        ctxs[w].end = end;
+        if (wl_workqueue_submit(sess->wq, col_join_cross_fill_worker_fn,
+            &ctxs[w]) != 0) {
+            rc = ENOMEM;
+            break;
+        }
+    }
+    wl_workqueue_wait_all(sess->wq);
+    free(ctxs);
+    if (rc != 0) {
+        col_rel_destroy(out);
+        return rc;
+    }
+
+    /* The placeholder $join relation was allocated before this fast path was
+     * selected and its initial capacity was never charged to the ledger. */
+    (*outp)->mem_ledger = NULL;
+    col_rel_destroy(*outp);
+    *outp = out;
+    return 0;
+}
+
+static uint32_t
+col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
+    const uint32_t *key_cols, uint32_t kc)
+{
+    uint32_t h = 2166136261u;
+    for (uint32_t i = 0; i < kc; i++) {
+        uint64_t v = (uint64_t)rel->columns[key_cols[i]][row];
+        h ^= (uint32_t)(v & 0xffffffff);
+        h *= 16777619u;
+        h ^= (uint32_t)(v >> 32);
+        h *= 16777619u;
+    }
+    return h;
+}
+
+static bool
+col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
+    const uint32_t *lk, const col_rel_t *right, uint32_t rr,
+    const uint32_t *rk, uint32_t kc)
+{
+    for (uint32_t k = 0; k < kc; k++)
+        if (left->columns[lk[k]][lr] != right->columns[rk[k]][rr])
+            return false;
+    return true;
+}
+
+static int
+col_join_append_pair(col_rel_t *out, const col_rel_t *left, uint32_t lr,
+    const col_rel_t *right, uint32_t rr, int64_t *fallback_row)
+{
+    if (out->nrows < out->capacity) {
+        uint32_t out_row = out->nrows;
+        if (out->timestamps)
+            memset(&out->timestamps[out_row], 0,
+                sizeof(col_delta_timestamp_t));
+        for (uint32_t c = 0; c < left->ncols; c++)
+            out->columns[c][out_row] = left->columns[c][lr];
+        for (uint32_t c = 0; c < right->ncols; c++)
+            out->columns[left->ncols + c][out_row] = right->columns[c][rr];
+        out->nrows++;
+        return 0;
+    }
+
+    for (uint32_t c = 0; c < left->ncols; c++)
+        fallback_row[c] = left->columns[c][lr];
+    for (uint32_t c = 0; c < right->ncols; c++)
+        fallback_row[left->ncols + c] = right->columns[c][rr];
+    return col_rel_append_row(out, fallback_row);
+}
+
 int
 col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
 {
@@ -2524,11 +2753,8 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                 "Ephemeral hash table created - nbuckets=%u",
                 nbuckets_ep);
             for (uint32_t rr = 0; rr < right->nrows; rr++) {
-                int64_t rrow_buf[COL_STACK_MAX];
-                col_rel_row_copy_out(right, rr, rrow_buf);
-                const int64_t *rrow = rrow_buf;
-                uint32_t h
-                    = hash_int64_keys_fast(rrow, rk, kc) & (nbuckets_ep - 1);
+                uint32_t h = col_join_hash_rel_keys(right, rr, rk, kc)
+                    & (nbuckets_ep - 1);
                 ht_next_ep[rr] = ht_head_ep[h];
                 ht_head_ep[h] = rr + 1; /* 1-based; 0 = end of chain */
             }
@@ -2556,31 +2782,69 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         }
 
         int join_rc = 0;
-        for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
-            int64_t lrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(left, lr, lrow_buf);
-            const int64_t *lrow = lrow_buf;
-
-            if (arr) {
-                /* Arrangement probe: fill key_row at right-side positions. */
-                for (uint32_t k = 0; k < kc; k++)
-                    key_row[rk[k]] = lrow[lk[k]];
-                uint32_t rr = col_arrangement_find_first(arr, right->columns,
-                        right->ncols, key_row);
-                while (rr != UINT32_MAX && join_rc == 0) {
-                    int64_t rrow_buf[COL_STACK_MAX];
-                    col_rel_row_copy_out(right, rr, rrow_buf);
-                    const int64_t *rrow = rrow_buf;
-                    /* Verify key match: find_next may return collision rows. */
-                    if (keys_match_fast(lrow, lk, rrow, rk, kc)) {
-                        memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
-                        memcpy(tmp + left->ncols, rrow,
-                            sizeof(int64_t) * right->ncols);
-                        join_rc = col_rel_append_row(out, tmp);
+        int join_overflow = 0;
+        if (kc == 0 && col_join_should_parallelize_cross(sess, left, right)) {
+            join_rc = col_join_parallel_cross(sess, left, right, &out,
+                    &join_overflow);
+            if (join_rc == EINVAL)
+                join_rc = 0;
+            else if (join_rc == 0 && join_overflow)
+                join_rc = EOVERFLOW;
+        } else for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
+                if (arr) {
+                    /* Arrangement probe: fill key_row at right-side positions. */
+                    for (uint32_t k = 0; k < kc; k++)
+                        key_row[rk[k]] = left->columns[lk[k]][lr];
+                    uint32_t rr = col_arrangement_find_first(arr,
+                            right->columns,
+                            right->ncols, key_row);
+                    while (rr != UINT32_MAX && join_rc == 0) {
+                        /* Verify key match: find_next may return collision rows. */
+                        if (col_join_keys_match_rel(left, lr, lk, right, rr, rk,
+                            kc)) {
+                            join_rc = col_join_append_pair(out, left, lr, right,
+                                    rr, tmp);
+                            if (join_rc != 0) {
+                                fprintf(stderr,
+                                    "ERROR: col_rel_append_row failed in "
+                                    "arrangement probe with rc=%d\n",
+                                    join_rc);
+                                break;
+                            }
+                            if ((sess->join_output_limit > 0
+                                && out->nrows >= sess->join_output_limit)
+                                || (out->nrows % 10000 == 0 && out->nrows > 0
+                                && wl_mem_ledger_should_backpressure(
+                                    &sess->mem_ledger, WL_MEM_SUBSYS_RELATION,
+                                    80))) {
+                                fprintf(
+                                    stderr,
+                                    "join output limit reached: %u rows "
+                                    "(limit=%llu)\n",
+                                    out->nrows,
+                                    (unsigned long long)sess->join_output_limit);
+                                join_rc = EOVERFLOW;
+                            }
+                        }
+                        rr = col_arrangement_find_next(arr, rr);
+                    }
+                } else {
+                    /* Ephemeral hash probe. */
+                    uint32_t h = col_join_hash_rel_keys(left, lr, lk, kc)
+                        & (nbuckets_ep - 1);
+                    for (uint32_t e = ht_head_ep[h]; e != 0;
+                        e = ht_next_ep[e - 1]) {
+                        uint32_t rr = e - 1;
+                        if (!col_join_keys_match_rel(left, lr, lk, right, rr,
+                            rk,
+                            kc))
+                            continue;
+                        join_rc = col_join_append_pair(out, left, lr, right, rr,
+                                tmp);
                         if (join_rc != 0) {
                             fprintf(stderr,
-                                "ERROR: col_rel_append_row failed in "
-                                "arrangement probe with rc=%d\n",
+                                "ERROR: col_rel_append_row failed in ephemeral "
+                                "hash probe with rc=%d\n",
                                 join_rc);
                             break;
                         }
@@ -2590,57 +2854,17 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                             && wl_mem_ledger_should_backpressure(
                                 &sess->mem_ledger, WL_MEM_SUBSYS_RELATION,
                                 80))) {
-                            fprintf(
-                                stderr,
+                            fprintf(stderr,
                                 "join output limit reached: %u rows "
                                 "(limit=%llu)\n",
                                 out->nrows,
                                 (unsigned long long)sess->join_output_limit);
                             join_rc = EOVERFLOW;
+                            break;
                         }
-                    }
-                    rr = col_arrangement_find_next(arr, rr);
-                }
-            } else {
-                /* Ephemeral hash probe. */
-                uint32_t h
-                    = hash_int64_keys_fast(lrow, lk, kc) & (nbuckets_ep - 1);
-                for (uint32_t e = ht_head_ep[h]; e != 0;
-                    e = ht_next_ep[e - 1]) {
-                    uint32_t rr = e - 1;
-                    int64_t rrow_buf[COL_STACK_MAX];
-                    col_rel_row_copy_out(right, rr, rrow_buf);
-                    const int64_t *rrow = rrow_buf;
-                    if (!keys_match_fast(lrow, lk, rrow, rk, kc))
-                        continue;
-                    memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
-                    memcpy(tmp + left->ncols, rrow,
-                        sizeof(int64_t) * right->ncols);
-                    join_rc = col_rel_append_row(out, tmp);
-                    if (join_rc != 0) {
-                        fprintf(stderr,
-                            "ERROR: col_rel_append_row failed in ephemeral "
-                            "hash probe with rc=%d\n",
-                            join_rc);
-                        break;
-                    }
-                    if ((sess->join_output_limit > 0
-                        && out->nrows >= sess->join_output_limit)
-                        || (out->nrows % 10000 == 0 && out->nrows > 0
-                        && wl_mem_ledger_should_backpressure(
-                            &sess->mem_ledger, WL_MEM_SUBSYS_RELATION,
-                            80))) {
-                        fprintf(stderr,
-                            "join output limit reached: %u rows "
-                            "(limit=%llu)\n",
-                            out->nrows,
-                            (unsigned long long)sess->join_output_limit);
-                        join_rc = EOVERFLOW;
-                        break;
                     }
                 }
             }
-        }
 
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG,
             "Merge-join loop completed, out->nrows=%u, rc=%d",

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1056,8 +1056,10 @@ col_op_variable(const wl_plan_op_t *op, eval_stack_t *stack,
     /* WL_DELTA_AUTO: use delta if strictly smaller than full relation.
      * Exception: inside a TDD worker sub-pass the broadcast $d$<rel> may be
      * >= the local partition, so we must use it whenever it is non-empty. */
-    bool use_delta = (delta && delta->nrows > 0
-        && (delta->nrows < full_rel->nrows || sess->tdd_subpass_active));
+    bool use_delta = delta && (((delta->nrows > 0
+        && delta->nrows < full_rel->nrows) || (delta->nrows > 0
+        && sess->tdd_subpass_active)) || (sess->tdd_outbound_only_active
+        && sess->current_iteration > 0));
     col_rel_t *rel = use_delta ? delta : full_rel;
     /* push borrowed reference - session owns the relation */
     return eval_stack_push_delta(stack, rel, false, use_delta);
@@ -2184,13 +2186,18 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
             return push_rc;
         }
         /* else: iteration 0 — no deltas yet, fall through to full right */
-    } else if (op->delta_mode != WL_DELTA_FORCE_FULL && !left_e.is_delta
-        && op->right_relation) {
+    } else if (op->delta_mode != WL_DELTA_FORCE_FULL && op->right_relation
+        && (!left_e.is_delta || (sess->tdd_outbound_only_active
+        && sess->current_iteration > 0))) {
         /* AUTO: original heuristic */
         char rdname[256];
         snprintf(rdname, sizeof(rdname), "$d$%s", op->right_relation);
         col_rel_t *rdelta = session_find_rel(sess, rdname);
-        if (rdelta && rdelta->nrows > 0 && rdelta->nrows < right->nrows) {
+        if (rdelta && (((rdelta->nrows > 0
+            && rdelta->nrows < right->nrows) || (rdelta->nrows > 0
+            && sess->tdd_subpass_active))
+            || (sess->tdd_outbound_only_active
+            && sess->current_iteration > 0))) {
             right = rdelta;
             used_right_delta = true;
         }
@@ -5786,12 +5793,17 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(empty);
             return push_rc;
         }
-    } else if (op->delta_mode != WL_DELTA_FORCE_FULL && !left_e.is_delta
-        && op->right_relation) {
+    } else if (op->delta_mode != WL_DELTA_FORCE_FULL && op->right_relation
+        && (!left_e.is_delta || (sess->tdd_outbound_only_active
+        && sess->current_iteration > 0))) {
         char rdname[256];
         snprintf(rdname, sizeof(rdname), "$d$%s", op->right_relation);
         col_rel_t *rdelta = session_find_rel(sess, rdname);
-        if (rdelta && rdelta->nrows > 0 && rdelta->nrows < right->nrows) {
+        if (rdelta && (((rdelta->nrows > 0
+            && rdelta->nrows < right->nrows) || (rdelta->nrows > 0
+            && sess->tdd_subpass_active))
+            || (sess->tdd_outbound_only_active
+            && sess->current_iteration > 0))) {
             right = rdelta;
             used_right_delta = true;
         }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5104,7 +5104,18 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
      * If this invocation cannot or should not dispatch parallel branch work,
      * use the existing serial K-fusion evaluator before allocating worker
      * sessions. */
-    wl_work_queue_t *wq = sess->wq; /* NULL when num_workers=1 or in workers */
+    uint32_t active_workers = live_count < sess->num_workers
+        ? live_count : sess->num_workers;
+    wl_work_queue_t *wq = NULL; /* NULL when serial or in workers */
+    if (active_workers > 1 && live_count >= WL_KFUSION_MIN_PARALLEL_K) {
+        int ensure_rc = wl_columnar_session_ensure_workqueue(sess,
+                active_workers);
+        if (ensure_rc != 0) {
+            free(live_indices);
+            return ensure_rc;
+        }
+        wq = sess->wq;
+    }
     if (!wq || live_count < WL_KFUSION_MIN_PARALLEL_K) {
         free(live_indices);
         return col_op_k_fusion_serial(op, stack, sess);
@@ -5145,6 +5156,10 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
          * darr_* are zeroed: workers rebuild delta arrangements per-iteration. */
         worker_sess[d] = *sess;
         worker_sess[d].wq = NULL; /* prevent nested K-fusion from workers */
+        worker_sess[d].wq_workers = 0;
+        worker_sess[d].tdd_workers = NULL;
+        worker_sess[d].tdd_workers_cap = 0;
+        worker_sess[d].tdd_workers_count = 0;
         if (worker_sess[d].join_output_limit > 0 && live_count > 1) {
             uint64_t per_branch =
                 worker_sess[d].join_output_limit / live_count;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2172,8 +2172,24 @@ col_join_reserve_exact(col_rel_t *rel, uint32_t nrows)
     if (nrows <= rel->capacity)
         return 0;
     uint32_t old_cap = rel->capacity;
-    if (col_columns_realloc(rel->columns, rel->ncols, nrows) != 0)
-        return ENOMEM;
+    if (rel->arena_owned) {
+        int64_t **new_cols = col_columns_alloc(rel->ncols, nrows);
+        if (!new_cols)
+            return ENOMEM;
+        for (uint32_t c = 0; c < rel->ncols; c++)
+            memcpy(new_cols[c], rel->columns[c],
+                sizeof(int64_t) * rel->nrows);
+        free(rel->columns);
+        rel->columns = new_cols;
+        rel->arena_owned = false;
+    } else if (rel->columns) {
+        if (col_columns_realloc(rel->columns, rel->ncols, nrows) != 0)
+            return ENOMEM;
+    } else {
+        rel->columns = col_columns_alloc(rel->ncols, nrows);
+        if (!rel->columns)
+            return ENOMEM;
+    }
     rel->capacity = nrows;
     if (rel->mem_ledger && rel->ncols > 0)
         wl_mem_ledger_alloc(rel->mem_ledger, WL_MEM_SUBSYS_RELATION,
@@ -2191,12 +2207,134 @@ typedef struct {
     uint64_t end;
 } col_join_cross_ctx_t;
 
+typedef struct {
+    const col_rel_t *left;
+    const col_rel_t *right;
+    const col_diff_arrangement_t *darr;
+    const uint32_t *lk;
+    const uint32_t *rk;
+    uint32_t kc;
+    const wl_plan_op_t *op;
+    col_rel_t *out;
+    uint32_t begin;
+    uint32_t end;
+    uint64_t out_begin;
+    uint64_t count;
+    uint64_t limit;
+    atomic_bool *stop;
+    atomic_uint_fast64_t *shared_count;
+    int rc;
+} col_join_keyed_ctx_t;
+
+static int64_t
+col_join_pair_value(const col_rel_t *left, uint32_t lr, const col_rel_t *right,
+    uint32_t rr, uint32_t idx);
+
+static uint32_t
+col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
+    const uint32_t *key_cols, uint32_t kc);
+
+static bool
+col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
+    const uint32_t *lk, const col_rel_t *right, uint32_t rr,
+    const uint32_t *rk, uint32_t kc);
+
 static uint32_t
 col_join_output_width(const col_rel_t *left, const col_rel_t *right,
     const wl_plan_op_t *op)
 {
     return (op && op->project_count > 0 && op->project_indices)
         ? op->project_count : left->ncols + right->ncols;
+}
+
+static void
+col_join_write_pair_at(col_rel_t *out, uint64_t out_row,
+    const col_rel_t *left, uint32_t lr, const col_rel_t *right, uint32_t rr,
+    const uint32_t *project_indices, uint32_t project_count)
+{
+    if (project_count > 0 && project_indices) {
+        for (uint32_t c = 0; c < project_count; c++)
+            out->columns[c][out_row] = col_join_pair_value(left, lr, right,
+                    rr, project_indices[c]);
+    } else {
+        for (uint32_t c = 0; c < left->ncols; c++)
+            out->columns[c][out_row] = left->columns[c][lr];
+        for (uint32_t c = 0; c < right->ncols; c++)
+            out->columns[left->ncols + c][out_row] = right->columns[c][rr];
+    }
+}
+
+static void
+col_join_keyed_count_worker_fn(void *arg)
+{
+    col_join_keyed_ctx_t *ctx = (col_join_keyed_ctx_t *)arg;
+    const col_rel_t *left = ctx->left;
+    const col_rel_t *right = ctx->right;
+    const col_diff_arrangement_t *darr = ctx->darr;
+    uint64_t count = 0;
+    uint64_t reported = 0;
+
+    for (uint32_t lr = ctx->begin; lr < ctx->end
+        && (!ctx->stop || !atomic_load_explicit(ctx->stop,
+        memory_order_relaxed)); lr++) {
+        uint32_t h = col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
+            & (darr->nbuckets - 1);
+        for (uint32_t e = darr->ht_head[h]; e != 0;
+            e = darr->ht_next[e - 1]) {
+            if (ctx->stop && atomic_load_explicit(ctx->stop,
+                memory_order_relaxed))
+                break;
+            uint32_t rr = e - 1;
+            if (col_join_keys_match_rel(left, lr, ctx->lk, right, rr, ctx->rk,
+                ctx->kc)) {
+                count++;
+                if (ctx->limit > 0 && ctx->shared_count
+                    && (count - reported) >= 1024u) {
+                    uint64_t seen = atomic_fetch_add_explicit(
+                        ctx->shared_count, 1024u, memory_order_relaxed)
+                        + 1024u;
+                    reported += 1024u;
+                    if (seen >= ctx->limit && ctx->stop) {
+                        atomic_store_explicit(ctx->stop, true,
+                            memory_order_relaxed);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if (count > reported && ctx->shared_count) {
+        uint64_t delta = count - reported;
+        uint64_t seen = atomic_fetch_add_explicit(ctx->shared_count, delta,
+                memory_order_relaxed) + delta;
+        if (ctx->limit > 0 && seen >= ctx->limit && ctx->stop)
+            atomic_store_explicit(ctx->stop, true, memory_order_relaxed);
+    }
+    ctx->count = count;
+}
+
+static void
+col_join_keyed_fill_worker_fn(void *arg)
+{
+    col_join_keyed_ctx_t *ctx = (col_join_keyed_ctx_t *)arg;
+    const col_rel_t *left = ctx->left;
+    const col_rel_t *right = ctx->right;
+    const col_diff_arrangement_t *darr = ctx->darr;
+    uint64_t out_row = ctx->out_begin;
+
+    for (uint32_t lr = ctx->begin; lr < ctx->end; lr++) {
+        uint32_t h = col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
+            & (darr->nbuckets - 1);
+        for (uint32_t e = darr->ht_head[h]; e != 0;
+            e = darr->ht_next[e - 1]) {
+            uint32_t rr = e - 1;
+            if (col_join_keys_match_rel(left, lr, ctx->lk, right, rr, ctx->rk,
+                ctx->kc)) {
+                col_join_write_pair_at(ctx->out, out_row++, left, lr, right,
+                    rr, ctx->op->project_indices, ctx->op->project_count);
+            }
+        }
+    }
 }
 
 static int64_t
@@ -2582,7 +2720,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         return ENOMEM;
     }
     /* Attach ledger so row growth is tracked under RELATION subsystem */
-    out->mem_ledger = &sess->mem_ledger;
+    col_join_attach_ledger(sess, out);
 
     /* Backpressure check (Issue #224): when RELATION subsystem reaches >= 80%
      * of its budget, skip row generation and push an empty result instead of
@@ -6184,7 +6322,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             col_rel_destroy(left);
         return ENOMEM;
     }
-    out->mem_ledger = &sess->mem_ledger;
+    col_join_attach_ledger(sess, out);
 
     /* Backpressure check (Issue #224) */
     if (wl_mem_ledger_should_backpressure(&sess->mem_ledger,
@@ -6231,6 +6369,138 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         darr->indexed_rows = right->nrows;
         darr->current_nrows = right->nrows;
+
+        uint32_t min_left = col_join_parallel_min_left_rows();
+        if (min_left == 0)
+            min_left = 1;
+        uint32_t W = left->nrows / min_left;
+        if (W > sess->num_workers)
+            W = sess->num_workers;
+        if (!sess->coordinator && W > 1) {
+            int ensure_rc = wl_columnar_session_ensure_workqueue(sess, W);
+            if (ensure_rc != 0) {
+                free(tmp);
+                col_rel_destroy(out);
+                free(lk);
+                free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
+                if (left_e.owned)
+                    col_rel_destroy(left);
+                return ensure_rc;
+            }
+            col_join_keyed_ctx_t *ctxs = (col_join_keyed_ctx_t *)calloc(
+                W, sizeof(col_join_keyed_ctx_t));
+            uint64_t *offsets = (uint64_t *)calloc(W + 1, sizeof(uint64_t));
+            if (!ctxs || !offsets) {
+                free(ctxs);
+                free(offsets);
+                free(tmp);
+                col_rel_destroy(out);
+                free(lk);
+                free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
+                if (left_e.owned)
+                    col_rel_destroy(left);
+                return ENOMEM;
+            }
+            uint32_t chunk = (left->nrows + W - 1u) / W;
+            atomic_bool stop = ATOMIC_VAR_INIT(false);
+            atomic_uint_fast64_t shared_count = ATOMIC_VAR_INIT(0);
+            int prc = 0;
+            for (uint32_t w = 0; w < W; w++) {
+                uint32_t begin = w * chunk;
+                uint32_t end = begin + chunk;
+                if (begin > left->nrows)
+                    begin = left->nrows;
+                if (end > left->nrows)
+                    end = left->nrows;
+                ctxs[w].left = left;
+                ctxs[w].right = right;
+                ctxs[w].darr = darr;
+                ctxs[w].lk = lk;
+                ctxs[w].rk = rk;
+                ctxs[w].kc = kc;
+                ctxs[w].op = op;
+                ctxs[w].begin = begin;
+                ctxs[w].end = end;
+                ctxs[w].limit = sess->join_output_limit;
+                ctxs[w].stop = &stop;
+                ctxs[w].shared_count = &shared_count;
+                if (wl_workqueue_submit(sess->wq,
+                    col_join_keyed_count_worker_fn, &ctxs[w]) != 0)
+                    prc = ENOMEM;
+            }
+            wl_workqueue_wait_all(sess->wq);
+            if (atomic_load_explicit(&stop, memory_order_relaxed)
+                && prc == 0)
+                prc = EOVERFLOW;
+            uint64_t total = 0;
+            for (uint32_t w = 0; w < W; w++) {
+                if (ctxs[w].rc != 0 && prc == 0)
+                    prc = ctxs[w].rc;
+                offsets[w] = total;
+                total += ctxs[w].count;
+            }
+            offsets[W] = total;
+            if (prc == 0 && sess->join_output_limit > 0
+                && total >= sess->join_output_limit)
+                prc = EOVERFLOW;
+            if (prc == 0 && total > UINT32_MAX)
+                prc = ENOMEM;
+            if (prc == 0 && total > out->capacity && ocols > 0) {
+                uint64_t add_rows = total - out->capacity;
+                uint64_t row_bytes = (uint64_t)ocols * sizeof(int64_t);
+                uint64_t add_bytes = add_rows > UINT64_MAX / row_bytes
+                    ? UINT64_MAX : add_rows * row_bytes;
+                uint64_t budget = atomic_load_explicit(
+                    &sess->mem_ledger.total_budget, memory_order_relaxed);
+                uint64_t current = atomic_load_explicit(
+                    &sess->mem_ledger.subsys_bytes[WL_MEM_SUBSYS_RELATION],
+                    memory_order_relaxed);
+                uint64_t cap = (budget
+                    * wl_mem_subsys_pct[WL_MEM_SUBSYS_RELATION]) / 100u;
+                uint64_t threshold = (cap * 80u) / 100u;
+                if (budget > 0 && cap > 0
+                    && (add_bytes > UINT64_MAX - current
+                    || current + add_bytes >= threshold))
+                    prc = EOVERFLOW;
+            }
+            if (prc == 0) {
+                if (col_join_reserve_exact(out, (uint32_t)total) != 0) {
+                    prc = ENOMEM;
+                } else {
+                    out->nrows = (uint32_t)total;
+                    for (uint32_t w = 0; w < W; w++) {
+                        ctxs[w].out = out;
+                        ctxs[w].out_begin = offsets[w];
+                        ctxs[w].rc = 0;
+                        if (wl_workqueue_submit(sess->wq,
+                            col_join_keyed_fill_worker_fn, &ctxs[w]) != 0)
+                            prc = ENOMEM;
+                    }
+                    wl_workqueue_wait_all(sess->wq);
+                    for (uint32_t w = 0; w < W; w++)
+                        if (ctxs[w].rc != 0 && prc == 0)
+                            prc = ctxs[w].rc;
+                }
+            }
+            free(offsets);
+            free(ctxs);
+            if (prc != 0) {
+                free(tmp);
+                col_rel_destroy(out);
+                free(lk);
+                free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
+                if (left_e.owned)
+                    col_rel_destroy(left);
+                return prc;
+            }
+            goto join_success;
+        }
 
         /* Probe left against the persistent diff arrangement hash table */
         for (uint32_t lr = 0; lr < left->nrows && join_rc == 0; lr++) {
@@ -6328,6 +6598,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     }
 
+join_success:
     free(tmp);
     free(lk);
     free(rk);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5122,6 +5122,16 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         return push_rc;
     }
 
+    /* Use session-level workqueue created at col_session_create (issue #99).
+     * If this invocation cannot or should not dispatch parallel branch work,
+     * use the existing serial K-fusion evaluator before allocating worker
+     * sessions. */
+    wl_work_queue_t *wq = sess->wq; /* NULL when num_workers=1 or in workers */
+    if (!wq || live_count < WL_KFUSION_MIN_PARALLEL_K) {
+        free(live_indices);
+        return col_op_k_fusion_serial(op, stack, sess);
+    }
+
     col_rel_t **results = (col_rel_t **)calloc(live_count, sizeof(col_rel_t *));
     col_op_k_fusion_worker_t *workers = (col_op_k_fusion_worker_t *)calloc(
         live_count, sizeof(col_op_k_fusion_worker_t));
@@ -5137,15 +5147,6 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         free(worker_sess);
         return ENOMEM;
     }
-
-    /* Use session-level workqueue created at col_session_create (issue #99).
-     * When wq is NULL or the active branch count is below threshold, live
-     * copies are evaluated sequentially below with no thread overhead. */
-    wl_work_queue_t *wq = sess->wq; /* NULL when num_workers=1 */
-    /* Threshold: for few live copies, parallel dispatch costs more than it
-    * saves. Force sequential execution when active copy count is small. */
-    if (wq && live_count < WL_KFUSION_MIN_PARALLEL_K)
-        wq = NULL;
 
     int rc = 0;
 

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2132,7 +2132,7 @@ col_join_should_parallelize_rows(const wl_col_session_t *sess,
 {
     if (!sess || !left || !right)
         return false;
-    if (sess->coordinator || !sess->wq || sess->num_workers <= 1)
+    if (sess->coordinator || sess->num_workers <= 1)
         return false;
     uint32_t min_left = col_join_parallel_min_left_rows();
     if (min_left == 0)
@@ -2249,7 +2249,7 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
 {
     if (!sess || !left || !right || !outp || !*outp)
         return EINVAL;
-    if (!sess->wq || sess->num_workers <= 1 || right->nrows == 0)
+    if (sess->num_workers <= 1 || right->nrows == 0)
         return EINVAL;
 
     uint64_t total = (uint64_t)left->nrows * (uint64_t)right->nrows;
@@ -2262,6 +2262,16 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
         return ENOMEM;
 
     uint32_t nrows = (uint32_t)emit_total;
+    uint32_t active_workers = sess->num_workers > emit_total
+        ? (uint32_t)emit_total
+        : sess->num_workers;
+    if (active_workers <= 1)
+        return EINVAL;
+    int ensure_rc = wl_columnar_session_ensure_workqueue(sess, active_workers);
+    if (ensure_rc != 0)
+        return ensure_rc;
+
+    uint32_t W = active_workers;
     col_rel_t *out = col_rel_new_auto("$join",
             col_join_output_width(left, right, op));
     if (!out)
@@ -2273,7 +2283,6 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
     }
     out->nrows = nrows;
 
-    uint32_t W = sess->num_workers;
     col_join_cross_ctx_t *ctxs = (col_join_cross_ctx_t *)calloc(
         W, sizeof(col_join_cross_ctx_t));
     if (!ctxs) {

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2583,8 +2583,8 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
      * TDD workers (coordinator != NULL) skip this pre-join check (Issue #404):
      * returning empty results before row generation causes silent correctness
      * bugs — zero join output leads to premature fixed-point convergence.
-     * Workers still have in-loop backpressure + join_output_limit as safety
-     * nets.  Coordinator sessions retain full pre-join protection. */
+     * Workers still have in-loop backpressure + join_output_limit as hard
+     * safety nets.  Coordinator sessions retain full pre-join protection. */
     if (wl_mem_ledger_should_backpressure(&sess->mem_ledger,
         WL_MEM_SUBSYS_RELATION, 80)
         && !sess->coordinator) {
@@ -2703,26 +2703,15 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         free(ht_head);
         free(ht_next);
         if (join_rc != 0) {
-            if (join_rc != EOVERFLOW) {
-                free(tmp);
-                col_rel_destroy(out);
-                free(lk);
-                free(rk);
-                if (left_e.owned)
-                    col_rel_destroy(left);
-                return join_rc;
-            }
-            /* Warn when a TDD worker truncates: silent truncation causes
-             * premature convergence and incorrect results (Issue #404). */
-            if (sess->coordinator) {
-                fprintf(stderr,
-                    "[wirelog] WARNING: join truncated on worker %u "
-                    "(limit=%llu, nrows=%u) — results may be incomplete\n",
-                    sess->worker_id,
-                    (unsigned long long)sess->join_output_limit,
-                    out->nrows);
-            }
-            join_rc = 0; /* soft truncation: push partial result below */
+            free(tmp);
+            col_rel_destroy(out);
+            free(lk);
+            free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left);
+            return join_rc;
         }
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG,
             "Unary join completed, out->nrows=%u",
@@ -2913,29 +2902,18 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         free(ht_head_ep);
         free(ht_next_ep);
         if (join_rc != 0) {
-            if (join_rc != EOVERFLOW) {
-                WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG,
-                    "Merge-join failed with rc=%d, out->nrows=%u",
-                    join_rc, out->nrows);
-                free(tmp);
-                col_rel_destroy(out);
-                free(lk);
-                free(rk);
-                if (left_e.owned)
-                    col_rel_destroy(left);
-                return join_rc;
-            }
-            /* Warn when a TDD worker truncates: silent truncation causes
-             * premature convergence and incorrect results (Issue #404). */
-            if (sess->coordinator) {
-                fprintf(stderr,
-                    "[wirelog] WARNING: join truncated on worker %u "
-                    "(limit=%llu, nrows=%u) — results may be incomplete\n",
-                    sess->worker_id,
-                    (unsigned long long)sess->join_output_limit,
-                    out->nrows);
-            }
-            join_rc = 0; /* soft truncation: push partial result below */
+            WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG,
+                "Merge-join failed with rc=%d, out->nrows=%u",
+                join_rc, out->nrows);
+            free(tmp);
+            col_rel_destroy(out);
+            free(lk);
+            free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left);
+            return join_rc;
         }
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG, "Merge-join succeeded");
     }
@@ -5167,6 +5145,12 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
          * darr_* are zeroed: workers rebuild delta arrangements per-iteration. */
         worker_sess[d] = *sess;
         worker_sess[d].wq = NULL; /* prevent nested K-fusion from workers */
+        if (worker_sess[d].join_output_limit > 0 && live_count > 1) {
+            uint64_t per_branch =
+                worker_sess[d].join_output_limit / live_count;
+            worker_sess[d].join_output_limit =
+                per_branch > 0 ? per_branch : 1;
+        }
         /* NULL out owned resources before allocation so cleanup_wq is safe
          * even if we abort early (e.g. clone failure).  Each owned pointer
          * is replaced below; the parent session retains its own copies. */
@@ -5307,7 +5291,6 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     for (uint32_t d = 0; d < live_count; d++) {
         if (workers[d].rc != 0) {
             rc = workers[d].rc;
-            eval_stack_drain(&workers[d].stack);
             goto cleanup_results;
         }
 
@@ -5397,6 +5380,7 @@ cleanup_results:
     for (uint32_t d = 0; d < live_count; d++) {
         if (results[d])
             col_rel_destroy(results[d]);
+        eval_stack_drain(&workers[d].stack);
     }
 
 cleanup_wq:
@@ -5410,6 +5394,7 @@ cleanup_wq:
      * Lock-free design: no synchronization needed because each worker owns
      * its isolated cache — no races at cleanup time. */
     for (uint32_t d = 0; d < live_count; d++) {
+        eval_stack_drain(&workers[d].stack);
         col_mat_cache_t *wc = &worker_sess[d].mat_cache;
         /* Issue #196: worker mat_cache starts empty (zeroed above), so ALL
          * entries were created by this worker — free from index 0. */
@@ -6246,17 +6231,17 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             }
         }
 
-        if (join_rc != 0 && join_rc != EOVERFLOW) {
+        if (join_rc != 0) {
             free(tmp);
             col_rel_destroy(out);
             free(lk);
             free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
             return join_rc;
         }
-        if (join_rc == EOVERFLOW)
-            join_rc = 0; /* soft truncation */
     } else {
         /* Ephemeral hash table fallback (same as col_op_join) */
         uint32_t nbuckets_ep = next_pow2(right->nrows >
@@ -6306,17 +6291,17 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         free(ht_head_ep);
         free(ht_next_ep);
-        if (join_rc != 0 && join_rc != EOVERFLOW) {
+        if (join_rc != 0) {
             free(tmp);
             col_rel_destroy(out);
             free(lk);
             free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
             return join_rc;
         }
-        if (join_rc == EOVERFLOW)
-            join_rc = 0;
     }
 
     free(tmp);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -4865,7 +4865,6 @@ typedef struct {
     wl_col_session_t
     *sess;        /* Per-worker session wrapper (isolated mat_cache) */
     int rc;       /* Return code from evaluation */
-    bool skipped; /* true if skipped due to empty forced delta (#85) */
 } col_op_k_fusion_worker_t;
 
 /**
@@ -5080,16 +5079,59 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     if (sess->wq == NULL && sess->num_workers <= 1)
         return col_op_k_fusion_serial(op, stack, sess);
 
+    /* Issue #560: Advance the compound-arena epoch frontier before
+     * evaluating K-Fusion branch liveness so the parallel path preserves the
+     * same coordinator epoch boundary ordering as worker dispatch. The
+     * compound_arena is borrowed from the coordinator (Issue #579 / R-5);
+     * only the coordinator may mutate it. */
+    if (sess->coordinator == NULL
+        && sess->compound_arena && sess->rotation_ops
+        && sess->rotation_ops->gc_epoch_boundary) {
+        sess->rotation_ops->gc_epoch_boundary(sess);
+    }
+
     uint64_t _phase_t0 = now_ns();
-    col_rel_t **results = (col_rel_t **)calloc(k, sizeof(col_rel_t *));
+    uint32_t *live_indices = (uint32_t *)malloc(k * sizeof(uint32_t));
+    if (!live_indices)
+        return ENOMEM;
+    uint32_t live_count = 0;
+    for (uint32_t d = 0; d < k; d++) {
+        wl_plan_relation_t plan_data;
+        plan_data.name = "<k_fusion_copy>";
+        plan_data.delta_name = NULL;
+        plan_data.ops = meta->k_ops[d];
+        plan_data.op_count = meta->k_op_counts[d];
+        if (!has_empty_forced_delta(&plan_data, sess, sess->current_iteration))
+            live_indices[live_count++] = d;
+    }
+    if (live_count == 0) {
+        COL_SESSION(sess)->kfusion_alloc_ns += now_ns() - _phase_t0;
+        uint32_t ncols = 0;
+        if (op->relation_name) {
+            col_rel_t *target = session_find_rel(sess, op->relation_name);
+            if (target)
+                ncols = target->ncols;
+        }
+        col_rel_t *empty = col_rel_new_auto("$kfusion_empty", ncols);
+        free(live_indices);
+        if (!empty)
+            return ENOMEM;
+        int push_rc = eval_stack_push(stack, empty, true);
+        if (push_rc != 0)
+            col_rel_destroy(empty);
+        return push_rc;
+    }
+
+    col_rel_t **results = (col_rel_t **)calloc(live_count, sizeof(col_rel_t *));
     col_op_k_fusion_worker_t *workers = (col_op_k_fusion_worker_t *)calloc(
-        k, sizeof(col_op_k_fusion_worker_t));
+        live_count, sizeof(col_op_k_fusion_worker_t));
     /* Per-worker session wrappers: shallow copy of sess with an isolated
      * mat_cache so concurrent col_op_join calls do not race on the cache. */
     wl_col_session_t *worker_sess
-        = (wl_col_session_t *)calloc(k, sizeof(wl_col_session_t));
+        = (wl_col_session_t *)calloc(live_count, sizeof(wl_col_session_t));
     COL_SESSION(sess)->kfusion_alloc_ns += now_ns() - _phase_t0;
     if (!results || !workers || !worker_sess) {
+        free(live_indices);
         free(results);
         free(workers);
         free(worker_sess);
@@ -5097,40 +5139,26 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     /* Use session-level workqueue created at col_session_create (issue #99).
-     * When num_workers=1 (wq==NULL), K copies are evaluated sequentially
-     * below with no thread overhead. */
+     * When wq is NULL or the active branch count is below threshold, live
+     * copies are evaluated sequentially below with no thread overhead. */
     wl_work_queue_t *wq = sess->wq; /* NULL when num_workers=1 */
-    /* Threshold: for small K, parallel dispatch costs more than it saves.
-     * Force sequential execution when K < WL_KFUSION_MIN_PARALLEL_K. */
-    if (wq && k < WL_KFUSION_MIN_PARALLEL_K)
+    /* Threshold: for few live copies, parallel dispatch costs more than it
+    * saves. Force sequential execution when active copy count is small. */
+    if (wq && live_count < WL_KFUSION_MIN_PARALLEL_K)
         wq = NULL;
 
     int rc = 0;
-
-    /* Issue #560: Advance the compound-arena epoch frontier before
-     * spawning K-Fusion workers so each worker's view of the arena
-     * starts at a freshly-retired generation.  This bounds the set
-     * of compound handles workers can observe and lets the
-     * epoch-frontier GC reclaim handles whose multiplicity already
-     * dropped to zero in the parent.  Each link is NULL-guarded so
-     * sessions without a compound arena or rotation strategy still
-     * spawn workers unchanged.  The compound_arena is borrowed from
-     * the coordinator (Issue #579 / R-5); only the coordinator may
-     * mutate it, so worker-context invocations skip the dispatch. */
-    if (sess->coordinator == NULL
-        && sess->compound_arena && sess->rotation_ops
-        && sess->rotation_ops->gc_epoch_boundary) {
-        sess->rotation_ops->gc_epoch_boundary(sess);
-    }
 
     /* Issue #196: Workers start with zeroed mat_cache (no shared entries).
      * All worker cache entries are worker-owned; cleanup frees all of them
      * starting from index 0, so no base_count snapshot is needed. */
 
-    /* Initialise per-worker session wrappers and submit all K tasks in one
-     * batch so workers execute in parallel. */
+    /* Initialise per-worker session wrappers and submit only live tasks in one
+     * batch so W acts as a cap instead of forcing allocation for skipped
+     * delta-copy branches. */
     _phase_t0 = now_ns();
-    for (uint32_t d = 0; d < k; d++) {
+    for (uint32_t d = 0; d < live_count; d++) {
+        uint32_t branch_idx = live_indices[d];
         /* Shallow copy shares rels[], plan, etc. (read-only during K-fusion).
          * mat_cache is zeroed below (Issue #196): workers start fresh.
          * arr_* are deep-copied (#260): each worker gets an independent
@@ -5205,19 +5233,19 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         {
             size_t parent_cap
                 = sess->eval_arena ? sess->eval_arena->capacity : 0;
-            size_t worker_cap = parent_cap / k;
+            size_t worker_cap = parent_cap / live_count;
             if (worker_cap < 8 * 1024 * 1024)
                 worker_cap = 8 * 1024 * 1024; /* 8MB minimum */
             worker_sess[d].eval_arena = wl_arena_create(worker_cap);
             /* NULL arena is handled gracefully: operators check before use */
         }
-        /* Issue #196: Scale per-worker delta_pool inversely with K to
-         * keep aggregate memory ~constant (32MB total vs K×32MB). */
+        /* Issue #196: Scale per-worker delta_pool inversely with active
+         * branch count to keep aggregate memory ~constant. */
         {
-            size_t pool_arena = 32 * 1024 * 1024 / k;
+            size_t pool_arena = 32 * 1024 * 1024 / live_count;
             if (pool_arena < 4 * 1024 * 1024)
                 pool_arena = 4 * 1024 * 1024; /* 4MB minimum */
-            uint32_t pool_slots = 128 / k;
+            uint32_t pool_slots = 128 / live_count;
             if (pool_slots < 16)
                 pool_slots = 16;
             worker_sess[d].delta_pool
@@ -5225,20 +5253,10 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         }
 
         workers[d].plan_data.name = "<k_fusion_copy>";
-        workers[d].plan_data.ops = meta->k_ops[d];
-        workers[d].plan_data.op_count = meta->k_op_counts[d];
+        workers[d].plan_data.ops = meta->k_ops[branch_idx];
+        workers[d].plan_data.op_count = meta->k_op_counts[branch_idx];
         workers[d].sess = &worker_sess[d];
         workers[d].rc = 0;
-
-        /* Per-copy empty-delta skip (issue #85): if this copy's sub-plan
-         * has a FORCE_DELTA op referencing an empty/absent delta on
-         * iteration > 0, skip dispatching — the copy would produce 0 rows. */
-        if (has_empty_forced_delta(&workers[d].plan_data, sess,
-            sess->current_iteration)) {
-            workers[d].rc = 0; /* mark as succeeded with no output */
-            workers[d].skipped = true;
-            continue;
-        }
 
         if (wq) {
             /* Parallel path: submit to session workqueue (issue #99) */
@@ -5269,7 +5287,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
 #ifdef WL_PROFILE
     {
         wl_profile_t base_profile = sess->profile;
-        for (uint32_t d = 0; d < k; d++) {
+        for (uint32_t d = 0; d < live_count; d++) {
             /* Merge counters: sum increments from baseline */
             sess->profile.join_calls
                 += worker_sess[d].profile.join_calls - base_profile.join_calls;
@@ -5285,13 +5303,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
 
     /* Collect results from each worker's eval_stack */
     _phase_t0 = now_ns();
-    for (uint32_t d = 0; d < k; d++) {
-        /* Skipped workers (empty forced delta) contribute an empty result */
-        if (workers[d].skipped) {
-            results[d] = NULL; /* NULL = no rows from this copy */
-            continue;
-        }
-
+    for (uint32_t d = 0; d < live_count; d++) {
         if (workers[d].rc != 0) {
             rc = workers[d].rc;
             eval_stack_drain(&workers[d].stack);
@@ -5336,30 +5348,28 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         eval_stack_drain(&workers[d].stack);
     }
 
-    /* Merge K results with deduplication.
+    /* Merge live branch results with deduplication.
      * Workers ran WL_PLAN_OP_CONSOLIDATE as the last plan op, so each
-     * result is already sorted+deduped — no qsort needed here.
-     * Skipped copies (empty forced delta) have NULL results — compact
-     * them out before merging. */
+     * result is already sorted+deduped — no qsort needed here. */
     {
-        /* Compact non-NULL results (skipped copies have NULL). Use the
+        /* Compact non-NULL results. Use the
          * existing results array as backing — we build compact in-place. */
-        col_rel_t **compact = (col_rel_t **)malloc(k * sizeof(col_rel_t *));
+        col_rel_t **compact
+            = (col_rel_t **)malloc(live_count * sizeof(col_rel_t *));
         if (!compact) {
             rc = ENOMEM;
             goto cleanup_results;
         }
         uint32_t n_results = 0;
-        for (uint32_t d = 0; d < k; d++) {
+        for (uint32_t d = 0; d < live_count; d++) {
             if (results[d])
                 compact[n_results++] = results[d];
         }
 
         col_rel_t *merged;
         if (n_results == 0) {
-            /* All copies skipped: produce empty output.  Derive column
-             * count from the K-fusion target relation (op->relation_name)
-             * so the empty result has a matching schema. */
+            /* Defensive fallback: produce empty output with the target
+             * relation schema if no worker produced a relation. */
             uint32_t ncols = 0;
             if (op->relation_name) {
                 col_rel_t *target = session_find_rel(sess, op->relation_name);
@@ -5383,7 +5393,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
 
 cleanup_results:
     _phase_t0 = now_ns();
-    for (uint32_t d = 0; d < k; d++) {
+    for (uint32_t d = 0; d < live_count; d++) {
         if (results[d])
             col_rel_destroy(results[d]);
     }
@@ -5398,7 +5408,7 @@ cleanup_wq:
      * Free each worker's private arrangement caches (arr_* and darr_*).
      * Lock-free design: no synchronization needed because each worker owns
      * its isolated cache — no races at cleanup time. */
-    for (uint32_t d = 0; d < k; d++) {
+    for (uint32_t d = 0; d < live_count; d++) {
         col_mat_cache_t *wc = &worker_sess[d].mat_cache;
         /* Issue #196: worker mat_cache starts empty (zeroed above), so ALL
          * entries were created by this worker — free from index 0. */
@@ -5458,6 +5468,7 @@ cleanup_wq:
     free(worker_sess);
     free(results);
     free(workers);
+    free(live_indices);
     COL_SESSION(sess)->kfusion_cleanup_ns += now_ns() - _phase_t0;
     return rc;
 }

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -53,6 +53,16 @@
 #define WL_PREFETCH_W(addr) ((void)(addr))
 #endif
 
+#ifdef WL_RADIX_BENCH
+static bool
+wl_columnar_relation_radix_bench_enabled(void)
+{
+    const char *env = getenv("WIRELOG_RADIX_BENCH_LOG");
+
+    return env && env[0] != '\0' && strcmp(env, "0") != 0;
+}
+#endif
+
 /* ---- COW helpers --------------------------------------------------------- */
 
 /*
@@ -1960,7 +1970,7 @@ radix_sort_k16(col_rel_t *r, uint32_t start_row, uint32_t nrows)
     free(count);
 #ifdef WL_RADIX_BENCH
     _tA = now_ns() - _t0;
-    {
+    if (wl_columnar_relation_radix_bench_enabled()) {
         uint64_t _tot = _tU + _tS + _tA;
         fprintf(stderr,
             "[radix-bench k=16] nrows=%u nc=%u pass=%u skip=%u "
@@ -2138,7 +2148,7 @@ col_rel_radix_sort(col_rel_t *r, uint32_t start_row, uint32_t nrows)
     free(bv_cache);
 #ifdef WL_RADIX_BENCH
     _tA = now_ns() - _t0;
-    {
+    if (wl_columnar_relation_radix_bench_enabled()) {
         uint64_t _tot = _tU + _tS + _tA;
         fprintf(stderr,
             "[radix-bench k=8] nrows=%u nc=%u pass=%u skip=%u "

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -84,6 +84,42 @@ session_compound_max_epochs_from_env(void)
     return (uint32_t)v;
 }
 
+static int
+session_hash_result_or_fallback(wl_col_session_t *sess, int rc)
+{
+    if (rc == ENOMEM) {
+        session_rel_free_hash(sess);
+        return 0;
+    }
+    return rc;
+}
+
+static void
+session_invalidate_relation_caches(wl_col_session_t *sess, const char *name)
+{
+    col_session_invalidate_arrangements(&sess->base, name);
+    col_mat_cache_clear(&sess->mat_cache);
+
+    uint32_t out = 0;
+    for (uint32_t i = 0; i < sess->filt_cache_count; i++) {
+        col_filt_cache_entry_t *e = &sess->filt_cache[i];
+        if (strcmp(e->rel_name, name) == 0) {
+            free(e->rel_name);
+            free(e->filter_data);
+            if (e->filtered)
+                col_rel_destroy(e->filtered);
+            memset(e, 0, sizeof(*e));
+            continue;
+        }
+        if (out != i) {
+            sess->filt_cache[out] = sess->filt_cache[i];
+            memset(&sess->filt_cache[i], 0, sizeof(sess->filt_cache[i]));
+        }
+        out++;
+    }
+    sess->filt_cache_count = out;
+}
+
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
@@ -113,6 +149,29 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
         r->columns = heap_cols;
         r->arena_owned = false;
     }
+
+    for (uint32_t i = 0; i < sess->nrels; i++) {
+        if (sess->rels[i] && strcmp(sess->rels[i]->name, r->name) == 0) {
+            if (sess->rels[i] == r)
+                return 0;
+            session_invalidate_relation_caches(sess, r->name);
+            col_rel_destroy(sess->rels[i]);
+            sess->rels[i] = r;
+            return 0;
+        }
+    }
+
+    for (uint32_t i = 0; i < sess->nrels; i++) {
+        if (!sess->rels[i]) {
+            sess->rels[i] = r;
+            int hash_ret = session_hash_result_or_fallback(sess,
+                    session_rel_build_hash(sess));
+            if (hash_ret != 0)
+                return hash_ret;
+            return 0;
+        }
+    }
+
     if (sess->nrels >= sess->rel_cap) {
         uint32_t nc = sess->rel_cap ? sess->rel_cap * 2 : 16;
         col_rel_t **nr
@@ -128,7 +187,8 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
     /* Update hash table for O(1) lookup (Issue #281).
      * May rebuild if load factor exceeded or rebuild on first insert. */
     int hash_ret = session_rel_hash_insert(sess, idx);
-    if (hash_ret != 0 && hash_ret != ENOMEM)
+    hash_ret = session_hash_result_or_fallback(sess, hash_ret);
+    if (hash_ret != 0)
         return hash_ret;
     /* ENOMEM in hash insert is non-fatal; fallback to linear search in
      * session_find_rel. Continue adding relation. */
@@ -141,11 +201,10 @@ session_remove_rel(wl_col_session_t *sess, const char *name)
 {
     for (uint32_t i = 0; i < sess->nrels; i++) {
         if (sess->rels[i] && strcmp(sess->rels[i]->name, name) == 0) {
+            session_invalidate_relation_caches(sess, name);
             col_rel_destroy(sess->rels[i]);
             sess->rels[i] = NULL;
-            /* Update hash table: mark as removed (Issue #281).
-             * Chain walk will see NULL rels[i] and skip. */
-            session_rel_hash_remove(sess, i);
+            session_rel_free_hash(sess);
             return;
         }
     }

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2034,14 +2034,17 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
              * the full join), which is worse than single-threaded. */
             if (recursive_has_exchange) {
                 if (!tdd_stratum_has_idb_self_join(rsp)) {
-                    /* Category A: no IDB-IDB joins.  TDD would fall into
-                     * replicate_mode (all workers receive the full dataset;
-                     * no work is partitioned → zero speedup).  With W>1,
-                     * memory backpressure inside each worker truncates joins
-                     * earlier than a single-threaded coordinator would,
-                     * causing fewer derived facts and a tuple count
-                     * discrepancy vs W=1 (Issue #416 residual).
-                     * recursive_tdd_safe stays false → single-threaded. */
+                    /* Category A: no IDB-IDB joins.  Owner-partitioned TDD is
+                     * correct only when every recursive IDB probe uses the
+                     * relation's EXCHANGE key.  Rules that consume the same
+                     * IDB through multiple key columns (e.g. DOOP SubtypeOf's
+                     * array component rule) require cross-owner access and
+                     * must stay single-threaded for now. */
+                    recursive_tdd_safe =
+                        stratum_max_idb_body_atoms(rsp) <= 1
+                        && tdd_stratum_exchange_keys_are_multi_column(rsp)
+                        && tdd_stratum_single_idb_join_keys_exchange_aligned(
+                        rsp);
                 } else if (tdd_stratum_idb_self_join_exchange_aligned(
                         rsp, sess)) {
                     /* Category B: IDB-IDB joins are exchange-aligned. */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -398,6 +398,26 @@ wl_columnar_session_get_tdd_exchange_breakdown_stats(wl_session_t *sess,
 }
 
 /*
+ * wl_columnar_session_get_tdd_worker_width_stats:
+ *
+ * Return adaptive TDD worker-width selections from the last snapshot.
+ * Hidden benchmark instrumentation hook; not part of the installed API.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4
+__attribute__((visibility("hidden")))
+#endif
+void
+wl_columnar_session_get_tdd_worker_width_stats(wl_session_t *sess,
+    uint32_t *out_last_active_workers, uint32_t *out_max_active_workers)
+{
+    wl_col_session_t *cs = COL_SESSION(sess);
+    if (out_last_active_workers)
+        *out_last_active_workers = cs->tdd_last_active_workers;
+    if (out_max_active_workers)
+        *out_max_active_workers = cs->tdd_max_active_workers;
+}
+
+/*
  * col_session_cleanup_old_data:
  *
  * Remove data that is entirely before the frontier (iteration, stratum).
@@ -1934,6 +1954,8 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     sess->tdd_exchange_gather_ns = 0;
     sess->tdd_exchange_broadcast_ns = 0;
     sess->tdd_final_merge_ns = 0;
+    sess->tdd_last_active_workers = 0;
+    sess->tdd_max_active_workers = 0;
 
     /* Phase 4 incremental skip: when last_inserted_relation is set, only
      * re-evaluate strata that transitively depend on the inserted relation.

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1192,18 +1192,28 @@ col_worker_session_create(wl_col_session_t *coordinator,
      * we lazily shrink the coordinator to its per-party share so that, once
      * workers are live, aggregate memory usage stays within the 75%-RAM
      * envelope (coordinator + W workers each hold tdd_budget_per_party). */
+    uint32_t active_workers = coordinator->tdd_active_workers > 0
+        ? coordinator->tdd_active_workers : coordinator->num_workers;
+    if (active_workers == 0)
+        active_workers = 1;
     uint64_t worker_budget;
     if (coordinator->tdd_budget_per_party > 0) {
+        uint64_t max_workers = coordinator->num_workers > 0
+            ? coordinator->num_workers : active_workers;
+        uint64_t active_party_budget = (coordinator->tdd_budget_per_party
+            * (max_workers + 1)) / (uint64_t)(active_workers + 1);
+        if (active_party_budget == 0)
+            active_party_budget = coordinator->tdd_budget_per_party;
         if (coordinator->tdd_workers_count == 0) {
             /* First worker: shrink coordinator to its per-party share. */
             atomic_store_explicit(&coordinator->mem_ledger.total_budget,
-                coordinator->tdd_budget_per_party, memory_order_relaxed);
+                active_party_budget, memory_order_relaxed);
         }
-        worker_budget = coordinator->tdd_budget_per_party;
+        worker_budget = active_party_budget;
     } else {
         worker_budget = atomic_load_explicit(
             &coordinator->mem_ledger.total_budget, memory_order_relaxed)
-            / coordinator->num_workers;
+            / active_workers;
     }
     wl_mem_ledger_init(&out_worker->mem_ledger, worker_budget);
 
@@ -1212,9 +1222,9 @@ col_worker_session_create(wl_col_session_t *coordinator,
      * shrink to a fair per-worker share (0 = disabled, preserved as-is).
      * Clamp to minimum 1 so that limit < W does not accidentally disable
      * the cap (0 means unlimited). */
-    if (coordinator->num_workers > 0 && coordinator->join_output_limit > 0) {
+    if (active_workers > 0 && coordinator->join_output_limit > 0) {
         uint64_t per_worker =
-            coordinator->join_output_limit / coordinator->num_workers;
+            coordinator->join_output_limit / active_workers;
         out_worker->join_output_limit = per_worker > 0 ? per_worker : 1;
     }
 
@@ -1234,9 +1244,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
 
     /* Step 7: Allocate per-worker arena (scaled by num_workers) */
     {
-        uint32_t k = coordinator->num_workers > 0
-            ? coordinator->num_workers
-            : 1;
+        uint32_t k = active_workers > 0 ? active_workers : 1;
         size_t arena_cap = coordinator->eval_arena
             ? coordinator->eval_arena->capacity / k
             : 8UL * 1024 * 1024;
@@ -1248,9 +1256,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
 
     /* Step 8: Allocate per-worker delta_pool (scaled by num_workers) */
     {
-        uint32_t k = coordinator->num_workers > 0
-            ? coordinator->num_workers
-            : 1;
+        uint32_t k = active_workers > 0 ? active_workers : 1;
         size_t pool_arena = 32UL * 1024 * 1024 / k;
         if (pool_arena < 4UL * 1024 * 1024)
             pool_arena = 4UL * 1024 * 1024;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -210,6 +210,108 @@ session_remove_rel(wl_col_session_t *sess, const char *name)
     }
 }
 
+typedef struct wl_columnar_session_tdd_decision {
+    bool use_tdd;
+    wl_columnar_internal_tdd_fallback_reason_t fallback_reason;
+} wl_columnar_session_tdd_decision_t;
+
+static const char *
+wl_columnar_session_tdd_fallback_reason_name(
+    wl_columnar_internal_tdd_fallback_reason_t reason)
+{
+    switch (reason) {
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE:
+        return "none";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NON_RECURSIVE:
+        return "non_recursive";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_SNAPSHOT_INELIGIBLE:
+        return "snapshot_ineligible";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NO_EXCHANGE:
+        return "no_exchange";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN:
+        return "unsafe_plan";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_ADAPTIVE_WORKERS:
+        return "adaptive_workers";
+    case WL_COLUMNAR_INTERNAL_TDD_FALLBACK_REASON_COUNT:
+        break;
+    }
+    return "unknown";
+}
+
+static bool
+wl_columnar_session_tdd_stratum_has_exchange(const wl_plan_stratum_t *sp)
+{
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rp = &sp->relations[ri];
+        for (uint32_t oi = 0; oi < rp->op_count; oi++) {
+            if (rp->ops[oi].op == WL_PLAN_OP_EXCHANGE)
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool
+wl_columnar_session_tdd_stratum_is_safe(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess)
+{
+    /* TDD is only beneficial for recursive strata when there is no
+     * IDB self-join OR the IDB self-join is exchange-aligned.  A
+     * non-aligned self-join forces replicate_mode (all W workers do
+     * the full join), which is worse than single-threaded. */
+    if (!tdd_stratum_has_idb_self_join(sp)) {
+        /* Category A: no IDB-IDB joins.  Owner-partitioned TDD is
+         * correct only when every recursive IDB probe uses the
+         * relation's EXCHANGE key.  Rules that consume the same IDB
+         * through multiple key columns require cross-owner access and
+         * must stay single-threaded for now. */
+        return stratum_max_idb_body_atoms(sp) <= 1
+               && tdd_stratum_exchange_keys_are_multi_column(sp)
+               && tdd_stratum_single_idb_join_keys_exchange_aligned(sp);
+    }
+    if (tdd_stratum_idb_self_join_exchange_aligned(sp, sess))
+        return true;
+
+    /* Category C: non-aligned IDB-IDB joins. BDX mode is only correct for
+     * rules with at most 2 IDB body atoms. */
+    return stratum_max_idb_body_atoms(sp) <= 2;
+}
+
+static wl_columnar_session_tdd_decision_t
+wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess,
+    bool snapshot_tdd_eligible)
+{
+    wl_columnar_session_tdd_decision_t decision = {
+        .use_tdd = false,
+        .fallback_reason = WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE,
+    };
+
+    if (!sp->is_recursive) {
+        decision.fallback_reason =
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NON_RECURSIVE;
+        return decision;
+    }
+    if (!snapshot_tdd_eligible) {
+        decision.fallback_reason =
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_SNAPSHOT_INELIGIBLE;
+        return decision;
+    }
+    if (!wl_columnar_session_tdd_stratum_has_exchange(sp)) {
+        decision.fallback_reason =
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NO_EXCHANGE;
+        return decision;
+    }
+    if (!wl_columnar_session_tdd_stratum_is_safe(sp, sess)) {
+        decision.fallback_reason =
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN;
+        return decision;
+    }
+
+    decision.use_tdd = true;
+    return decision;
+}
+
 /* Operator implementations moved to columnar/ops.c;
  * evaluator functions moved to columnar/eval.c;
  * declarations in columnar/internal.h. */
@@ -415,6 +517,57 @@ wl_columnar_session_get_tdd_worker_width_stats(wl_session_t *sess,
         *out_last_active_workers = cs->tdd_last_active_workers;
     if (out_max_active_workers)
         *out_max_active_workers = cs->tdd_max_active_workers;
+}
+
+/*
+ * wl_columnar_session_get_tdd_decision_stats:
+ *
+ * Return TDD planner decisions from the last snapshot.  Recursive strata are
+ * planned TDD-first; fallback counters explain why K-fusion/serial evaluation
+ * was used instead.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4
+__attribute__((visibility("hidden")))
+#endif
+void
+wl_columnar_session_get_tdd_decision_stats(wl_session_t *sess,
+    uint32_t *out_recursive_strata, uint32_t *out_executed_strata,
+    uint32_t *out_fallback_strata, uint32_t *out_snapshot_ineligible,
+    uint32_t *out_no_exchange, uint32_t *out_unsafe_plan,
+    uint32_t *out_adaptive_workers, const char **out_last_fallback_reason)
+{
+    wl_col_session_t *cs = COL_SESSION(sess);
+    if (out_recursive_strata)
+        *out_recursive_strata = cs->tdd_recursive_strata;
+    if (out_executed_strata)
+        *out_executed_strata = cs->tdd_executed_strata;
+    if (out_fallback_strata)
+        *out_fallback_strata = cs->tdd_fallback_strata;
+    if (out_snapshot_ineligible) {
+        *out_snapshot_ineligible =
+            cs->tdd_fallback_reason_counts[
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_SNAPSHOT_INELIGIBLE];
+    }
+    if (out_no_exchange) {
+        *out_no_exchange =
+            cs->tdd_fallback_reason_counts[
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NO_EXCHANGE];
+    }
+    if (out_unsafe_plan) {
+        *out_unsafe_plan =
+            cs->tdd_fallback_reason_counts[
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN];
+    }
+    if (out_adaptive_workers) {
+        *out_adaptive_workers =
+            cs->tdd_fallback_reason_counts[
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_ADAPTIVE_WORKERS];
+    }
+    if (out_last_fallback_reason) {
+        *out_last_fallback_reason =
+            wl_columnar_session_tdd_fallback_reason_name(
+            cs->tdd_last_fallback_reason);
+    }
 }
 
 /*
@@ -1956,6 +2109,13 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     sess->tdd_final_merge_ns = 0;
     sess->tdd_last_active_workers = 0;
     sess->tdd_max_active_workers = 0;
+    sess->tdd_recursive_strata = 0;
+    sess->tdd_executed_strata = 0;
+    sess->tdd_fallback_strata = 0;
+    memset(sess->tdd_fallback_reason_counts, 0,
+        sizeof(sess->tdd_fallback_reason_counts));
+    sess->tdd_last_fallback_reason = WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE;
+    sess->tdd_decision_tracking_active = false;
 
     /* Phase 4 incremental skip: when last_inserted_relation is set, only
      * re-evaluate strata that transitively depend on the inserted relation.
@@ -2089,79 +2249,30 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
         && sess->num_workers > 1 && sess->tdd_workers
         && (sess->last_inserted_relation != NULL ||
         sess->total_iterations == 0));
+    sess->tdd_decision_tracking_active = true;
     for (uint32_t si = 0; si < plan->stratum_count; si++) {
         if ((affected_mask & ((uint64_t)1 << si)) == 0)
             continue;
-        /* Issue #361, #388, #372: TDD hybrid init partitions IDB by hash key.
-         * Recursive strata with EXCHANGE ops can use TDD when:
-         *   (a) no IDB self-join exists (safe to partition without replication), OR
-         *   (b) IDB self-join is exchange-aligned (join key == EXCHANGE key, so
-         *       each worker can serve joins locally with delta broadcast).
-         * Strata with non-exchange-aligned IDB self-joins (e.g. TC r(x,z):-r(x,y),
-         * r(y,z) where join key col1≠partition key col0) or without EXCHANGE ops
-         * fall back to single-threaded to avoid cross-partition data unavailability
-         * or W-fold redundant work in replicate_mode. */
-        bool recursive_has_exchange = false;
-        bool recursive_tdd_safe = false; /* default: no TDD for recursive */
+        wl_columnar_session_tdd_decision_t tdd_decision =
+            wl_columnar_session_tdd_plan_stratum(&plan->strata[si], sess,
+                snapshot_tdd_eligible);
+        bool use_tdd = tdd_decision.use_tdd;
         if (plan->strata[si].is_recursive) {
-            const wl_plan_stratum_t *rsp = &plan->strata[si];
-            for (uint32_t ri = 0;
-                ri < rsp->relation_count && !recursive_has_exchange; ri++) {
-                const wl_plan_relation_t *rp = &rsp->relations[ri];
-                for (uint32_t oi = 0; oi < rp->op_count; oi++) {
-                    if (rp->ops[oi].op == WL_PLAN_OP_EXCHANGE) {
-                        recursive_has_exchange = true;
-                        break;
-                    }
-                }
-            }
-            /* TDD is only beneficial for recursive strata when there is no
-             * IDB self-join OR the IDB self-join is exchange-aligned.  A
-             * non-aligned self-join forces replicate_mode (all W workers do
-             * the full join), which is worse than single-threaded. */
-            if (recursive_has_exchange) {
-                if (!tdd_stratum_has_idb_self_join(rsp)) {
-                    /* Category A: no IDB-IDB joins.  Owner-partitioned TDD is
-                     * correct only when every recursive IDB probe uses the
-                     * relation's EXCHANGE key.  Rules that consume the same
-                     * IDB through multiple key columns (e.g. DOOP SubtypeOf's
-                     * array component rule) require cross-owner access and
-                     * must stay single-threaded for now. */
-                    recursive_tdd_safe =
-                        stratum_max_idb_body_atoms(rsp) <= 1
-                        && tdd_stratum_exchange_keys_are_multi_column(rsp)
-                        && tdd_stratum_single_idb_join_keys_exchange_aligned(
-                        rsp);
-                } else if (tdd_stratum_idb_self_join_exchange_aligned(
-                        rsp, sess)) {
-                    /* Category B: IDB-IDB joins are exchange-aligned. */
-                    recursive_tdd_safe = true;
-                } else {
-                    /* Category C: non-aligned IDB-IDB joins.
-                     * BDX mode is only correct for rules with at most
-                     * 2 IDB body atoms (see design doc for proof). */
-                    uint32_t max_atoms =
-                        stratum_max_idb_body_atoms(rsp);
-                    if (max_atoms <= 2) {
-                        recursive_tdd_safe = true;
-                    }
-                    /* else: >2 IDB body atoms, fall back to
-                     * single-threaded (recursive_tdd_safe stays false) */
+            sess->tdd_recursive_strata++;
+            if (use_tdd) {
+                sess->tdd_executed_strata++;
+            } else {
+                wl_columnar_internal_tdd_fallback_reason_t reason =
+                    tdd_decision.fallback_reason;
+                sess->tdd_fallback_strata++;
+                sess->tdd_last_fallback_reason = reason;
+                if (reason > WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE
+                    && reason <
+                    WL_COLUMNAR_INTERNAL_TDD_FALLBACK_REASON_COUNT) {
+                    sess->tdd_fallback_reason_counts[reason]++;
                 }
             }
         }
-        /* Issue #416: Non-recursive strata are always evaluated
-         * single-threaded.  col_eval_stratum_tdd_nonrecursive uses
-         * tdd_init_workers which partitions ALL relations (EDB and IDB)
-         * by col0.  Any rule whose join key is not col0 — the common
-         * case for DOOP preprocessing strata — loses cross-partition
-         * tuples, producing fewer derived facts that feed into recursive
-         * strata and causing W>1 to produce fewer final tuples than W=1
-         * (empirically: ~8.5% fewer for the DOOP benchmark). */
-        bool use_tdd = snapshot_tdd_eligible
-            && (plan->strata[si].is_recursive
-                ? (recursive_has_exchange && recursive_tdd_safe)
-                : false); /* Issue #416: non-recursive always single-threaded */
         /* Issue #390: Correctness oracle — compare TDD vs single-threaded
          * tuple counts for recursive strata.  Enabled via env var.
          * Debug-only; never runs in production.
@@ -2303,11 +2414,13 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
                     sess->rels[out++] = sess->rels[in];
             }
             sess->nrels = out;
+            sess->tdd_decision_tracking_active = false;
             return rc;
         }
         if (sess->eval_arena)
             wl_arena_reset(sess->eval_arena);
     }
+    sess->tdd_decision_tracking_active = false;
 
     /* Reset after successful eval so next plain snapshot runs all strata */
     sess->last_inserted_relation = NULL;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -570,6 +570,52 @@ wl_columnar_session_get_tdd_decision_stats(wl_session_t *sess,
     }
 }
 
+int
+wl_columnar_session_ensure_workqueue(wl_col_session_t *sess,
+    uint32_t active_workers)
+{
+    if (!sess)
+        return EINVAL;
+    if (active_workers <= 1)
+        return 0;
+    if (active_workers > sess->num_workers)
+        return EINVAL;
+    if (sess->wq && sess->wq_workers >= active_workers)
+        return 0;
+
+    wl_work_queue_t *new_wq = wl_workqueue_create(active_workers);
+    if (!new_wq)
+        return ENOMEM;
+
+    wl_workqueue_destroy(sess->wq);
+    sess->wq = new_wq;
+    sess->wq_workers = active_workers;
+    return 0;
+}
+
+int
+wl_columnar_session_ensure_tdd_worker_slots(wl_col_session_t *sess,
+    uint32_t active_workers)
+{
+    if (!sess)
+        return EINVAL;
+    if (active_workers == 0 || active_workers > sess->num_workers)
+        return EINVAL;
+    if (sess->tdd_workers_cap >= active_workers)
+        return 0;
+
+    wl_col_session_t *new_workers = (wl_col_session_t *)realloc(
+        sess->tdd_workers, active_workers * sizeof(wl_col_session_t));
+    if (!new_workers)
+        return ENOMEM;
+
+    memset(&new_workers[sess->tdd_workers_cap], 0,
+        (active_workers - sess->tdd_workers_cap) * sizeof(wl_col_session_t));
+    sess->tdd_workers = new_workers;
+    sess->tdd_workers_cap = active_workers;
+    return 0;
+}
+
 /*
  * col_session_cleanup_old_data:
  *
@@ -717,9 +763,9 @@ col_compute_worker_cap(uint64_t ram_bytes)
  * Implements wl_compute_backend_t.session_create vtable slot.
  *
  * @param plan:        Execution plan (borrowed, must outlive session)
- * @param num_workers: Thread pool size for parallel K-fusion. When > 1,
- *                     creates a workqueue at session init. When 1, K-fusion
- *                     evaluates copies sequentially (no thread overhead).
+ * @param num_workers: Thread pool size cap for parallel K-fusion/TDD.
+ *                    Workers are allocated lazily for the active width of a
+ *                    given stratum/operator.
  * @param out:         (out) Receives &sess->base on success
  *
  * Memory initialization order:
@@ -909,32 +955,9 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         return ENOMEM;
     }
 
-    /* Create workqueue for parallel K-fusion when num_workers > 1.
-     * Single-threaded mode (num_workers=1) leaves wq=NULL; K-fusion
-     * evaluates copies sequentially with no thread overhead. (Issue #99) */
-    if (sess->num_workers > 1) {
-        sess->wq = wl_workqueue_create(sess->num_workers);
-        if (!sess->wq) {
-            free(sess->rels);
-            free(sess);
-            return ENOMEM;
-        }
-    }
-
-    /* Issue #318: Pre-allocate TDD worker sessions array for distributed eval.
-     * Workers are initialized lazily (tdd_workers_count == 0 until first use).
-     * num_workers > 1 check matches the workqueue creation guard above. */
-    if (sess->num_workers > 1) {
-        sess->tdd_workers = (wl_col_session_t *)calloc(
-            sess->num_workers, sizeof(wl_col_session_t));
-        if (!sess->tdd_workers) {
-            wl_workqueue_destroy(sess->wq);
-            free(sess->rels);
-            free(sess);
-            return ENOMEM;
-        }
-        sess->tdd_workers_count = 0; /* populated lazily */
-    }
+    /* Worker resources are allocated lazily after an operator/stratum chooses
+     * its active width. This preserves workers=N as a cap rather than forcing
+     * N threads and N TDD worker slots at session creation. */
 
     /* Create delta pool for per-iteration temporaries.
      * Slab: 256 relations (cover ~20 rules x 5 ops + headroom)
@@ -1308,6 +1331,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
 
     /* Step 3: NULL all owned pointers (safe for cleanup on early abort) */
     out_worker->wq = NULL;
+    out_worker->wq_workers = 0;
     out_worker->eval_arena = NULL;
     out_worker->delta_pool = NULL;
     out_worker->rels = NULL;
@@ -1344,6 +1368,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->exchange_num_workers = 0;
     /* Issue #318: TDD workers array is owned by coordinator; workers have none */
     out_worker->tdd_workers = NULL;
+    out_worker->tdd_workers_cap = 0;
     out_worker->tdd_workers_count = 0;
     /* Issue #317: Worker does not own the progress tracker.
      * NULL entries so col_session_destroy (if called on worker) does not
@@ -2246,7 +2271,7 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
      * Issue #413: Enable TDD for initial snapshot (total_iterations == 0)
      * OR incremental evaluation (last_inserted_relation != NULL). */
     bool snapshot_tdd_eligible = (affected_mask == UINT64_MAX
-        && sess->num_workers > 1 && sess->tdd_workers
+        && sess->num_workers > 1
         && (sess->last_inserted_relation != NULL ||
         sess->total_iterations == 0));
     sess->tdd_decision_tracking_active = true;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -996,14 +996,10 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
                 uint32_t nw = sess->num_workers;
                 if (nw > 1) {
                     /* Issue #416 (lazy budget partitioning): coordinator
-                     * starts with the full budget so that single-threaded
-                     * strata (use_tdd=false) are not penalised by an
-                     * artificially low backpressure threshold.  The per-
-                     * party share is stored in tdd_budget_per_party and
-                     * applied to the coordinator lazily (on first worker
-                     * session init) only when workers are actually used.
-                     * This ensures W=N and W=1 produce identical results
-                     * for workloads where no stratum uses TDD. */
+                     * keeps the full budget so single-threaded strata
+                     * (use_tdd=false) are not penalised by an artificially
+                     * low backpressure threshold. Worker sessions receive a
+                     * per-party budget when they are actually used. */
                     sess->tdd_budget_per_party
                         = total / (uint64_t)(nw + 1);
                     budget = total;
@@ -1384,12 +1380,10 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->last_removed_relation = NULL;
 
     /* Step 5: Initialize independent mem_ledger (avoid copying atomics).
-     * Issue #416 (lazy budget partitioning): if tdd_budget_per_party was
-     * set at session init, the coordinator started with the full budget so
-     * single-threaded strata are not penalised.  On the first worker init
-     * we lazily shrink the coordinator to its per-party share so that, once
-     * workers are live, aggregate memory usage stays within the 75%-RAM
-     * envelope (coordinator + W workers each hold tdd_budget_per_party). */
+     * Workers receive a per-party budget, but the coordinator keeps its
+     * original budget. W is an upper bound on active workers, and shrinking the
+     * coordinator permanently causes later sequential strata to trip
+     * backpressure under a stale worker-sized budget. */
     uint32_t active_workers = coordinator->tdd_active_workers > 0
         ? coordinator->tdd_active_workers : coordinator->num_workers;
     if (active_workers == 0)
@@ -1402,11 +1396,6 @@ col_worker_session_create(wl_col_session_t *coordinator,
             * (max_workers + 1)) / (uint64_t)(active_workers + 1);
         if (active_party_budget == 0)
             active_party_budget = coordinator->tdd_budget_per_party;
-        if (coordinator->tdd_workers_count == 0) {
-            /* First worker: shrink coordinator to its per-party share. */
-            atomic_store_explicit(&coordinator->mem_ledger.total_budget,
-                active_party_budget, memory_order_relaxed);
-        }
         worker_budget = active_party_budget;
     } else {
         worker_budget = atomic_load_explicit(

--- a/wirelog/columnar/session_hash.c
+++ b/wirelog/columnar/session_hash.c
@@ -194,4 +194,5 @@ session_rel_free_hash(wl_col_session_t *sess)
     sess->rel_hash_head = NULL;
     sess->rel_hash_next = NULL;
     sess->rel_hash_nbuckets = 0;
+    sess->rel_hash_chain_cap = 0;
 }

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -316,7 +316,8 @@ wl_plan_op_is_universal(wl_plan_op_type_t op)
  *   MAP:         project_indices, project_count  (and/or map_exprs)
  *   FILTER:      filter_expr
  *   JOIN:        right_relation, right_filter_expr, left_keys, right_keys,
- *                key_count
+ *                key_count, optional project_indices/project_count for
+ *                projection-only JOIN->MAP fusion
  *   ANTIJOIN:    right_relation, right_filter_expr, left_keys, right_keys,
  *                key_count
  *   REDUCE:      agg_fn, group_by_indices, group_by_count

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -1143,6 +1143,127 @@ free_op(wl_plan_op_t *op)
     }
 }
 
+static bool
+map_op_is_pure_projection(const wl_plan_op_t *op)
+{
+    if (!op || op->op != WL_PLAN_OP_MAP || op->project_count == 0
+        || !op->project_indices)
+        return false;
+    if (!op->map_exprs || op->map_expr_count == 0)
+        return true;
+
+    if (op->map_expr_count != op->project_count)
+        return false;
+    for (uint32_t i = 0; i < op->map_expr_count; i++) {
+        const wl_plan_expr_buffer_t *expr = &op->map_exprs[i];
+        if (!expr->data || expr->size == 0)
+            continue;
+        if (expr->size < 4 || expr->data[0] != WL_PLAN_EXPR_VAR)
+            return false;
+        uint16_t len;
+        memcpy(&len, expr->data + 1, sizeof(len));
+        if ((uint32_t)len + 3u != expr->size || len <= 3)
+            return false;
+        if (expr->data[3] != 'c' || expr->data[4] != 'o'
+            || expr->data[5] != 'l')
+            return false;
+        uint32_t col = 0;
+        for (uint32_t p = 6; p < expr->size; p++) {
+            if (!isdigit((unsigned char)expr->data[p]))
+                return false;
+            col = col * 10u + (uint32_t)(expr->data[p] - '0');
+        }
+        if (col != op->project_indices[i])
+            return false;
+    }
+    return true;
+}
+
+static int
+compose_join_projection(wl_plan_op_t *join, const wl_plan_op_t *map)
+{
+    uint32_t *indices = (uint32_t *)malloc(map->project_count
+            * sizeof(uint32_t));
+    if (!indices)
+        return -1;
+
+    for (uint32_t i = 0; i < map->project_count; i++) {
+        uint32_t idx = map->project_indices[i];
+        if (join->project_count > 0 && join->project_indices)
+            indices[i] = idx < join->project_count
+                ? join->project_indices[idx] : UINT32_MAX;
+        else
+            indices[i] = idx;
+    }
+
+    free((void *)join->project_indices);
+    join->project_indices = indices;
+    join->project_count = map->project_count;
+    join->materialized = false;
+    return 0;
+}
+
+static int
+rewrite_join_project_fusion_ops(wl_plan_op_t *ops, uint32_t *op_count)
+{
+    if (!ops || !op_count)
+        return 0;
+
+    uint32_t i = 0;
+    while (i + 1 < *op_count) {
+        wl_plan_op_t *join = &ops[i];
+        wl_plan_op_t *map = &ops[i + 1];
+        if (join->op != WL_PLAN_OP_JOIN || !map_op_is_pure_projection(map)) {
+            i++;
+            continue;
+        }
+
+        if (compose_join_projection(join, map) != 0)
+            return -1;
+
+        free_op(map);
+        for (uint32_t j = i + 1; j + 1 < *op_count; j++)
+            ops[j] = ops[j + 1];
+        memset(&ops[*op_count - 1], 0, sizeof(wl_plan_op_t));
+        (*op_count)--;
+    }
+    return 0;
+}
+
+static int
+rewrite_join_project_fusion(wl_plan_t *plan)
+{
+    if (!plan)
+        return 0;
+
+    wl_plan_stratum_t *strata = (wl_plan_stratum_t *)plan->strata;
+    for (uint32_t s = 0; s < plan->stratum_count; s++) {
+        wl_plan_stratum_t *stratum = &strata[s];
+        wl_plan_relation_t *relations
+            = (wl_plan_relation_t *)stratum->relations;
+        for (uint32_t r = 0; r < stratum->relation_count; r++) {
+            wl_plan_relation_t *rel = &relations[r];
+            wl_plan_op_t *ops = (wl_plan_op_t *)rel->ops;
+            if (rewrite_join_project_fusion_ops(ops, &rel->op_count) != 0)
+                return -1;
+#if ENABLE_K_FUSION
+            for (uint32_t i = 0; i < rel->op_count; i++) {
+                if (ops[i].op != WL_PLAN_OP_K_FUSION || !ops[i].opaque_data)
+                    continue;
+                wl_plan_op_k_fusion_t *meta
+                    = (wl_plan_op_k_fusion_t *)ops[i].opaque_data;
+                for (uint32_t d = 0; d < meta->k; d++) {
+                    if (rewrite_join_project_fusion_ops(meta->k_ops[d],
+                        &meta->k_op_counts[d]) != 0)
+                        return -1;
+                }
+            }
+#endif
+        }
+    }
+    return 0;
+}
+
 /* ======================================================================== */
 /* Multi-Way Delta Expansion (Semi-Naive K-Atom Rewriting with CSE Hints)   */
 /* ======================================================================== */
@@ -2624,6 +2745,10 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
      * materialization hints to avoid the regression seen without CSE. */
     rewrite_lftj_chains(plan);
     rewrite_multiway_delta(plan);
+    if (rewrite_join_project_fusion(plan) != 0) {
+        wl_plan_free(plan);
+        return -1;
+    }
     rewrite_insert_exchanges(plan);
 
     *out = plan;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -1189,11 +1189,15 @@ compose_join_projection(wl_plan_op_t *join, const wl_plan_op_t *map)
 
     for (uint32_t i = 0; i < map->project_count; i++) {
         uint32_t idx = map->project_indices[i];
-        if (join->project_count > 0 && join->project_indices)
-            indices[i] = idx < join->project_count
-                ? join->project_indices[idx] : UINT32_MAX;
-        else
+        if (join->project_count > 0 && join->project_indices) {
+            if (idx >= join->project_count) {
+                free(indices);
+                return -1;
+            }
+            indices[i] = join->project_indices[idx];
+        } else {
             indices[i] = idx;
+        }
     }
 
     free((void *)join->project_indices);

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1030,15 +1030,21 @@ static wirelog_ir_node_t *
 wrap_column_cmp_filter(wirelog_ir_node_t *child, uint32_t left_col,
     const wl_ir_expr_t *right_expr)
 {
-    wirelog_ir_node_t *filter = wl_ir_node_create(WIRELOG_IR_FILTER);
-    if (!filter)
+    if (!right_expr)
         return child;
+
+    wirelog_ir_node_t *filter = wl_ir_node_create(WIRELOG_IR_FILTER);
+    if (!filter) {
+        wl_ir_expr_free((wl_ir_expr_t *)right_expr);
+        return child;
+    }
 
     wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
     wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
     if (!cmp || !lhs) {
         wl_ir_expr_free(cmp);
         wl_ir_expr_free(lhs);
+        wl_ir_expr_free((wl_ir_expr_t *)right_expr);
         wl_ir_node_free(filter);
         return child;
     }
@@ -1304,6 +1310,105 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     return result;
 }
 
+static bool
+wl_ir_program_ast_is_constant(const wl_parser_ast_node_t *node)
+{
+    return node && (node->type == WL_PARSER_AST_NODE_INTEGER
+           || node->type == WL_PARSER_AST_NODE_STRING);
+}
+
+static bool
+wl_ir_program_extract_var_const_eq(const wl_parser_ast_node_t *node,
+    const char **out_var, const wl_parser_ast_node_t **out_const)
+{
+    if (!node || node->type != WL_PARSER_AST_NODE_COMPARISON
+        || node->cmp_op != WIRELOG_CMP_EQ || node->child_count < 2)
+        return false;
+
+    const wl_parser_ast_node_t *left = node->children[0];
+    const wl_parser_ast_node_t *right = node->children[1];
+    if (!left || !right)
+        return false;
+
+    if (left->type == WL_PARSER_AST_NODE_VARIABLE
+        && wl_ir_program_ast_is_constant(right)) {
+        *out_var = left->name;
+        *out_const = right;
+        return *out_var != NULL;
+    }
+
+    if (right->type == WL_PARSER_AST_NODE_VARIABLE
+        && wl_ir_program_ast_is_constant(left)) {
+        *out_var = right->name;
+        *out_const = left;
+        return *out_var != NULL;
+    }
+
+    return false;
+}
+
+static wl_ir_expr_t *
+wl_ir_program_constant_expr(const wl_parser_ast_node_t *node)
+{
+    if (!node)
+        return NULL;
+    if (node->type == WL_PARSER_AST_NODE_INTEGER) {
+        wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
+        if (expr)
+            expr->int_value = node->int_value;
+        return expr;
+    }
+    if (node->type == WL_PARSER_AST_NODE_STRING) {
+        wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
+        if (expr)
+            expr->str_value = strdup_safe(node->str_value);
+        return expr;
+    }
+    return NULL;
+}
+
+static void
+wl_ir_program_push_constant_filter_to_scan(wirelog_ir_node_t **scan,
+    char **vars, uint32_t var_count, const char *var_name,
+    const wl_parser_ast_node_t *constant)
+{
+    if (!scan || !*scan || !vars || !var_name || !constant)
+        return;
+
+    for (uint32_t i = 0; i < var_count; i++) {
+        if (!vars[i] || strcmp(vars[i], var_name) != 0)
+            continue;
+
+        wl_ir_expr_t *rhs = wl_ir_program_constant_expr(constant);
+        if (!rhs)
+            continue;
+        *scan = wrap_column_cmp_filter(*scan, i, rhs);
+    }
+}
+
+static void
+wl_ir_program_push_constant_filters(const wl_parser_ast_node_t *rule_node,
+    wirelog_ir_node_t **scans, char ***scan_vars, uint32_t *scan_vcounts,
+    uint32_t scan_count)
+{
+    if (!rule_node || !scans || !scan_vars || !scan_vcounts)
+        return;
+
+    for (uint32_t i = 1; i < rule_node->child_count; i++) {
+        const wl_parser_ast_node_t *body = rule_node->children[i];
+        const char *var_name = NULL;
+        const wl_parser_ast_node_t *constant = NULL;
+        if (!wl_ir_program_extract_var_const_eq(body, &var_name, &constant))
+            continue;
+
+        for (uint32_t scan_idx = 0; scan_idx < scan_count; scan_idx++) {
+            wl_ir_program_push_constant_filter_to_scan(&scans[scan_idx],
+                scan_vars[scan_idx], scan_vcounts[scan_idx], var_name,
+                constant);
+        }
+    }
+}
+
 /* ---- Single Rule Conversion ---- */
 
 static wirelog_ir_node_t *
@@ -1353,6 +1458,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             scan_count++;
         }
     }
+
+    wl_ir_program_push_constant_filters(rule_node, scans, scan_vars,
+        scan_vcounts, scan_count);
 
     /* ---- Step 2: JOIN across multiple scans ---- */
 

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -51,6 +51,14 @@ collect_scans(wirelog_ir_node_t *node, wirelog_ir_node_t **out, uint32_t max)
 /* Internal: variable set operations                                        */
 /* ======================================================================== */
 
+static const wirelog_ir_node_t *
+wl_passes_jpp_data_node(const wirelog_ir_node_t *node)
+{
+    while (node && node->type == WIRELOG_IR_FILTER && node->child_count > 0)
+        node = node->children[0];
+    return node;
+}
+
 /*
  * Get the variable names for a SCAN node.
  * Returns column_names and sets *count.
@@ -58,6 +66,7 @@ collect_scans(wirelog_ir_node_t *node, wirelog_ir_node_t **out, uint32_t max)
 static char **
 scan_vars(const wirelog_ir_node_t *scan, uint32_t *count)
 {
+    scan = wl_passes_jpp_data_node(scan);
     if (!scan) {
         *count = 0;
         return NULL;
@@ -214,6 +223,7 @@ static bool
 scan_is_idb(const wirelog_ir_node_t *scan, const char *const *idb_names,
     uint32_t idb_count)
 {
+    scan = wl_passes_jpp_data_node(scan);
     if (!scan || !scan->relation_name || !idb_names)
         return false;
     for (uint32_t i = 0; i < idb_count; i++) {


### PR DESCRIPTION
## Summary

- parallelize persistent differential keyed joins with worker-count capping
- keep exact reserve safe for arena-backed relation buffers and ledger accounting
- preserve join output limit and RELATION backpressure behavior in the parallel path
- keep coordinator memory budget from being permanently shrunk by worker creation

## Validation

- `meson compile -C build`
- `meson test -C build wirelog:tdd_decision_stats wirelog:tdd_recursive wirelog:tdd_multiworker wirelog:tdd_exchange wirelog:workers_as_cap wirelog:doop_multiworker --print-errorlogs`
- DOOP benchmark before PR branch rebase: W=1 `46514.6 ms`, W=8 `33680.1 ms`, W=192 `32823.4 ms`, all with `6,271,791` tuples

Refs #659.
