### PR TITLE
[codex] Restore DOOP performance groundwork for issue 659

### DIFF
--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -45,6 +45,35 @@ arr_hash_key(const int64_t *row, const uint32_t *key_cols, uint32_t key_count,
     return (uint32_t)(h & (uint64_t)(nbuckets - 1));
 }
 
+static uint32_t
+arr_hash_rel_key(const col_rel_t *rel, uint32_t row,
+    const uint32_t *key_cols, uint32_t key_count, uint32_t nbuckets)
+{
+    uint64_t h = 14695981039346656037ULL; /* FNV-1a basis */
+    for (uint32_t k = 0; k < key_count; k++) {
+        uint64_t v = (uint64_t)rel->columns[key_cols[k]][row];
+        for (int b = 0; b < 8; b++) {
+            h ^= v & 0xFFu;
+            h *= 1099511628211ULL;
+            v >>= 8;
+        }
+    }
+    return (uint32_t)(h & (uint64_t)(nbuckets - 1));
+}
+
+static bool
+arr_key_cols_valid(const col_rel_t *rel, const uint32_t *key_cols,
+    uint32_t key_count)
+{
+    if (!rel || !key_cols || key_count == 0)
+        return false;
+    for (uint32_t k = 0; k < key_count; k++) {
+        if (key_cols[k] >= rel->ncols)
+            return false;
+    }
+    return true;
+}
+
 /* Round n up to the next power of 2; minimum 16. */
 static uint32_t
 arr_next_pow2(uint32_t n)
@@ -111,10 +140,8 @@ arr_build_full(col_arrangement_t *arr, const col_rel_t *rel)
     }
 
     for (uint32_t row = 0; row < nrows; row++) {
-        int64_t row_buf[16]; /* stack buffer; avoids col_rel_row heap alloc */
-        col_rel_row_copy_out(rel, row, row_buf);
-        uint32_t bucket
-            = arr_hash_key(row_buf, arr->key_cols, arr->key_count, nbuckets);
+        uint32_t bucket = arr_hash_rel_key(rel, row, arr->key_cols,
+                arr->key_count, nbuckets);
         arr->ht_next[row] = arr->ht_head[bucket];
         arr->ht_head[bucket] = row;
     }
@@ -149,10 +176,8 @@ arr_update_incremental(col_arrangement_t *arr, const col_rel_t *rel,
 
     uint32_t nb = arr->nbuckets;
     for (uint32_t row = old_nrows; row < nrows; row++) {
-        int64_t row_buf[16]; /* stack buffer; avoids col_rel_row heap alloc */
-        col_rel_row_copy_out(rel, row, row_buf);
-        uint32_t bucket = arr_hash_key(row_buf, arr->key_cols, arr->key_count,
-                nb);
+        uint32_t bucket = arr_hash_rel_key(rel, row, arr->key_cols,
+                arr->key_count, nb);
         arr->ht_next[row] = arr->ht_head[bucket];
         arr->ht_head[bucket] = row;
     }
@@ -238,6 +263,8 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         }
     }
     if (!rel)
+        return NULL;
+    if (!arr_key_cols_valid(rel, key_cols, key_count))
         return NULL;
 
     /* Search registry for matching (rel_name, key_cols) entry. */
@@ -485,6 +512,8 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
 {
     if (!cs || !rel_name || !delta_rel || !key_cols || key_count == 0)
         return NULL;
+    if (!arr_key_cols_valid(delta_rel, key_cols, key_count))
+        return NULL;
 
     /* Search existing cache entries. */
     for (uint32_t i = 0; i < cs->darr_count; i++) {
@@ -593,6 +622,8 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count)
 {
     if (!cs || !rel_name || !filtered_rel || !key_cols || key_count == 0)
+        return NULL;
+    if (!arr_key_cols_valid(filtered_rel, key_cols, key_count))
         return NULL;
 
     /* Search existing entries. */

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1604,6 +1604,24 @@ tdd_reconstruct_delta_matrix(col_eval_tdd_worker_ctx_t *ctxs,
     }
 }
 
+static void
+tdd_discard_delta_queue(wl_mpsc_queue_t *queue, uint32_t W, uint32_t nrels)
+{
+    if (!queue)
+        return;
+    uint32_t max_msgs = W * nrels;
+    if (max_msgs == 0)
+        max_msgs = 1;
+    wl_delta_msg_t *msgs = (wl_delta_msg_t *)calloc(max_msgs,
+            sizeof(wl_delta_msg_t));
+    if (!msgs)
+        return;
+    uint32_t msg_count = wl_mpsc_dequeue_all(queue, msgs, max_msgs);
+    for (uint32_t i = 0; i < msg_count; i++)
+        col_rel_destroy((col_rel_t *)msgs[i].delta);
+    free(msgs);
+}
+
 /*
  * tdd_cleanup_workers:
  * Destroy and zero all initialized TDD worker sessions.
@@ -5769,10 +5787,17 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     }
 
     col_rel_t **owner_fallback_saved = NULL;
+    col_rel_t **global_read_saved = NULL;
     bool owner_adaptive_fallback = false;
     if (owner_exchange_mode) {
         owner_fallback_saved = tdd_save_coord_idb(sp, coord);
         if (!owner_fallback_saved) {
+            coord->tdd_total_ns += now_ns() - tdd_total_t0;
+            return ENOMEM;
+        }
+    } else if (global_read_mode) {
+        global_read_saved = tdd_save_coord_idb(sp, coord);
+        if (!global_read_saved) {
             coord->tdd_total_ns += now_ns() - tdd_total_t0;
             return ENOMEM;
         }
@@ -5786,6 +5811,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         rc = tdd_init_workers_hybrid(sp, coord, true, W);
     if (rc != 0) {
         tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+        tdd_free_saved_coord_idb(sp, global_read_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
         return rc;
     }
@@ -5798,6 +5824,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 if (rc != 0) {
                     tdd_cleanup_workers(coord);
                     tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+                    tdd_free_saved_coord_idb(sp, global_read_saved);
                     coord->tdd_total_ns += now_ns() - tdd_total_t0;
                     return rc;
                 }
@@ -5809,6 +5836,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     rc = tdd_preregister_idb_on_workers(sp, coord);
     if (rc != 0) {
         tdd_cleanup_workers(coord);
+        tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+        tdd_free_saved_coord_idb(sp, global_read_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
         return rc;
     }
@@ -5836,6 +5865,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             col_rel_t *slot = col_rel_new_auto(dname, ncols_ri);
             if (!slot) {
                 tdd_cleanup_workers(coord);
+                tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+                tdd_free_saved_coord_idb(sp, global_read_saved);
                 coord->tdd_total_ns += now_ns() - tdd_total_t0;
                 return ENOMEM;
             }
@@ -5843,6 +5874,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             if (rc != 0) {
                 col_rel_destroy(slot);
                 tdd_cleanup_workers(coord);
+                tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+                tdd_free_saved_coord_idb(sp, global_read_saved);
                 coord->tdd_total_ns += now_ns() - tdd_total_t0;
                 return rc;
             }
@@ -6089,6 +6122,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             coord->tdd_submit_loop_ns += submit_ns;
 
             if (!submit_ok) {
+                tdd_discard_delta_queue(coord->delta_queue, W, nrels);
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
                         col_rel_destroy(ctxs[w].delta_rels[ri]);
@@ -6125,6 +6159,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                     fprintf(stderr,
                         "TDD worker error stratum=%u iter=%u rc=%d\n",
                         stratum_idx, eff_iter, rc);
+                tdd_discard_delta_queue(coord->delta_queue, W, nrels);
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
                         col_rel_destroy(ctxs[w].delta_rels[ri]);
@@ -6287,6 +6322,7 @@ done:
         rc = tdd_restore_coord_idb(sp, coord, owner_fallback_saved);
         tdd_cleanup_workers(coord);
         tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+        tdd_free_saved_coord_idb(sp, global_read_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
         if (rc != 0)
             return rc;
@@ -6294,7 +6330,20 @@ done:
             coord->outer_epoch);
         return col_eval_stratum(sp, coord, stratum_idx);
     }
+    if (global_read_mode && rc == EOVERFLOW) {
+        int restore_rc = tdd_restore_coord_idb(sp, coord, global_read_saved);
+        tdd_cleanup_workers(coord);
+        tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+        tdd_free_saved_coord_idb(sp, global_read_saved);
+        coord->tdd_total_ns += now_ns() - tdd_total_t0;
+        if (restore_rc != 0)
+            return restore_rc;
+        coord->frontier_ops->reset_stratum_frontier(coord, stratum_idx,
+            coord->outer_epoch);
+        return col_eval_stratum(sp, coord, stratum_idx);
+    }
     tdd_free_saved_coord_idb(sp, owner_fallback_saved);
+    tdd_free_saved_coord_idb(sp, global_read_saved);
 
     /* Issue #416: Accumulate instead of assign so total_iterations stays > 0
      * after any completed evaluation.  Assigning final_eff_iter (which is 0

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2337,44 +2337,46 @@ cleanup:
 }
 
 static int
-tdd_refresh_global_read_idb(const wl_plan_stratum_t *sp,
-    wl_col_session_t *coord, uint32_t W)
+tdd_refresh_global_read_relation(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, uint32_t ri, uint32_t W)
 {
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        const char *name = sp->relations[ri].name;
-        col_rel_t *src = session_find_rel(coord, name);
-        if (!src)
+    if (!sp || !coord || ri >= sp->relation_count)
+        return EINVAL;
+
+    const char *name = sp->relations[ri].name;
+    col_rel_t *src = session_find_rel(coord, name);
+    if (!src)
+        return 0;
+
+    for (uint32_t w = 0; w < W; w++) {
+        col_rel_t *dst = session_find_rel(&coord->tdd_workers[w], name);
+        if (!dst)
             continue;
-        for (uint32_t w = 0; w < W; w++) {
-            col_rel_t *dst = session_find_rel(&coord->tdd_workers[w], name);
-            if (!dst)
-                continue;
-            if (src->ncols > 0) {
-                if (dst->ncols != src->ncols) {
-                    col_rel_t *view = NULL;
-                    int rc = nonrec_make_shared_relation_view(src, &view);
-                    if (rc != 0)
-                        return rc;
-                    rc = session_add_rel(&coord->tdd_workers[w], view);
-                    if (rc != 0) {
-                        col_rel_destroy(view);
-                        return rc;
-                    }
-                } else {
-                    int rc = col_rel_install_shared_view(dst, src);
-                    if (rc != 0) {
-                        dst->nrows = 0;
-                        rc = col_rel_append_all(dst, src, NULL);
-                    }
-                    if (rc != 0)
-                        return rc;
+        if (src->ncols > 0) {
+            if (dst->ncols != src->ncols) {
+                col_rel_t *view = NULL;
+                int rc = nonrec_make_shared_relation_view(src, &view);
+                if (rc != 0)
+                    return rc;
+                rc = session_add_rel(&coord->tdd_workers[w], view);
+                if (rc != 0) {
+                    col_rel_destroy(view);
+                    return rc;
                 }
             } else {
-                dst->nrows = 0;
+                int rc = col_rel_install_shared_view(dst, src);
+                if (rc != 0) {
+                    dst->nrows = 0;
+                    rc = col_rel_append_all(dst, src, NULL);
+                }
+                if (rc != 0)
+                    return rc;
             }
-            col_session_invalidate_arrangements(
-                &coord->tdd_workers[w].base, name);
+        } else {
+            dst->nrows = 0;
         }
+        col_session_invalidate_arrangements(&coord->tdd_workers[w].base,
+            name);
     }
     return 0;
 }
@@ -5597,6 +5599,11 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
             }
             tdd_dedup_set_insert_rel(coord_idb, combined);
             col_session_invalidate_arrangements(&coord->base, rel_name);
+            rc = tdd_refresh_global_read_relation(sp, coord, ri, W);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
         }
 
         const uint32_t *key_cols = NULL;
@@ -6101,12 +6108,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 ctxs[w].runtime_ns = 0;
                 ctxs[w].rc = 0;
             }
-            if (global_read_mode) {
-                rc = tdd_refresh_global_read_idb(sp, coord, W);
-                if (rc != 0)
-                    goto done;
-            }
-
             /* DISPATCH */
             bool submit_ok = true;
             uint64_t dispatch_t0 = now_ns();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2257,6 +2257,186 @@ tdd_replicate_workers(wl_col_session_t *coord, uint32_t W)
     return rc;
 }
 
