### PR TITLE
Restore Windows MSVC build by shimming the missing atomic primitives

### DIFF
--- a/wirelog/columnar/mem_ledger.h
+++ b/wirelog/columnar/mem_ledger.h
@@ -32,6 +32,16 @@
  * acquire/release semantics. */
 typedef volatile uint64_t wl_atomic_u64;
 
+/* C11 atomic types/initializer used by the parallel keyed-join path.
+ * Field accesses are paired with the atomic_*_explicit shims below; for
+ * relaxed-order callers a volatile-qualified plain type is sufficient on
+ * the architectures MSVC targets (x86/x64/ARM64), and the shimmed
+ * fetch_add still routes through _InterlockedCompareExchange64 for the
+ * read-modify-write ops. */
+typedef volatile bool atomic_bool;
+typedef volatile uint_fast64_t atomic_uint_fast64_t;
+#define ATOMIC_VAR_INIT(x) (x)
+
 /* MSVC atomic macros using intrinsics that are guaranteed to exist */
 #define atomic_load_explicit(ptr, order) (*(ptr))
 #define atomic_store_explicit(ptr, val, order) (*(ptr) = (val))
@@ -61,14 +71,14 @@ wl_atomic_fetch_sub_internal(volatile __int64 *ptr, __int64 dec)
 }
 
 #define atomic_fetch_add_explicit(ptr, inc, order) \
-    wl_atomic_fetch_add_internal((volatile __int64 *)(ptr), (__int64)(inc))
+        wl_atomic_fetch_add_internal((volatile __int64 *)(ptr), (__int64)(inc))
 #define atomic_fetch_sub_explicit(ptr, dec, order) \
-    wl_atomic_fetch_sub_internal((volatile __int64 *)(ptr), (__int64)(dec))
+        wl_atomic_fetch_sub_internal((volatile __int64 *)(ptr), (__int64)(dec))
 #define atomic_compare_exchange_weak_explicit(ptr, expected, desired,        \
-                                              succ_order, fail_order)        \
-    (_InterlockedCompareExchange64((volatile __int64 *)(ptr),                \
-                                   (__int64)(desired), (__int64)*(expected)) \
-     == (__int64)*(expected))
+            succ_order, fail_order)        \
+        (_InterlockedCompareExchange64((volatile __int64 *)(ptr),                \
+        (__int64)(desired), (__int64)*(expected)) \
+        == (__int64)*(expected))
 
 /* Memory orders (ignored on MSVC - intrinsics always use acquire/release semantics) */
 #define memory_order_relaxed 0
@@ -207,7 +217,7 @@ wl_mem_ledger_subsys_over_budget(const wl_mem_ledger_t *ledger, int subsys);
  */
 bool
 wl_mem_ledger_should_backpressure(const wl_mem_ledger_t *ledger, int subsys,
-                                  uint32_t threshold_pct);
+    uint32_t threshold_pct);
 
 /*
  * wl_mem_ledger_bytes_remaining:


### PR DESCRIPTION
## Summary

- The recent parallelized differential keyed-join change (`0107ad0`, "Parallelize differential keyed joins") added `atomic_bool`, `atomic_uint_fast64_t`, and `ATOMIC_VAR_INIT` to `wirelog/columnar/ops.c`. On Linux/macOS these are reachable via `<stdatomic.h>` (transitively included through `mem_ledger.h`); on Windows MSVC, `mem_ledger.h` instead takes the manual-shim branch and never includes `<stdatomic.h>`, so the new types and macro are undefined. The result is that `col_join_keyed_ctx_t`'s typedef fails and every downstream reference in `ops.c` is reported as "undeclared identifier", aborting the MSVC build.
- Fix: extend the existing `_MSC_VER` block in `mem_ledger.h` to provide the three missing pieces, alongside the already-present `wl_atomic_u64`, `atomic_load_explicit`, `atomic_store_explicit`, and `atomic_fetch_add/sub_explicit` shims. The new types are `volatile`-qualified plain types matching the existing `wl_atomic_u64` pattern; relaxed loads and stores keep using the dereference shims, and `atomic_fetch_add` on the new 64-bit type still routes through `_InterlockedCompareExchange64`.
- No production behavior change on Linux/macOS — the `<stdatomic.h>` branch continues to provide the C11 types directly.

## Test plan

- [x] `meson test -C build` on Linux: 207 OK / 0 fail / 7 skipped — no regression.
- [x] Identified the failing CI job (`Build / windows-latest / msvc`) on `main` HEAD via `gh run view 25388961578`; fatal MSVC error chain begins at `wirelog/columnar/ops.c:2310` with `error C2065: 'ctx': undeclared identifier`, originating from the `col_join_keyed_ctx_t` struct typedef whose two new atomic fields fail to parse.
- [ ] Validate via `Build / windows-latest / msvc` on this PR.