### PR TITLE
Improve TDD worker sizing diagnostics

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -5764,7 +5764,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         && tdd_stratum_single_idb_join_keys_exchange_aligned(sp);
     bool bdx_mode = has_idb_self_join && !self_join_mode;
     const char *global_read_env = getenv("WIRELOG_TDD_GLOBAL_READ");
-    bool global_read_mode = global_read_env && global_read_env[0] == '1'
+    bool global_read_mode = !(global_read_env && global_read_env[0] == '0'
+        && global_read_env[1] == '\0')
         && !owner_exchange_mode && !self_join_mode && !bdx_mode
         && tdd_stratum_global_read_candidate(sp);
     bool replicate_mode = !owner_exchange_mode

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4867,24 +4867,91 @@ tdd_check_convergence(const col_eval_tdd_worker_ctx_t *ctxs, uint32_t W)
     return true;
 }
 
+static bool
+tdd_estimate_add_rel_name(const char **names, uint32_t *count, uint32_t cap,
+    const char *name)
+{
+    if (!name || !names || !count)
+        return true;
+    for (uint32_t i = 0; i < *count; i++) {
+        if (names[i] && strcmp(names[i], name) == 0)
+            return true;
+    }
+    if (*count >= cap)
+        return false;
+    names[(*count)++] = name;
+    return true;
+}
+
+static bool
+tdd_estimate_collect_ops(const wl_plan_op_t *ops, uint32_t op_count,
+    const wl_plan_stratum_t *sp, const char **names, uint32_t *count,
+    uint32_t cap)
+{
+    (void)sp;
+    for (uint32_t oi = 0; oi < op_count; oi++) {
+        const wl_plan_op_t *op = &ops[oi];
+        const char *rel_name = NULL;
+        if (op->op == WL_PLAN_OP_VARIABLE) {
+            rel_name = op->relation_name;
+        } else if (op->op == WL_PLAN_OP_JOIN
+            || op->op == WL_PLAN_OP_SEMIJOIN
+            || op->op == WL_PLAN_OP_ANTIJOIN) {
+            rel_name = op->right_relation;
+        } else if (op->op == WL_PLAN_OP_K_FUSION && op->opaque_data) {
+            const wl_plan_op_k_fusion_t *kf =
+                (const wl_plan_op_k_fusion_t *)op->opaque_data;
+            for (uint32_t ki = 0; ki < kf->k; ki++) {
+                if (!tdd_estimate_collect_ops(kf->k_ops[ki],
+                    kf->k_op_counts[ki], sp, names, count, cap))
+                    return false;
+            }
+        } else if (op->op == WL_PLAN_OP_LFTJ && op->opaque_data) {
+            const wl_plan_op_lftj_t *lftj =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            for (uint32_t i = 0; i < lftj->k; i++) {
+                if (!tdd_estimate_add_rel_name(names, count, cap,
+                    lftj->rel_names ? lftj->rel_names[i] : NULL))
+                    return false;
+            }
+        }
+        if (!tdd_estimate_add_rel_name(names, count, cap, rel_name))
+            return false;
+    }
+    return true;
+}
+
 static uint64_t
 tdd_estimate_stratum_work_rows(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord)
 {
-    uint64_t stratum_rows = 0;
+    const char *names[256];
+    uint32_t name_count = 0;
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
-        if (r)
-            stratum_rows += r->nrows;
+        if (!tdd_estimate_add_rel_name(names, &name_count, 256,
+            sp->relations[ri].name))
+            goto fallback;
+        if (!tdd_estimate_collect_ops(sp->relations[ri].ops,
+            sp->relations[ri].op_count, sp, names, &name_count, 256))
+            goto fallback;
     }
 
-    uint64_t input_rows = 0;
+    uint64_t rows = 0;
+    for (uint32_t i = 0; i < name_count; i++) {
+        col_rel_t *r = session_find_rel(coord, names[i]);
+        if (r)
+            rows += r->nrows;
+    }
+    return rows;
+
+fallback:
+    rows = 0;
     for (uint32_t ri = 0; ri < coord->nrels; ri++) {
         col_rel_t *r = coord->rels[ri];
         if (r)
-            input_rows += r->nrows;
+            rows += r->nrows;
     }