+static int
+tdd_init_workers_global_read(wl_col_session_t *coord, uint32_t W)
+{
+    if (W == 0 || W > coord->num_workers)
+        return EINVAL;
+    int rc = wl_columnar_session_ensure_workqueue(coord, W);
+    if (rc != 0)
+        return rc;
+    rc = wl_columnar_session_ensure_tdd_worker_slots(coord, W);
+    if (rc != 0)
+        return rc;
+
+    tdd_cleanup_workers(coord);
+
+    coord->tdd_active_workers = W;
+    tdd_record_active_workers(coord, W);
+
+    uint32_t nrels = coord->nrels;
+    col_rel_t ***worker_rels = (col_rel_t ***)calloc(W, sizeof(col_rel_t **));
+    if (!worker_rels)
+        return ENOMEM;
+
+    for (uint32_t w = 0; w < W; w++) {
+        worker_rels[w] = (col_rel_t **)calloc(nrels ? nrels : 1,
+                sizeof(col_rel_t *));
+        if (!worker_rels[w]) {
+            rc = ENOMEM;
+            goto cleanup;
+        }
+        for (uint32_t r = 0; r < nrels; r++) {
+            col_rel_t *src = coord->rels[r];
+            if (!src)
+                continue;
+            rc = nonrec_make_shared_relation_view(src, &worker_rels[w][r]);
+            if (rc != 0)
+                goto cleanup;
+        }
+        rc = col_worker_session_create(coord, w, worker_rels[w], nrels,
+                &coord->tdd_workers[w]);
+        if (rc != 0)
+            goto cleanup;
+        coord->tdd_workers_count = w + 1;
+    }
+
+cleanup:
+    if (worker_rels) {
+        for (uint32_t w = coord->tdd_workers_count; w < W; w++) {
+            if (!worker_rels[w])
+                continue;
+            for (uint32_t r = 0; r < nrels; r++)
+                col_rel_destroy(worker_rels[w][r]);
+        }
+        for (uint32_t w = 0; w < W; w++)
+            free(worker_rels[w]);
+        free(worker_rels);
+    }
+    if (rc != 0)
+        tdd_cleanup_workers(coord);
+    return rc;
+}
+
+static int
+tdd_refresh_global_read_idb(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, uint32_t W)
+{
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const char *name = sp->relations[ri].name;
+        col_rel_t *src = session_find_rel(coord, name);
+        if (!src)
+            continue;
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *dst = session_find_rel(&coord->tdd_workers[w], name);
+            if (!dst)
+                continue;
+            if (src->ncols > 0) {
+                if (dst->ncols != src->ncols) {
+                    col_rel_t *view = NULL;
+                    int rc = nonrec_make_shared_relation_view(src, &view);
+                    if (rc != 0)
+                        return rc;
+                    rc = session_add_rel(&coord->tdd_workers[w], view);
+                    if (rc != 0) {
+                        col_rel_destroy(view);
+                        return rc;
+                    }
+                } else {
+                    int rc = col_rel_install_shared_view(dst, src);
+                    if (rc != 0) {
+                        dst->nrows = 0;
+                        rc = col_rel_append_all(dst, src, NULL);
+                    }
+                    if (rc != 0)
+                        return rc;
+                }
+            } else {
+                dst->nrows = 0;
+            }
+            col_session_invalidate_arrangements(
+                &coord->tdd_workers[w].base, name);
+        }
+    }
+    return 0;
+}
+
+static int
+tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, uint32_t W)
+{
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const char *dname = sp->relations[ri].delta_name;
+        const char *rel_name = sp->relations[ri].name;
+        col_rel_t *src = session_find_rel(coord, rel_name);
+
+        for (uint32_t w = 0; w < W; w++)
+            session_remove_rel(&coord->tdd_workers[w], dname);
+
+        if (!src || src->nrows == 0)
+            continue;
+
+        const uint32_t *key_cols = NULL;
+        uint32_t key_count = 0;
+        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+            if (sp->relations[ri].ops[oi].op == WL_PLAN_OP_EXCHANGE) {
+                const wl_plan_op_exchange_t *meta =
+                    (const wl_plan_op_exchange_t *)
+                    sp->relations[ri].ops[oi].opaque_data;
+                if (meta && meta->key_col_count > 0) {
+                    key_cols = meta->key_col_idxs;
+                    key_count = meta->key_col_count;
+                }
+                break;
+            }
+        }
+        uint32_t default_key[] = { 0 };
+        if (!key_cols || key_count == 0) {
+            key_cols = default_key;
+            key_count = 1;
+        }
+
+        col_rel_t **parts = (col_rel_t **)calloc(W, sizeof(col_rel_t *));
+        if (!parts)
+            return ENOMEM;
+        int rc = col_rel_exchange_partition(src, key_cols, key_count, W,
+                parts);
+        if (rc != 0) {
+            for (uint32_t w = 0; w < W; w++)
+                col_rel_destroy(parts[w]);
+            free(parts);
+            return rc;
+        }
+
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *part = parts[w];
+            parts[w] = NULL;
+            if (!part || part->nrows == 0) {
+                col_rel_destroy(part);
+                continue;
+            }
+            free(part->name);
+            part->name = wl_strdup(dname);
+            if (!part->name) {
+                col_rel_destroy(part);
+                rc = ENOMEM;
+                break;
+            }
+            rc = session_add_rel(&coord->tdd_workers[w], part);
+            if (rc != 0) {
+                col_rel_destroy(part);
+                break;
+            }
+        }
+        for (uint32_t w = 0; w < W; w++)
+            col_rel_destroy(parts[w]);
+        free(parts);
+        if (rc != 0)
+            return rc;
+    }
+    return 0;
+}
+
 /*
  * tdd_worker_subpass_fn:
  * Execute one sub-pass of the semi-naive iteration on a worker's partition.
@@ -2307,11 +2487,6 @@ tdd_worker_subpass_fn(void *arg)
     uint32_t eff_iter = ctx->eff_iter;
     uint32_t nrels = sp->relation_count;
     uint64_t worker_t0 = now_ns();
-#define TDD_WORKER_RETURN() \
-        do { \
-            ctx->runtime_ns = now_ns() - worker_t0; \
-            return; \
-        } while (0)
 
     /* Issue #282: Enable differential operators from eff_iter 1 onward.
      * Mirrors eval.c:410-411 / Clarification 3.
@@ -2326,9 +2501,21 @@ tdd_worker_subpass_fn(void *arg)
      * size, so the normal "delta < full" guard must be bypassed. */
     bool saved_tdd_subpass = sess->tdd_subpass_active;
     bool saved_outbound_only = sess->tdd_outbound_only_active;
