### PR TITLE
Shim setenv/unsetenv on MSVC for join-overflow and tdd-decision tests

### DIFF
--- a/tests/test_join_overflow.c
+++ b/tests/test_join_overflow.c
@@ -24,6 +24,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#endif
+
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;

--- a/tests/test_tdd_decision_stats.c
+++ b/tests/test_tdd_decision_stats.c
@@ -19,6 +19,24 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#endif
+
 extern void
 wl_columnar_session_get_tdd_decision_stats(wl_session_t *sess,
     uint32_t *out_recursive_strata, uint32_t *out_executed_strata,


### PR DESCRIPTION
## Summary

`Build / windows-latest / msvc` on `main` has been failing the link of `tests/test_join_overflow.exe` since `3db91c1` and would fail the same way for `tests/test_tdd_decision_stats.exe` from `d0ce8cd` once it ran. Both files reference `setenv`/`unsetenv` to drive their environment-variable knobs (`WIRELOG_JOIN_OUTPUT_LIMIT`, `WIRELOG_TDD_MIN_ROWS_PER_WORKER`), neither of which exists in the MSVC C runtime.

```
test_join_overflow.c.obj : error LNK2001: unresolved external symbol setenv
test_join_overflow.c.obj : error LNK2001: unresolved external symbol unsetenv
tests\test_join_overflow.exe : fatal error LNK1120: 2 unresolved externals
```

Add the same `_putenv_s`-backed shim block that `tests/test_wl_easy.c`, `tests/test_log_integration.c`, and the other env-driven test files already carry under `#ifdef _WIN32`. The shim is preprocessed out on Linux/macOS, so behavior is unchanged on those platforms.

## Test plan

- [x] `ninja -C build tests/test_join_overflow tests/test_tdd_decision_stats` — links clean.
- [x] `tests/test_join_overflow` — 4/4 PASS on Linux.
- [x] `tests/test_tdd_decision_stats` — 3/3 PASS on Linux.
- [ ] Validate via `Build / windows-latest / msvc` on this PR that the linker errors are gone and both tests run on Windows.