-    return input_rows > stratum_rows ? input_rows : stratum_rows;
+    return rows;
 }
 
 static uint32_t

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -3953,7 +3953,7 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
         if (!tdd_relation_has_exchange_key(rel))
             return false;
         uint32_t top_joins = ops_count_join_like(rel->ops, rel->op_count);
-        if (top_joins > 2)
+        if (top_joins > 4)
             return false;
 
         for (uint32_t oi = 0; oi < rel->op_count; oi++) {
@@ -3965,7 +3965,7 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
             for (uint32_t ki = 0; ki < kf->k; ki++) {
                 uint32_t child_joins = ops_count_join_like(kf->k_ops[ki],
                         kf->k_op_counts[ki]);
-                if (child_joins > 2)
+                if (child_joins > 4)
                     return false;
             }
         }
@@ -4896,6 +4896,22 @@ tdd_choose_active_workers(const wl_plan_stratum_t *sp,
     return active;
 }
 
+static uint32_t
+tdd_global_read_worker_cap(void)
+{
+    uint32_t cap = 16;
+    const char *env = getenv("WIRELOG_TDD_GLOBAL_READ_MAX_ACTIVE_WORKERS");
+    if (env && env[0] != '\0') {
+        char *endp = NULL;
+        errno = 0;
+        unsigned long v = strtoul(env, &endp, 10);
+        if (endp != env && *endp == '\0' && errno != ERANGE && v > 0
+            && v <= UINT32_MAX)
+            cap = (uint32_t)v;
+    }
+    return cap;
+}
+
 /*
  * bdx_hash_diff:
  * Remove from delta any row that already exists in base.  This exact
@@ -5779,6 +5795,11 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             W = 1;
     }
     W = tdd_choose_active_workers(sp, coord, W, replicate_mode);
+    if (global_read_mode) {
+        uint32_t cap = tdd_global_read_worker_cap();
+        if (W > cap)
+            W = cap;
+    }
     if (W <= 1) {
         tdd_record_active_workers(coord, 1);
         if (coord->tdd_decision_tracking_active) {

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -3875,22 +3875,61 @@ stratum_max_idb_body_atoms(const wl_plan_stratum_t *sp)
     return max_count;
 }
 
-static uint32_t
-ops_count_join_like(const wl_plan_op_t *ops, uint32_t op_count)
+static bool
+op_references_stratum_idb(const wl_plan_op_t *op,
+    const wl_plan_stratum_t *sp)
 {
-    uint32_t count = 0;
+    if (op->op == WL_PLAN_OP_VARIABLE)
+        return is_stratum_idb(sp, op->relation_name);
+    if ((op->op == WL_PLAN_OP_JOIN
+        || op->op == WL_PLAN_OP_SEMIJOIN
+        || op->op == WL_PLAN_OP_ANTIJOIN)
+        && op->right_relation)
+        return is_stratum_idb(sp, op->right_relation);
+    return false;
+}
+
+static uint32_t
+ops_max_idb_segment_join_like(const wl_plan_op_t *ops, uint32_t op_count,
+    const wl_plan_stratum_t *sp)
+{
+    uint32_t max_count = 0;
+    uint32_t segment_count = 0;
+    uint32_t depth = 0;
+    bool segment_has_idb = false;
+
     for (uint32_t oi = 0; oi < op_count; oi++) {
-        switch (ops[oi].op) {
+        const wl_plan_op_t *op = &ops[oi];
+        if (op->op == WL_PLAN_OP_VARIABLE && depth >= 1) {
+            if (segment_has_idb && segment_count > max_count)
+                max_count = segment_count;
+            segment_count = 0;
+            segment_has_idb = false;
+        }
+
+        if (op_references_stratum_idb(op, sp))
+            segment_has_idb = true;
+
+        switch (op->op) {
         case WL_PLAN_OP_JOIN:
         case WL_PLAN_OP_SEMIJOIN:
         case WL_PLAN_OP_ANTIJOIN:
-            count++;
+            segment_count++;
             break;
         default:
             break;
         }
+
+        if (op->op == WL_PLAN_OP_VARIABLE) {
+            depth++;
+        } else if (op->op == WL_PLAN_OP_CONCAT && depth > 0) {
+            depth--;
+        }
     }
-    return count;
+
+    if (segment_has_idb && segment_count > max_count)
+        max_count = segment_count;
+    return max_count;
 }
 
 static uint32_t
@@ -3952,7 +3991,8 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
         const wl_plan_relation_t *rel = &sp->relations[ri];
         if (!tdd_relation_has_exchange_key(rel))
             return false;
-        uint32_t top_joins = ops_count_join_like(rel->ops, rel->op_count);
+        uint32_t top_joins = ops_max_idb_segment_join_like(rel->ops,
+                rel->op_count, sp);
         if (top_joins > 4)
             return false;
 
@@ -3963,8 +4003,8 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
             const wl_plan_op_k_fusion_t *kf =
                 (const wl_plan_op_k_fusion_t *)rel->ops[oi].opaque_data;
             for (uint32_t ki = 0; ki < kf->k; ki++) {
-                uint32_t child_joins = ops_count_join_like(kf->k_ops[ki],
-                        kf->k_op_counts[ki]);
+                uint32_t child_joins = ops_max_idb_segment_join_like(
+                    kf->k_ops[ki], kf->k_op_counts[ki], sp);
                 if (child_joins > 4)
                     return false;
             }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -3091,10 +3091,12 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                  * `right` is the cached filtered relation from filt_cache;
                  * filt_arr persists across sub-passes to avoid ephemeral
                  * hash table rebuild on every semi-naive iteration. */