+    bool saved_delta_seeded = sess->delta_seeded;
     sess->tdd_subpass_active = true;
     sess->tdd_outbound_only_active = ctx->outbound_only;
+    if (ctx->force_diff && ctx->outbound_only && eff_iter > 0)
+        sess->delta_seeded = true;
     sess->current_iteration = eff_iter;
+#define TDD_WORKER_RETURN() \
+        do { \
+            sess->tdd_subpass_active = saved_tdd_subpass; \
+            sess->tdd_outbound_only_active = saved_outbound_only; \
+            sess->delta_seeded = saved_delta_seeded; \
+            sess->diff_operators_active = saved_diff; \
+            ctx->runtime_ns = now_ns() - worker_t0; \
+            return; \
+        } while (0)
 
     /* Free per-sub-pass delta arrangements (eval.c:429) */
     col_session_free_delta_arrangements(sess);
@@ -2380,6 +2567,11 @@ tdd_worker_subpass_fn(void *arg)
 
         int rc = col_eval_relation_plan(rp, &stack, sess);
         if (rc != 0) {
+            if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
+                fprintf(stderr,
+                    "TDD relation error worker=%u rel=%s iter=%u rc=%d\n",
+                    sess->worker_id, rp->name ? rp->name : "(null)",
+                    eff_iter, rc);
             eval_stack_drain(&stack);
             ctx->rc = rc;
             free(snap);
@@ -2427,9 +2619,16 @@ tdd_worker_subpass_fn(void *arg)
                 sess->diff_operators_active = saved_diff;
                 TDD_WORKER_RETURN();
             }
-            if (target && target->nrows > 0) {
+            if (target && target->nrows > 0
+                && !(ctx->force_diff && ctx->outbound_only)) {
                 rc = bdx_hash_diff(delta, target);
                 if (rc != 0) {
+                    if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
+                        fprintf(stderr,
+                            "TDD local diff error worker=%u rel=%s iter=%u "
+                            "delta_cols=%u target_cols=%u rc=%d\n",
+                            sess->worker_id, rp->name ? rp->name : "(null)",
+                            eff_iter, delta->ncols, target->ncols, rc);
                     col_rel_destroy(delta);
                     ctx->rc = rc;
                     free(snap);
@@ -2445,6 +2644,13 @@ tdd_worker_subpass_fn(void *arg)
                 if (coord_target && coord_target->nrows > 0) {
                     rc = tdd_hashset_diff(delta, coord_target);
                     if (rc != 0) {
+                        if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
+                            fprintf(stderr,
+                                "TDD coord diff error worker=%u rel=%s "
+                                "iter=%u delta_cols=%u target_cols=%u rc=%d\n",
+                                sess->worker_id,
+                                rp->name ? rp->name : "(null)", eff_iter,
+                                delta->ncols, coord_target->ncols, rc);
                         col_rel_destroy(delta);
                         ctx->rc = rc;
                         free(snap);
@@ -3644,6 +3850,67 @@ stratum_max_idb_body_atoms(const wl_plan_stratum_t *sp)
         }
     }
     return max_count;
+}
+
+static uint32_t
+ops_count_join_like(const wl_plan_op_t *ops, uint32_t op_count)
+{
+    uint32_t count = 0;
+    for (uint32_t oi = 0; oi < op_count; oi++) {
+        switch (ops[oi].op) {
+        case WL_PLAN_OP_JOIN:
+        case WL_PLAN_OP_SEMIJOIN:
+        case WL_PLAN_OP_ANTIJOIN:
+            count++;
+            break;
+        default:
+            break;
+        }
+    }
+    return count;
+}
+
+static bool
+tdd_relation_has_exchange_key(const wl_plan_relation_t *rel)
+{
+    for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+        if (rel->ops[oi].op != WL_PLAN_OP_EXCHANGE)
+            continue;
+        const wl_plan_op_exchange_t *meta =
+            (const wl_plan_op_exchange_t *)rel->ops[oi].opaque_data;
+        return meta && meta->key_col_idxs && meta->key_col_count > 0;
+    }
+    return false;
+}
+
+bool
+tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
+{
+    if (!sp || tdd_stratum_has_idb_self_join(sp)
+        || stratum_max_idb_body_atoms(sp) > 1)
+        return false;
+
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rel = &sp->relations[ri];
+        if (!tdd_relation_has_exchange_key(rel))
+            return false;
+        if (ops_count_join_like(rel->ops, rel->op_count) > 1)
+            return false;
+
+        for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+            if (rel->ops[oi].op != WL_PLAN_OP_K_FUSION
+                || !rel->ops[oi].opaque_data)
+                continue;
+            const wl_plan_op_k_fusion_t *kf =
+                (const wl_plan_op_k_fusion_t *)rel->ops[oi].opaque_data;
+            for (uint32_t ki = 0; ki < kf->k; ki++) {
+                if (ops_count_join_like(kf->k_ops[ki],
+                    kf->k_op_counts[ki]) > 1)
+                    return false;
+            }
+        }
+    }
+    return true;
 }
 
 static uint32_t
@@ -5182,6 +5449,166 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
     return 0;
 }
 
+static int
+tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W,
+    bool *out_any_accepted, uint32_t *out_accepted_rows)
+{
+    uint32_t nrels = sp->relation_count;
+    int rc = 0;
+    if (out_any_accepted)
+        *out_any_accepted = false;
+    if (out_accepted_rows)
+        *out_accepted_rows = 0;
+
+    for (uint32_t ri = 0; ri < nrels; ri++) {
+        const char *dname = sp->relations[ri].delta_name;
+        const char *rel_name = sp->relations[ri].name;
+
+        for (uint32_t w = 0; w < W; w++)
+            session_remove_rel(&coord->tdd_workers[w], dname);
+
+        uint32_t total = 0;
+        uint32_t ncols = 0;
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *d = ctxs[w].delta_rels[ri];
+            if (d && d->nrows > 0) {
+                total += d->nrows;
+                if (ncols == 0)
+                    ncols = d->ncols;
+            }
+        }
+        if (total == 0) {
+            for (uint32_t w = 0; w < W; w++) {
+                col_rel_destroy(ctxs[w].delta_rels[ri]);
+                ctxs[w].delta_rels[ri] = NULL;
+            }
+            continue;
+        }
+
+        col_rel_t *combined = col_rel_new_auto(dname, ncols);
+        if (!combined)
+            return ENOMEM;
+
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *d = ctxs[w].delta_rels[ri];
+            ctxs[w].delta_rels[ri] = NULL;
+            if (d && d->nrows > 0)
+                rc = col_rel_append_all(combined, d, NULL);
+            col_rel_destroy(d);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+        }
+
+        if (combined->nrows > 1)
+            tdd_dedup_rel(combined);
+
+        col_rel_t *coord_idb = session_find_rel(coord, rel_name);
+        if (coord_idb && coord_idb->nrows > 0 && combined->nrows > 0) {
+            rc = tdd_hashset_diff(combined, coord_idb);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+        }
+        if (combined->nrows == 0) {
+            rc = tdd_install_empty_delta_on_workers(coord, dname, ncols, W);
+            col_rel_destroy(combined);
+            if (rc != 0)
+                return rc;
+            continue;
+        }
+
+        if (out_any_accepted)
+            *out_any_accepted = true;
+        if (out_accepted_rows)
+            *out_accepted_rows += combined->nrows;
+
+        if (coord_idb) {
+            if (coord_idb->ncols == 0 && combined->ncols > 0) {
+                rc = col_rel_set_schema(coord_idb, combined->ncols,
+                        (const char *const *)combined->col_names);
+                if (rc != 0) {
+                    col_rel_destroy(combined);
+                    return rc;
+                }
+            }
+            rc = col_rel_append_all(coord_idb, combined, NULL);
+            if (rc != 0) {
+                col_rel_destroy(combined);
+                return rc;
+            }
+            tdd_dedup_set_insert_rel(coord_idb, combined);
+            col_session_invalidate_arrangements(&coord->base, rel_name);
+        }
+
+        const uint32_t *key_cols = NULL;
+        uint32_t key_count = 0;
+        for (uint32_t oi = 0; oi < sp->relations[ri].op_count; oi++) {
+            if (sp->relations[ri].ops[oi].op == WL_PLAN_OP_EXCHANGE) {
+                const wl_plan_op_exchange_t *meta =
+                    (const wl_plan_op_exchange_t *)
+                    sp->relations[ri].ops[oi].opaque_data;
+                if (meta && meta->key_col_count > 0) {
+                    key_cols = meta->key_col_idxs;
+                    key_count = meta->key_col_count;
+                }
+                break;
+            }
+        }
+        uint32_t default_key[] = { 0 };
+        if (!key_cols || key_count == 0) {
+            key_cols = default_key;
+            key_count = 1;
+        }
+
+        col_rel_t **parts = (col_rel_t **)calloc(W, sizeof(col_rel_t *));
+        if (!parts) {
+            col_rel_destroy(combined);
+            return ENOMEM;
+        }
+        rc = col_rel_exchange_partition(combined, key_cols, key_count, W,
+                parts);
+        col_rel_destroy(combined);
+        if (rc != 0) {
+            for (uint32_t w = 0; w < W; w++)
+                col_rel_destroy(parts[w]);
+            free(parts);
+            return rc;
+        }
+
+        for (uint32_t w = 0; w < W; w++) {
+            col_rel_t *part = parts[w];
+            parts[w] = NULL;
+            if (!part || part->nrows == 0) {
+                col_rel_destroy(part);
+                continue;
+            }
+            free(part->name);
+            part->name = wl_strdup(dname);
+            if (!part->name) {
+                col_rel_destroy(part);
+                rc = ENOMEM;
+                break;
+            }
+            rc = session_add_rel(&coord->tdd_workers[w], part);
+            if (rc != 0) {
+                col_rel_destroy(part);
+                break;
+            }
+        }
+        for (uint32_t w = 0; w < W; w++)
+            col_rel_destroy(parts[w]);
+        free(parts);
+        if (rc != 0)
+            return rc;
+    }
+
+    return 0;
+}
+
 /*
  * col_eval_stratum_tdd_recursive:
  * Coordinator-driven semi-naive fixed-point for recursive strata.
@@ -5271,7 +5698,12 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         && stratum_max_idb_body_atoms(sp) <= 1
         && tdd_stratum_single_idb_join_keys_exchange_aligned(sp);
     bool bdx_mode = has_idb_self_join && !self_join_mode;
+    const char *global_read_env = getenv("WIRELOG_TDD_GLOBAL_READ");
+    bool global_read_mode = global_read_env && global_read_env[0] == '1'
+        && !owner_exchange_mode && !self_join_mode && !bdx_mode
+        && tdd_stratum_global_read_candidate(sp);
     bool replicate_mode = !owner_exchange_mode
+        && !global_read_mode
         && ((coord->last_inserted_relation == NULL)
         || (!self_join_mode && stratum_max_idb_body_atoms(sp) > 2));
     bdx_mode = bdx_mode && !replicate_mode;
@@ -5309,7 +5741,9 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         }
     }
 
-    if (replicate_mode)
+    if (global_read_mode)
+        rc = tdd_init_workers_global_read(coord, W);
+    else if (replicate_mode)
         rc = tdd_replicate_workers(coord, W);
     else
         rc = tdd_init_workers_hybrid(sp, coord, true, W);
@@ -5560,6 +5994,12 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         }
     }
 
+    if (global_read_mode) {
+        rc = tdd_seed_global_read_initial_deltas(sp, coord, W);
+        if (rc != 0)
+            goto done;
+    }
+
     for (uint32_t iter = 0; iter < MAX_ITERATIONS; iter++) {
         bool outer_any_new = false;
         bool converged = false;
@@ -5585,10 +6025,16 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 ctxs[w].eff_iter = eff_iter;
                 ctxs[w].any_new = false;
                 ctxs[w].all_empty_delta = false;
-                ctxs[w].force_diff = bdx_mode;
-                ctxs[w].outbound_only = owner_exchange_mode;
+                ctxs[w].force_diff = bdx_mode || global_read_mode;
+                ctxs[w].outbound_only = owner_exchange_mode
+                    || global_read_mode;
                 ctxs[w].runtime_ns = 0;
                 ctxs[w].rc = 0;
+            }
+            if (global_read_mode) {
+                rc = tdd_refresh_global_read_idb(sp, coord, W);
+                if (rc != 0)
+                    goto done;
             }
 
             /* DISPATCH */