-                uint64_t fhash = fnv1a_hash(op->right_filter_expr.data,
-                        op->right_filter_expr.size);
-                arr = col_session_get_filt_arrangement(sess,
-                        op->right_relation, fhash, right, rk, kc);
+                if (!sess->coordinator) {
+                    uint64_t fhash = fnv1a_hash(op->right_filter_expr.data,
+                            op->right_filter_expr.size);
+                    arr = col_session_get_filt_arrangement(sess,
+                            op->right_relation, fhash, right, rk, kc);
+                }
             }
         } else if (used_right_delta && op->right_relation && kc > 0)
             arr = col_session_get_delta_arrangement(sess, op->right_relation,
@@ -5545,6 +5547,9 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         worker_sess[d].filt_arr_entries = NULL;
         worker_sess[d].filt_arr_count = 0;
         worker_sess[d].filt_arr_cap = 0;
+        worker_sess[d].filt_cache = NULL;
+        worker_sess[d].filt_cache_count = 0;
+        worker_sess[d].filt_cache_cap = 0;
         /* Issue #196: Workers start with empty mat_cache.  Divergent rule
          * copies have ~0% cache hit rate, so inheriting parent entries
          * wastes memory without benefit. */
@@ -5769,6 +5774,13 @@ cleanup_wq:
         col_session_free_diff_arrangements(&worker_sess[d]);
         /* Free worker's private filtered arrangement cache (filt_arr_*). */
         col_session_free_filt_arrangements(&worker_sess[d]);
+        for (uint32_t i = 0; i < worker_sess[d].filt_cache_count; i++) {
+            free(worker_sess[d].filt_cache[i].rel_name);
+            free(worker_sess[d].filt_cache[i].filter_data);
+            if (worker_sess[d].filt_cache[i].filtered)
+                col_rel_destroy(worker_sess[d].filt_cache[i].filtered);
+        }
+        free(worker_sess[d].filt_cache);
         /* Free contents of pool-allocated relations before bulk destroy.
          * delta_pool_destroy frees the slab/arena but skips individually
          * malloc'd members (name, columns, col_names) -- leaks under ASAN.

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1018,7 +1018,10 @@ col_op_variable(const wl_plan_op_t *op, eval_stack_t *stack,
         delta = session_find_rel(sess, dname);
     }
 
-    if (op->delta_mode == WL_DELTA_FORCE_EMPTY) {
+    if (op->delta_mode == WL_DELTA_FORCE_EMPTY
+        || (op->delta_mode == WL_DELTA_FORCE_EMPTY_AFTER_SEED
+        && sess->tdd_outbound_only_active
+        && sess->current_iteration > 0)) {
         /* Issue #370: segment has no FORCE_DELTA — push empty to skip. */
         col_rel_t *empty = col_rel_pool_new_like(
             sess->delta_pool, "$empty_skip", full_rel);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -277,6 +277,35 @@ wl_columnar_session_tdd_stratum_is_safe(const wl_plan_stratum_t *sp,
     return stratum_max_idb_body_atoms(sp) <= 2;
 }
 
+static void
+wl_columnar_session_tdd_debug_decision(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess, bool snapshot_tdd_eligible,
+    wl_columnar_session_tdd_decision_t decision)
+{
+    const char *env = getenv("WIRELOG_TDD_DECISION_DEBUG");
+    if (!env || env[0] == '\0' || env[0] == '0')
+        return;
+
+    const char *first_rel = (sp && sp->relation_count > 0)
+        ? sp->relations[0].name : "(none)";
+    fprintf(stderr,
+        "TDD decision rel=%s recursive=%d snapshot=%d exchange=%d "
+        "safe=%d global_read_candidate=%d self_join=%d idb_atoms=%u "
+        "single_key_aligned=%d use_tdd=%d fallback=%s\n",
+        first_rel ? first_rel : "(null)",
+        sp ? (int)sp->is_recursive : 0,
+        (int)snapshot_tdd_eligible,
+        sp ? (int)wl_columnar_session_tdd_stratum_has_exchange(sp) : 0,
+        sp ? (int)wl_columnar_session_tdd_stratum_is_safe(sp, sess) : 0,
+        sp ? (int)tdd_stratum_global_read_candidate(sp) : 0,
+        sp ? (int)tdd_stratum_has_idb_self_join(sp) : 0,
+        sp ? stratum_max_idb_body_atoms(sp) : 0,
+        sp ? (int)tdd_stratum_single_idb_join_keys_exchange_aligned(sp) : 0,
+        (int)decision.use_tdd,
+        wl_columnar_session_tdd_fallback_reason_name(
+            decision.fallback_reason));
+}
+
 static wl_columnar_session_tdd_decision_t
 wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
     wl_col_session_t *sess,
@@ -290,16 +319,22 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
     if (!sp->is_recursive) {
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NON_RECURSIVE;
+        wl_columnar_session_tdd_debug_decision(sp, sess,
+            snapshot_tdd_eligible, decision);
         return decision;
     }
     if (!snapshot_tdd_eligible) {
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_SNAPSHOT_INELIGIBLE;
+        wl_columnar_session_tdd_debug_decision(sp, sess,
+            snapshot_tdd_eligible, decision);
         return decision;
     }
     if (!wl_columnar_session_tdd_stratum_has_exchange(sp)) {
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NO_EXCHANGE;
+        wl_columnar_session_tdd_debug_decision(sp, sess,
+            snapshot_tdd_eligible, decision);
         return decision;
     }
     if (!wl_columnar_session_tdd_stratum_is_safe(sp, sess)) {
@@ -307,14 +342,20 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
         if (!(env && env[0] == '0' && env[1] == '\0')
             && tdd_stratum_global_read_candidate(sp)) {
             decision.use_tdd = true;
+            wl_columnar_session_tdd_debug_decision(sp, sess,
+                snapshot_tdd_eligible, decision);
             return decision;
         }
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN;
+        wl_columnar_session_tdd_debug_decision(sp, sess,
+            snapshot_tdd_eligible, decision);
         return decision;
     }
 
     decision.use_tdd = true;
+    wl_columnar_session_tdd_debug_decision(sp, sess, snapshot_tdd_eligible,
+        decision);
     return decision;
 }
 

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1355,6 +1355,9 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->sarr_entries = NULL;
     out_worker->sarr_count = 0;
     out_worker->sarr_cap = 0;
+    out_worker->filt_arr_entries = NULL;
+    out_worker->filt_arr_count = 0;
+    out_worker->filt_arr_cap = 0;
     out_worker->filt_cache = NULL;
     out_worker->filt_cache_count = 0;
     out_worker->filt_cache_cap = 0;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2383,9 +2383,35 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
             }
         }
 
+        const char *tdd_profile = getenv("WIRELOG_TDD_STRATUM_PROFILE");
+        bool tdd_profile_active = tdd_profile && tdd_profile[0] != '\0'
+            && tdd_profile[0] != '0';
+        uint64_t stratum_t0 = tdd_profile_active ? now_ns() : 0;
+        uint64_t kfusion_base = sess->kfusion_ns;
+        uint64_t exchange_base = sess->exchange_time_ns;
+        uint64_t tdd_base = sess->tdd_total_ns;
+
         int rc = use_tdd
             ? col_eval_stratum_tdd(&plan->strata[si], sess, si)
             : col_eval_stratum(&plan->strata[si], sess, si);
+
+        if (tdd_profile_active) {
+            const char *first_rel = plan->strata[si].relation_count > 0
+                ? plan->strata[si].relations[0].name : "(none)";
+            fprintf(stderr,
+                "TDD stratum idx=%u rel=%s recursive=%d use_tdd=%d "
+                "fallback=%s "
+                "total_ms=%.3f kfusion_ms=%.3f exchange_ms=%.3f "
+                "tdd_ms=%.3f\n",
+                si, first_rel ? first_rel : "(null)",
+                (int)plan->strata[si].is_recursive, (int)use_tdd,
+                wl_columnar_session_tdd_fallback_reason_name(
+                    tdd_decision.fallback_reason),
+                (double)(now_ns() - stratum_t0) / 1e6,
+                (double)(sess->kfusion_ns - kfusion_base) / 1e6,
+                (double)(sess->exchange_time_ns - exchange_base) / 1e6,
+                (double)(sess->tdd_total_ns - tdd_base) / 1e6);
+        }
 
         if (tdd_cc_active && rc == 0 && pre_saved) {
             uint32_t *tdd_counts

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -304,7 +304,7 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
     }
     if (!wl_columnar_session_tdd_stratum_is_safe(sp, sess)) {
         const char *env = getenv("WIRELOG_TDD_GLOBAL_READ");
-        if (env && env[0] == '1'
+        if (!(env && env[0] == '0' && env[1] == '\0')
             && tdd_stratum_global_read_candidate(sp)) {
             decision.use_tdd = true;
             return decision;

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -212,12 +212,18 @@ typedef struct {
  *                       multiway delta expansion when the segment
  *                       contains no FORCE_DELTA op, preventing
  *                       wasteful full-join computation.
+ * WL_DELTA_FORCE_EMPTY_AFTER_SEED:
+ *                       Use normal AUTO selection for the seed pass, then
+ *                       force empty in outbound TDD sub-passes.  Used for
+ *                       EDB-only UNION child segments that seed a recursive
+ *                       relation once but do not need repeated evaluation.
  */
 typedef enum {
     WL_DELTA_AUTO = 0,
     WL_DELTA_FORCE_DELTA = 1,
     WL_DELTA_FORCE_FULL = 2,
     WL_DELTA_FORCE_EMPTY = 3,
+    WL_DELTA_FORCE_EMPTY_AFTER_SEED = 4,
 } wl_delta_mode_t;
 
 /* ======================================================================== */

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -1595,7 +1595,8 @@ expand_multiway_delta(const wl_plan_op_t *ops, uint32_t op_count,
     /* Per-copy segment skip (issue #370): same logic as K-fusion path.
      * Within each copy's op_count ops, neuter UNION child segments that
      * have FORCE_FULL (IDB ops from wrong rule) but no FORCE_DELTA.
-     * EDB-only segments (all AUTO) are preserved for base-case seeding. */
+     * EDB-only segments (all AUTO) are preserved for base-case seeding and
+     * skipped after the seed pass in outbound TDD evaluation. */
     for (uint32_t d = 0; d < k; d++) {
         uint32_t base = d * (op_count + 1); /* +1 for CONCAT after copy */
         uint32_t depth = 0;
@@ -1607,9 +1608,11 @@ expand_multiway_delta(const wl_plan_op_t *ops, uint32_t op_count,
             wl_plan_op_t *op = &new_ops[base + i];
 
             if (op->op == WL_PLAN_OP_VARIABLE && depth >= 1) {
-                if (seg_var_idx != UINT32_MAX && !seg_has_delta
-                    && seg_has_full)
-                    new_ops[seg_var_idx].delta_mode = WL_DELTA_FORCE_EMPTY;
+                if (seg_var_idx != UINT32_MAX && !seg_has_delta) {
+                    new_ops[seg_var_idx].delta_mode = seg_has_full
+                        ? WL_DELTA_FORCE_EMPTY
+                        : WL_DELTA_FORCE_EMPTY_AFTER_SEED;
+                }
                 seg_var_idx = base + i;
                 seg_has_delta = false;
                 seg_has_full = false;
@@ -1628,8 +1631,11 @@ expand_multiway_delta(const wl_plan_op_t *ops, uint32_t op_count,
                 depth--;
             }
         }
-        if (seg_var_idx != UINT32_MAX && !seg_has_delta && seg_has_full)
-            new_ops[seg_var_idx].delta_mode = WL_DELTA_FORCE_EMPTY;
+        if (seg_var_idx != UINT32_MAX && !seg_has_delta) {
+            new_ops[seg_var_idx].delta_mode = seg_has_full
+                ? WL_DELTA_FORCE_EMPTY
+                : WL_DELTA_FORCE_EMPTY_AFTER_SEED;
+        }
     }
 
     *out_count = wi;
@@ -1824,10 +1830,13 @@ expand_multiway_k_fusion(const wl_plan_op_t *ops, uint32_t op_count,
                 /* Finalize previous segment: neuter only if the segment
                  * has IDB ops (FORCE_FULL) but none are delta-active.
                  * EDB-only segments (all AUTO) are preserved for
-                 * base-case seeding at iteration 0. */
-                if (seg_var_idx != UINT32_MAX && !seg_has_delta
-                    && seg_has_full)
-                    seq[seg_var_idx].delta_mode = WL_DELTA_FORCE_EMPTY;
+                 * base-case seeding and skipped after the seed pass in
+                 * outbound TDD evaluation. */
+                if (seg_var_idx != UINT32_MAX && !seg_has_delta) {
+                    seq[seg_var_idx].delta_mode = seg_has_full
+                        ? WL_DELTA_FORCE_EMPTY
+                        : WL_DELTA_FORCE_EMPTY_AFTER_SEED;
+                }
                 seg_var_idx = i;
                 seg_has_delta = false;
                 seg_has_full = false;
@@ -1847,8 +1856,11 @@ expand_multiway_k_fusion(const wl_plan_op_t *ops, uint32_t op_count,
             }
         }
         /* Finalize last segment */
-        if (seg_var_idx != UINT32_MAX && !seg_has_delta && seg_has_full)
-            seq[seg_var_idx].delta_mode = WL_DELTA_FORCE_EMPTY;
+        if (seg_var_idx != UINT32_MAX && !seg_has_delta) {
+            seq[seg_var_idx].delta_mode = seg_has_full
+                ? WL_DELTA_FORCE_EMPTY
+                : WL_DELTA_FORCE_EMPTY_AFTER_SEED;
+        }
     }
 
     result->op = WL_PLAN_OP_K_FUSION;


### PR DESCRIPTION
## Summary

This PR lands preparatory TDD scheduler and profiling work for issue #659.

- Adds opt-in per-stratum TDD profiling via `WIRELOG_TDD_STRATUM_PROFILE=1`.
- Estimates TDD active worker width from the relations referenced by each stratum instead of all session relations.
- Keeps `workers=N` as an upper bound while reducing over-allocation for small TDD strata.

## Validation

- `meson test -C build wirelog:tdd_decision_stats wirelog:tdd_recursive wirelog:doop_multiworker wirelog:workers_as_cap wirelog:tdd_exchange --print-errorlogs`
- `meson test -C build wirelog:k_fusion_correctness wirelog:tdd_single_key_owner wirelog:tdd_exchange wirelog:tdd_multiworker wirelog:tdd_nonrecursive --print-errorlogs`
- `meson test -C build-asan wirelog:k_fusion_correctness wirelog:tdd_recursive --print-errorlogs`
- DOOP and CRDT benchmark tuple parity spot checks

## Notes

This is a preliminary PR. It does not close issue #659 by itself; the remaining work is to reduce the dominant unsafe/fallback strata such as `SubtypeOf` and `InitializedClass` more aggressively.