@@ -5638,6 +6084,10 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             }
 
             if (rc != 0) {
+                if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
+                    fprintf(stderr,
+                        "TDD worker error stratum=%u iter=%u rc=%d\n",
+                        stratum_idx, eff_iter, rc);
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
                         col_rel_destroy(ctxs[w].delta_rels[ri]);
@@ -5700,7 +6150,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * any_new flags is both necessary and sufficient for fixed-point
              * detection.
              */
-            if (!owner_exchange_mode && tdd_check_convergence(ctxs, W)) {
+            if (!owner_exchange_mode && !global_read_mode
+                && tdd_check_convergence(ctxs, W)) {
                 coord->tdd_convergence_ns += now_ns() - convergence_t0;
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
@@ -5723,6 +6174,9 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 if (owner_exchange_mode)
                     brc = tdd_owner_exchange_deltas(sp, coord, ctxs, W,
                             &owner_any_accepted, &owner_accepted_rows);
+                else if (global_read_mode)
+                    brc = tdd_global_read_exchange_deltas(sp, coord, ctxs, W,
+                            &owner_any_accepted, &owner_accepted_rows);
                 else if (bdx_mode)
                     brc = tdd_bdx_exchange_deltas(sp, coord, ctxs, W,
                             bdx_snap);
@@ -5735,6 +6189,10 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             }
 
             if (brc != 0) {
+                if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
+                    fprintf(stderr,
+                        "TDD exchange error stratum=%u iter=%u rc=%d\n",
+                        stratum_idx, eff_iter, brc);
                 rc = brc;
                 goto done;
             }
@@ -5754,12 +6212,14 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 break;
             }
 
-            if (owner_exchange_mode && !owner_any_accepted) {
+            if ((owner_exchange_mode || global_read_mode)
+                && !owner_any_accepted) {
                 converged = true;
                 break;
             }
 
-            outer_any_new = owner_exchange_mode ? owner_any_accepted : true;
+            outer_any_new = (owner_exchange_mode || global_read_mode)
+                ? owner_any_accepted : true;
             if (outer_any_new)
                 final_eff_iter = eff_iter;
         } /* end sub loop */
@@ -5811,7 +6271,7 @@ done:
         tdd_record_recursive_convergence(coord, sp, stratum_idx,
             rule_id_base, final_eff_iter);
 
-        if (bdx_mode || owner_exchange_mode) {
+        if (bdx_mode || owner_exchange_mode || global_read_mode) {
             /* Coordinator-owned modes maintain IDB monotonically during
              * exchange.  Just dedup final. */
             uint64_t merge_t0 = now_ns();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -3814,7 +3814,7 @@ ops_have_idb_idb_join(const wl_plan_op_t *ops, uint32_t op_count,
 /*
  * ops_count_idb_body_atoms:
  * Walk an op sequence and count the number of distinct IDB relations
- * referenced as body atoms (VARIABLE loads + JOIN right_relations).
+ * referenced as body atoms (VARIABLE loads + join-like right_relations).
  * Extends the pattern from ops_have_idb_idb_join but returns a count.
  */
 static uint32_t
@@ -3827,7 +3827,10 @@ ops_count_idb_body_atoms(const wl_plan_op_t *ops, uint32_t op_count,
         if (op->op == WL_PLAN_OP_VARIABLE) {
             if (is_stratum_idb(sp, op->relation_name))
                 count++;
-        } else if (op->op == WL_PLAN_OP_JOIN && op->right_relation) {
+        } else if ((op->op == WL_PLAN_OP_JOIN
+            || op->op == WL_PLAN_OP_SEMIJOIN
+            || op->op == WL_PLAN_OP_ANTIJOIN)
+            && op->right_relation) {
             if (is_stratum_idb(sp, op->right_relation))
                 count++;
         }

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -3870,6 +3870,37 @@ ops_count_join_like(const wl_plan_op_t *ops, uint32_t op_count)
     return count;
 }
 
+static uint32_t
+tdd_stratum_global_read_max_idb_atoms(const wl_plan_stratum_t *sp)
+{
+    uint32_t max_count = 0;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rel = &sp->relations[ri];
+        bool has_kfusion = false;
+        for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+            if (rel->ops[oi].op != WL_PLAN_OP_K_FUSION
+                || !rel->ops[oi].opaque_data)
+                continue;
+            has_kfusion = true;
+            const wl_plan_op_k_fusion_t *kf =
+                (const wl_plan_op_k_fusion_t *)rel->ops[oi].opaque_data;
+            for (uint32_t ki = 0; ki < kf->k; ki++) {
+                uint32_t c = ops_count_idb_body_atoms(kf->k_ops[ki],
+                        kf->k_op_counts[ki], sp);
+                if (c > max_count)
+                    max_count = c;
+            }
+        }
+        if (!has_kfusion) {
+            uint32_t c = ops_count_idb_body_atoms(rel->ops, rel->op_count,
+                    sp);
+            if (c > max_count)
+                max_count = c;
+        }
+    }
+    return max_count;
+}
+
 static bool
 tdd_relation_has_exchange_key(const wl_plan_relation_t *rel)
 {
@@ -3886,15 +3917,20 @@ tdd_relation_has_exchange_key(const wl_plan_relation_t *rel)
 bool
 tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
 {
-    if (!sp || tdd_stratum_has_idb_self_join(sp)
-        || stratum_max_idb_body_atoms(sp) > 1)
+    if (!sp)
+        return false;
+    if (tdd_stratum_has_idb_self_join(sp))
+        return false;
+    uint32_t max_idb_atoms = tdd_stratum_global_read_max_idb_atoms(sp);
+    if (max_idb_atoms > 2)
         return false;
 
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
         const wl_plan_relation_t *rel = &sp->relations[ri];
         if (!tdd_relation_has_exchange_key(rel))
             return false;
-        if (ops_count_join_like(rel->ops, rel->op_count) > 1)
+        uint32_t top_joins = ops_count_join_like(rel->ops, rel->op_count);
+        if (top_joins > 2)
             return false;
 
         for (uint32_t oi = 0; oi < rel->op_count; oi++) {
@@ -3904,8 +3940,9 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
             const wl_plan_op_k_fusion_t *kf =
                 (const wl_plan_op_k_fusion_t *)rel->ops[oi].opaque_data;
             for (uint32_t ki = 0; ki < kf->k; ki++) {
-                if (ops_count_join_like(kf->k_ops[ki],
-                    kf->k_op_counts[ki]) > 1)
+                uint32_t child_joins = ops_count_join_like(kf->k_ops[ki],
+                        kf->k_op_counts[ki]);
+                if (child_joins > 2)
                     return false;
             }
         }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1649,6 +1649,8 @@ tdd_stratum_idb_self_join_exchange_aligned(const wl_plan_stratum_t *sp,
 bool
 tdd_stratum_single_idb_join_keys_exchange_aligned(
     const wl_plan_stratum_t *sp);
+bool
+tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp);
 int
 col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
     uint32_t stratum_idx);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5481,8 +5481,8 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     col_rel_t **results = (col_rel_t **)calloc(live_count, sizeof(col_rel_t *));
     col_op_k_fusion_worker_t *workers = (col_op_k_fusion_worker_t *)calloc(
         live_count, sizeof(col_op_k_fusion_worker_t));
-    /* Per-worker session wrappers: shallow copy of sess with an isolated
-     * mat_cache so concurrent col_op_join calls do not race on the cache. */
+    /* Per-worker session wrappers: shallow copy of sess with isolated mutable
+     * caches so concurrent branch evaluation does not race on cache state. */
     wl_col_session_t *worker_sess
         = (wl_col_session_t *)calloc(live_count, sizeof(wl_col_session_t));
     COL_SESSION(sess)->kfusion_alloc_ns += now_ns() - _phase_t0;
@@ -5508,12 +5508,12 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         uint32_t branch_idx = live_indices[d];
         /* Shallow copy shares rels[], plan, etc. (read-only during K-fusion).
          * mat_cache is zeroed below (Issue #196): workers start fresh.
-         * arr_* are deep-copied (#260): each worker gets an independent
-         * arrangement cache to probe without races (no shared mutable state).
-         * darr_* are zeroed: workers rebuild delta arrangements per-iteration. */
+         * arrangement caches are zeroed below, so workers rebuild private
+         * entries on demand instead of cloning coordinator state. */
         worker_sess[d] = *sess;
         worker_sess[d].wq = NULL; /* prevent nested K-fusion from workers */
         worker_sess[d].wq_workers = 0;
+        worker_sess[d].num_workers = 1;
         worker_sess[d].tdd_workers = NULL;
         worker_sess[d].tdd_workers_cap = 0;
         worker_sess[d].tdd_workers_count = 0;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -18,6 +18,12 @@
  * K < WL_KFUSION_MIN_PARALLEL_K falls back to sequential execution. */
 #define WL_KFUSION_MIN_PARALLEL_K 4
 
+/* Best-effort match-pair cache for parallel keyed diff joins.  The cache is
+ * scratch memory outside the final output relation, so keep it bounded and
+ * fall back to the old fill traversal when a worker reaches the cap. */
+#define WL_JOIN_PAIR_CACHE_MAX_BYTES (256ULL * 1024ULL * 1024ULL)
+#define WL_JOIN_PAIR_CACHE_MIN_LEFT_ROWS 100000u
+
 #include "columnar/internal.h"
 #include "columnar/lftj.h"
 #include "wirelog/util/log.h"
@@ -2225,6 +2231,11 @@ typedef struct {
 } col_join_cross_ctx_t;
 
 typedef struct {
+    uint32_t lr;
+    uint32_t rr;
+} col_join_pair_ref_t;
+
+typedef struct {
     const col_rel_t *left;
     const col_rel_t *right;
     const col_diff_arrangement_t *darr;
@@ -2239,6 +2250,11 @@ typedef struct {
     uint64_t count;
     uint64_t limit;
     uint32_t *left_hashes;
+    col_join_pair_ref_t *pairs;
+    uint32_t pair_count;
+    uint32_t pair_cap;
+    uint32_t pair_cap_limit;
+    bool pairs_complete;
     atomic_bool *stop;
     atomic_uint_fast64_t *shared_count;
     int rc;
@@ -2282,6 +2298,52 @@ col_join_write_pair_at(col_rel_t *out, uint64_t out_row,
     }
 }
 
+static bool
+col_join_pair_cache_append(col_join_keyed_ctx_t *ctx, uint32_t lr,
+    uint32_t rr)
+{
+    if (!ctx->pairs_complete)
+        return false;
+    if (ctx->pair_cap_limit == 0) {
+        ctx->pairs_complete = false;
+        return false;
+    }
+    if (ctx->pair_count == ctx->pair_cap) {
+        uint32_t new_cap = ctx->pair_cap ? ctx->pair_cap * 2u : 1024u;
+        if (new_cap <= ctx->pair_cap) {
+            ctx->pairs_complete = false;
+            return false;
+        }
+        if (ctx->pair_cap_limit > 0 && new_cap > ctx->pair_cap_limit)
+            new_cap = ctx->pair_cap_limit;
+        size_t max_pairs = SIZE_MAX / sizeof(col_join_pair_ref_t);
+        if (new_cap <= ctx->pair_cap || (size_t)new_cap > max_pairs) {
+            free(ctx->pairs);
+            ctx->pairs = NULL;
+            ctx->pair_count = 0;
+            ctx->pair_cap = 0;
+            ctx->pairs_complete = false;
+            return false;
+        }
+        col_join_pair_ref_t *new_pairs = (col_join_pair_ref_t *)realloc(
+            ctx->pairs, (size_t)new_cap * sizeof(col_join_pair_ref_t));
+        if (!new_pairs) {
+            free(ctx->pairs);
+            ctx->pairs = NULL;
+            ctx->pair_count = 0;
+            ctx->pair_cap = 0;
+            ctx->pairs_complete = false;
+            return false;
+        }
+        ctx->pairs = new_pairs;
+        ctx->pair_cap = new_cap;
+    }
+    ctx->pairs[ctx->pair_count].lr = lr;
+    ctx->pairs[ctx->pair_count].rr = rr;
+    ctx->pair_count++;
+    return true;
+}
+
 static void
 col_join_keyed_count_worker_fn(void *arg)
 {
@@ -2307,6 +2369,7 @@ col_join_keyed_count_worker_fn(void *arg)
             uint32_t rr = e - 1;
             if (col_join_keys_match_rel(left, lr, ctx->lk, right, rr, ctx->rk,
                 ctx->kc)) {
+                (void)col_join_pair_cache_append(ctx, lr, rr);
                 count++;
                 if (ctx->limit > 0 && ctx->shared_count
                     && (count - reported) >= 1024u) {
@@ -2341,6 +2404,15 @@ col_join_keyed_fill_worker_fn(void *arg)
     const col_rel_t *right = ctx->right;
     const col_diff_arrangement_t *darr = ctx->darr;
     uint64_t out_row = ctx->out_begin;
+
+    if (ctx->pairs_complete && (uint64_t)ctx->pair_count == ctx->count) {
+        for (uint32_t i = 0; i < ctx->pair_count; i++) {
+            col_join_write_pair_at(ctx->out, out_row++, left,
+                ctx->pairs[i].lr, right, ctx->pairs[i].rr,
+                ctx->op->project_indices, ctx->op->project_count);
+        }
+        return;
+    }
 
     for (uint32_t lr = ctx->begin; lr < ctx->end; lr++) {
         uint32_t h = ctx->left_hashes ? ctx->left_hashes[lr]
@@ -6455,6 +6527,18 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 return ENOMEM;
             }
             uint32_t chunk = (left->nrows + W - 1u) / W;
+            uint64_t pair_budget = wl_mem_ledger_bytes_remaining(
+                &sess->mem_ledger) / 8u;
+            if (left->nrows < WL_JOIN_PAIR_CACHE_MIN_LEFT_ROWS)
+                pair_budget = 0;
+            if (pair_budget > WL_JOIN_PAIR_CACHE_MAX_BYTES)
+                pair_budget = WL_JOIN_PAIR_CACHE_MAX_BYTES;
+            uint64_t pair_budget_per_worker = W > 0 ? pair_budget / W : 0;
+            uint32_t pair_cap_limit = pair_budget_per_worker
+                / sizeof(col_join_pair_ref_t) > UINT32_MAX
+                ? UINT32_MAX
+                : (uint32_t)(pair_budget_per_worker
+                / sizeof(col_join_pair_ref_t));
             atomic_bool stop = ATOMIC_VAR_INIT(false);
             atomic_uint_fast64_t shared_count = ATOMIC_VAR_INIT(0);
             int prc = 0;
@@ -6476,6 +6560,8 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 ctxs[w].end = end;
                 ctxs[w].limit = sess->join_output_limit;
                 ctxs[w].left_hashes = left_hashes;
+                ctxs[w].pair_cap_limit = pair_cap_limit;
+                ctxs[w].pairs_complete = true;
                 ctxs[w].stop = &stop;
                 ctxs[w].shared_count = &shared_count;
                 if (wl_workqueue_submit(sess->wq,
@@ -6536,6 +6622,8 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                             prc = ctxs[w].rc;
                 }
             }
+            for (uint32_t w = 0; w < W; w++)
+                free(ctxs[w].pairs);
             free(offsets);
             free(ctxs);
             free(left_hashes);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5760,10 +5760,8 @@ col_op_semijoin(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
     for (uint32_t rr = 0; rr < right->nrows; rr++) {
-        int64_t rrow_buf[COL_STACK_MAX];
-        col_rel_row_copy_out(right, rr, rrow_buf);
-        const int64_t *rrow = rrow_buf;
-        uint32_t h = hash_int64_keys_fast(rrow, rk, kc) & (nbuckets - 1);
+        uint32_t h = col_join_hash_rel_keys(right, rr, rk, kc)
+            & (nbuckets - 1);
         ht_next[rr] = ht_head[h];
         ht_head[h] = rr + 1; /* 1-based; 0 = end of chain */
     }
@@ -5771,27 +5769,23 @@ col_op_semijoin(const wl_plan_op_t *op, eval_stack_t *stack,
     /* Probe: for each left row test membership, emit if found: O(|L|) */
     int sj_rc = 0;
     for (uint32_t lr = 0; lr < left->nrows && sj_rc == 0; lr++) {
-        int64_t lrow_buf[COL_STACK_MAX];
-        col_rel_row_copy_out(left, lr, lrow_buf);
-        const int64_t *lrow = lrow_buf;
-        uint32_t h = hash_int64_keys_fast(lrow, lk, kc) & (nbuckets - 1);
+        uint32_t h = col_join_hash_rel_keys(left, lr, lk, kc)
+            & (nbuckets - 1);
         bool found = false;
         for (uint32_t e = ht_head[h]; e != 0 && !found; e = ht_next[e - 1]) {
             uint32_t rr = e - 1;
-            int64_t rrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(right, rr, rrow_buf);
-            const int64_t *rrow = rrow_buf;
-            if (keys_match_fast(lrow, lk, rrow, rk, kc))
+            if (col_join_keys_match_rel(left, lr, lk, right, rr, rk, kc))
                 found = true;
         }
         if (found) {
             if (op->project_count > 0 && op->project_indices) {
                 for (uint32_t c = 0; c < ocols; c++) {
                     uint32_t si = op->project_indices[c];
-                    tmp[c] = (si < left->ncols) ? lrow[si] : 0;
+                    tmp[c] = (si < left->ncols) ? left->columns[si][lr] : 0;
                 }
             } else {
-                memcpy(tmp, lrow, sizeof(int64_t) * left->ncols);
+                for (uint32_t c = 0; c < left->ncols; c++)
+                    tmp[c] = left->columns[c][lr];
             }
             sj_rc = col_rel_append_row(out, tmp);
         }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5243,8 +5243,12 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         return EINVAL;
 
     /* Issue #549: W=1 fast-path. Skip per-worker clone/arena/delta_pool
-     * machinery when there's only one thread — pure overhead otherwise. */
-    if (sess->wq == NULL && sess->num_workers <= 1)
+     * machinery when there's only one thread — pure overhead otherwise.
+     * TDD workers already run under the distributed stratum workqueue; running
+     * nested K-fusion workers inside them oversubscribes execution and divides
+     * join_output_limit a second time. */
+    if (sess->tdd_subpass_active || sess->coordinator
+        || (sess->wq == NULL && sess->num_workers <= 1))
         return col_op_k_fusion_serial(op, stack, sess);
 
     /* Issue #560: Advance the compound-arena epoch frontier before

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2268,6 +2268,24 @@ typedef struct {
     int rc;
 } col_join_keyed_ctx_t;
 
+typedef struct {
+    const col_rel_t *left;
+    const col_rel_t *right;
+    const uint32_t *lk;
+    const uint32_t *rk;
+    uint32_t kc;
+    const wl_plan_op_t *op;
+    const uint32_t *ht_head;
+    const uint32_t *ht_next;
+    uint32_t nbuckets;
+    col_rel_t *out;
+    uint32_t begin;
+    uint32_t end;
+    uint64_t out_begin;
+    uint64_t count;
+    uint32_t *left_hashes;
+} col_semijoin_ctx_t;
+
 static int64_t
 col_join_pair_value(const col_rel_t *left, uint32_t lr, const col_rel_t *right,
     uint32_t rr, uint32_t idx);
@@ -2435,6 +2453,67 @@ col_join_keyed_fill_worker_fn(void *arg)
                     rr, ctx->op->project_indices, ctx->op->project_count);
             }
         }
+    }
+}
+
+static bool
+col_semijoin_row_found(const col_semijoin_ctx_t *ctx, uint32_t lr)
+{
+    const col_rel_t *left = ctx->left;
+    const col_rel_t *right = ctx->right;
+    uint32_t h = ctx->left_hashes ? ctx->left_hashes[lr]
+        : (col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
+        & (ctx->nbuckets - 1));
+
+    for (uint32_t e = ctx->ht_head[h]; e != 0; e = ctx->ht_next[e - 1]) {
+        uint32_t rr = e - 1;
+        if (col_join_keys_match_rel(left, lr, ctx->lk, right, rr, ctx->rk,
+            ctx->kc))
+            return true;
+    }
+    return false;
+}
+
+static void
+col_semijoin_count_worker_fn(void *arg)
+{
+    col_semijoin_ctx_t *ctx = (col_semijoin_ctx_t *)arg;
+    uint64_t count = 0;
+
+    for (uint32_t lr = ctx->begin; lr < ctx->end; lr++) {
+        if (ctx->left_hashes)
+            ctx->left_hashes[lr] = col_join_hash_rel_keys(ctx->left, lr,
+                    ctx->lk, ctx->kc) & (ctx->nbuckets - 1);
+        if (col_semijoin_row_found(ctx, lr))
+            count++;
+    }
+    ctx->count = count;
+}
+
+static void
+col_semijoin_fill_worker_fn(void *arg)
+{
+    col_semijoin_ctx_t *ctx = (col_semijoin_ctx_t *)arg;
+    const col_rel_t *left = ctx->left;
+    col_rel_t *out = ctx->out;
+    uint64_t out_row = ctx->out_begin;
+    uint32_t ocols = ctx->op->project_count ? ctx->op->project_count
+        : left->ncols;
+
+    for (uint32_t lr = ctx->begin; lr < ctx->end; lr++) {
+        if (!col_semijoin_row_found(ctx, lr))
+            continue;
+        if (ctx->op->project_count > 0 && ctx->op->project_indices) {
+            for (uint32_t c = 0; c < ocols; c++) {
+                uint32_t si = ctx->op->project_indices[c];
+                out->columns[c][out_row] = (si < left->ncols)
+                    ? left->columns[si][lr] : 0;
+            }
+        } else {
+            for (uint32_t c = 0; c < left->ncols; c++)
+                out->columns[c][out_row] = left->columns[c][lr];
+        }
+        out_row++;
     }
 }
 
@@ -5850,8 +5929,90 @@ col_op_semijoin(const wl_plan_op_t *op, eval_stack_t *stack,
         ht_head[h] = rr + 1; /* 1-based; 0 = end of chain */
     }
 
-    /* Probe: for each left row test membership, emit if found: O(|L|) */
     int sj_rc = 0;
+    uint32_t min_left = col_join_parallel_min_left_rows();
+    if (min_left == 0)
+        min_left = 1;
+    uint32_t W = left->nrows / min_left;
+    if (W > sess->num_workers)
+        W = sess->num_workers;
+    if (!sess->coordinator && W > 1 && right->nrows > 0) {
+        int ensure_rc = wl_columnar_session_ensure_workqueue(sess, W);
+        if (ensure_rc == 0) {
+            col_semijoin_ctx_t *ctxs = (col_semijoin_ctx_t *)calloc(
+                W, sizeof(col_semijoin_ctx_t));
+            uint64_t *offsets = (uint64_t *)calloc(W + 1,
+                    sizeof(uint64_t));
+            uint32_t *left_hashes = (uint32_t *)malloc(
+                sizeof(uint32_t) * (size_t)(left->nrows ? left->nrows : 1));
+            if (ctxs && offsets) {
+                uint32_t chunk = (left->nrows + W - 1u) / W;
+                int prc = 0;
+                for (uint32_t w = 0; w < W; w++) {
+                    uint32_t begin = w * chunk;
+                    uint32_t end = begin + chunk;
+                    if (begin > left->nrows)
+                        begin = left->nrows;
+                    if (end > left->nrows)
+                        end = left->nrows;
+                    ctxs[w].left = left;
+                    ctxs[w].right = right;
+                    ctxs[w].lk = lk;
+                    ctxs[w].rk = rk;
+                    ctxs[w].kc = kc;
+                    ctxs[w].op = op;
+                    ctxs[w].ht_head = ht_head;
+                    ctxs[w].ht_next = ht_next;
+                    ctxs[w].nbuckets = nbuckets;
+                    ctxs[w].begin = begin;
+                    ctxs[w].end = end;
+                    ctxs[w].left_hashes = left_hashes;
+                    if (wl_workqueue_submit(sess->wq,
+                        col_semijoin_count_worker_fn, &ctxs[w]) != 0)
+                        prc = ENOMEM;
+                }
+                wl_workqueue_wait_all(sess->wq);
+                uint64_t total = 0;
+                for (uint32_t w = 0; w < W; w++) {
+                    offsets[w] = total;
+                    total += ctxs[w].count;
+                }
+                offsets[W] = total;
+                if (prc == 0 && total > UINT32_MAX)
+                    prc = ENOMEM;
+                if (prc == 0 && col_join_reserve_exact(out,
+                    (uint32_t)total) != 0)
+                    prc = ENOMEM;
+                if (prc == 0) {
+                    out->nrows = (uint32_t)total;
+                    if (out->timestamps && total > 0)
+                        memset(out->timestamps, 0,
+                            (size_t)total * sizeof(col_delta_timestamp_t));
+                    for (uint32_t w = 0; w < W; w++) {
+                        ctxs[w].out = out;
+                        ctxs[w].out_begin = offsets[w];
+                        if (wl_workqueue_submit(sess->wq,
+                            col_semijoin_fill_worker_fn, &ctxs[w]) != 0)
+                            prc = ENOMEM;
+                    }
+                    wl_workqueue_wait_all(sess->wq);
+                }
+                if (prc != 0)
+                    out->nrows = 0;
+                free(left_hashes);
+                free(offsets);
+                free(ctxs);
+                if (prc == 0)
+                    goto semijoin_done;
+            } else {
+                free(left_hashes);
+                free(offsets);
+                free(ctxs);
+            }
+        }
+    }
+
+    /* Probe: for each left row test membership, emit if found: O(|L|) */
     for (uint32_t lr = 0; lr < left->nrows && sj_rc == 0; lr++) {
         uint32_t h = col_join_hash_rel_keys(left, lr, lk, kc)
             & (nbuckets - 1);
@@ -5875,6 +6036,7 @@ col_op_semijoin(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     }
 
+semijoin_done:
     free(ht_head);
     free(ht_next);
     if (sj_rc != 0) {

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2247,11 +2247,11 @@ static int64_t
 col_join_pair_value(const col_rel_t *left, uint32_t lr, const col_rel_t *right,
     uint32_t rr, uint32_t idx);
 
-static uint32_t
+static inline uint32_t
 col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     const uint32_t *key_cols, uint32_t kc);
 
-static bool
+static inline bool
 col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
     const uint32_t *lk, const col_rel_t *right, uint32_t rr,
     const uint32_t *rk, uint32_t kc);
@@ -2482,7 +2482,7 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
     return 0;
 }
 
-static uint32_t
+static inline uint32_t
 col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     const uint32_t *key_cols, uint32_t kc)
 {
@@ -2518,7 +2518,7 @@ col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     return h;
 }
 
-static bool
+static inline bool
 col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
     const uint32_t *lk, const col_rel_t *right, uint32_t rr,
     const uint32_t *rk, uint32_t kc)

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -24,6 +24,14 @@
 #define WL_JOIN_PAIR_CACHE_MAX_BYTES (256ULL * 1024ULL * 1024ULL)
 #define WL_JOIN_PAIR_CACHE_MIN_LEFT_ROWS 100000u
 
+#if defined(_MSC_VER)
+#define WL_OPS_ALWAYS_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#define WL_OPS_ALWAYS_INLINE inline __attribute__((always_inline))
+#else
+#define WL_OPS_ALWAYS_INLINE inline
+#endif
+
 #include "columnar/internal.h"
 #include "columnar/lftj.h"
 #include "wirelog/util/log.h"
@@ -2264,11 +2272,11 @@ static int64_t
 col_join_pair_value(const col_rel_t *left, uint32_t lr, const col_rel_t *right,
     uint32_t rr, uint32_t idx);
 
-static inline uint32_t
+static WL_OPS_ALWAYS_INLINE uint32_t
 col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     const uint32_t *key_cols, uint32_t kc);
 
-static inline bool
+static WL_OPS_ALWAYS_INLINE bool
 col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
     const uint32_t *lk, const col_rel_t *right, uint32_t rr,
     const uint32_t *rk, uint32_t kc);
@@ -2558,7 +2566,7 @@ col_join_parallel_cross(wl_col_session_t *sess, const col_rel_t *left,
     return 0;
 }
 
-static inline uint32_t
+static WL_OPS_ALWAYS_INLINE uint32_t
 col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     const uint32_t *key_cols, uint32_t kc)
 {
@@ -2594,7 +2602,7 @@ col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     return h;
 }
 
-static inline bool
+static WL_OPS_ALWAYS_INLINE bool
 col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
     const uint32_t *lk, const col_rel_t *right, uint32_t rr,
     const uint32_t *rk, uint32_t kc)

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5528,51 +5528,15 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
          * is replaced below; the parent session retains its own copies. */
         worker_sess[d].eval_arena = NULL;
         worker_sess[d].delta_pool = NULL;
-        /* Issue #260: Deep-copy parent's full-arrangement cache so each worker
-         * has an independent copy.  arr.key_cols is a shared alias of
-         * entry.key_cols inside each clone (see col_arr_entry_clone). */
         worker_sess[d].arr_entries = NULL;
         worker_sess[d].arr_count = 0;
         worker_sess[d].arr_cap = 0;
-        {
-            uint32_t clone_cap = 0;
-            int clone_rc = col_arr_entries_clone(
-                sess->arr_entries, sess->arr_count,
-                &worker_sess[d].arr_entries, &clone_cap);
-            if (clone_rc != 0) {
-                rc = ENOMEM;
-                if (wq)
-                    wl_workqueue_drain(wq);
-                goto cleanup_wq;
-            }
-            worker_sess[d].arr_count = sess->arr_count;
-            worker_sess[d].arr_cap = clone_cap;
-            /* Issue #216: inherit LRU tracking state so worker clock is
-             * consistent with coordinator; worker computes its own totals. */
-            worker_sess[d].arr_clock = sess->arr_clock;
-            worker_sess[d].arr_total_bytes = sess->arr_total_bytes;
-            worker_sess[d].arr_cache_limit_bytes = sess->arr_cache_limit_bytes;
-        }
-        /* Issue #274: Deep-copy differential arrangement cache so each worker
-         * has an independent copy. This prevents concurrent realloc() races
-         * when col_session_get_diff_arrangement() grows the registry. */
+        worker_sess[d].arr_clock = sess->arr_clock;
+        worker_sess[d].arr_total_bytes = 0;
+        worker_sess[d].arr_cache_limit_bytes = sess->arr_cache_limit_bytes;
         worker_sess[d].diff_arr_entries = NULL;
         worker_sess[d].diff_arr_count = 0;
         worker_sess[d].diff_arr_cap = 0;
-        {
-            uint32_t diff_clone_cap = 0;
-            int diff_clone_rc = col_diff_arr_entries_clone(
-                sess->diff_arr_entries, sess->diff_arr_count,
-                &worker_sess[d].diff_arr_entries, &diff_clone_cap);
-            if (diff_clone_rc != 0) {
-                rc = diff_clone_rc;
-                if (wq)
-                    wl_workqueue_drain(wq);
-                goto cleanup_wq;
-            }
-            worker_sess[d].diff_arr_count = sess->diff_arr_count;
-            worker_sess[d].diff_arr_cap = diff_clone_cap;
-        }
         worker_sess[d].darr_entries = NULL;
         worker_sess[d].darr_count = 0;
         worker_sess[d].darr_cap = 0;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2238,6 +2238,7 @@ typedef struct {
     uint64_t out_begin;
     uint64_t count;
     uint64_t limit;
+    uint32_t *left_hashes;
     atomic_bool *stop;
     atomic_uint_fast64_t *shared_count;
     int rc;
@@ -2296,6 +2297,8 @@ col_join_keyed_count_worker_fn(void *arg)
         memory_order_relaxed)); lr++) {
         uint32_t h = col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
             & (darr->nbuckets - 1);
+        if (ctx->left_hashes)
+            ctx->left_hashes[lr] = h;
         for (uint32_t e = darr->ht_head[h]; e != 0;
             e = darr->ht_next[e - 1]) {
             if (ctx->stop && atomic_load_explicit(ctx->stop,
@@ -2340,8 +2343,9 @@ col_join_keyed_fill_worker_fn(void *arg)
     uint64_t out_row = ctx->out_begin;
 
     for (uint32_t lr = ctx->begin; lr < ctx->end; lr++) {
-        uint32_t h = col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
-            & (darr->nbuckets - 1);
+        uint32_t h = ctx->left_hashes ? ctx->left_hashes[lr]
+            : (col_join_hash_rel_keys(left, lr, ctx->lk, ctx->kc)
+            & (darr->nbuckets - 1));
         for (uint32_t e = darr->ht_head[h]; e != 0;
             e = darr->ht_next[e - 1]) {
             uint32_t rr = e - 1;
@@ -6433,9 +6437,13 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             col_join_keyed_ctx_t *ctxs = (col_join_keyed_ctx_t *)calloc(
                 W, sizeof(col_join_keyed_ctx_t));
             uint64_t *offsets = (uint64_t *)calloc(W + 1, sizeof(uint64_t));
+            uint32_t *left_hashes = (uint32_t *)malloc(
+                sizeof(uint32_t)
+                * (size_t)(left->nrows ? left->nrows : 1));
             if (!ctxs || !offsets) {
                 free(ctxs);
                 free(offsets);
+                free(left_hashes);
                 free(tmp);
                 col_rel_destroy(out);
                 free(lk);
@@ -6467,6 +6475,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 ctxs[w].begin = begin;
                 ctxs[w].end = end;
                 ctxs[w].limit = sess->join_output_limit;
+                ctxs[w].left_hashes = left_hashes;
                 ctxs[w].stop = &stop;
                 ctxs[w].shared_count = &shared_count;
                 if (wl_workqueue_submit(sess->wq,
@@ -6529,6 +6538,7 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
             }
             free(offsets);
             free(ctxs);
+            free(left_hashes);
             if (prc != 0) {
                 free(tmp);
                 col_rel_destroy(out);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -303,6 +303,12 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
         return decision;
     }
     if (!wl_columnar_session_tdd_stratum_is_safe(sp, sess)) {
+        const char *env = getenv("WIRELOG_TDD_GLOBAL_READ");
+        if (env && env[0] == '1'
+            && tdd_stratum_global_read_candidate(sp)) {
+            decision.use_tdd = true;
+            return decision;
+        }
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN;
         return decision;


### PR DESCRIPTION
Refs #659

This PR is a predecessor for issue #659. It restores the production DOOP performance path on top of main while preserving the `workers=N` cap and tightening TDD safety guards. It does not close #659 because high-W scaling remains flat and default TDD coverage is still limited.

## Changes

- Add a guarded global-read recursive TDD path with rollback and incremental view refresh.
- Improve hot join/semijoin paths by hashing arrangement and semijoin keys from columns, inlining join-key helpers, caching diff join match pairs, and reusing diff join left buckets.
- Start K-Fusion branch workers with empty caches to avoid expensive per-branch cache cloning.
- Keep K-Fusion branch worker sessions single-threaded so nested join/semijoin workqueues do not violate `workers=N` as a hard cap.
- Count SEMIJOIN and ANTIJOIN IDB right relations in TDD IDB atom guards.

## Benchmarks

Measured locally on this workstation with `bench/data/doop`, `--repeat 1`, tuple parity `6276657`:

| build | workers | wall time | TDD strata | notes |
| --- | ---: | ---: | ---: | --- |
| main before this stack | 16 | ~53s | 1/5 | baseline after #672 |
| this branch | 1 | 49.6s | 0/5 | serial cap |
| this branch | 4 | 30.8s | 1/5 | tuple parity |
| this branch | 8 | 22.8s | 1/5 | tuple parity |
| this branch | 16 | 20.6s | 1/5 | tuple parity |
| this branch | 32 | 21.1s | 1/5 | tuple parity, flat vs W=16 |

With `WIRELOG_TDD_GLOBAL_READ=1`, DOOP reaches 2/5 TDD strata but remains guarded/opt-in and did not materially improve W=16/W=32 in this measurement.

## Known limitation

This does not solve issue #659. W=32 does not materially improve over W=16, so the next step remains true W=N scaling: decouple recursive TDD logical ownership shards from active OS workers and treat `JOIN_OUTPUT_LIMIT` saturation as adaptive fallback/backpressure rather than a user-visible failure.

## Validation

```
meson test -C build wirelog:tdd_decision_stats wirelog:tdd_single_key_owner wirelog:tdd_recursive wirelog:doop_multiworker wirelog:k_fusion_correctness wirelog:join_limit wirelog:workers_as_cap --print-errorlogs
```

Passed all listed tests locally.
