### PR TITLE
Bump version to 0.39.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.30.0',
+  version: '0.39.0',
   license: 'LGPL-3.0',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

Bump the Meson project version from `0.30.0` to `0.39.0`.

This is only a version bump. It does not create a tag or GitHub release.

## Validation

```bash
meson setup build --reconfigure
meson introspect build --projectinfo
meson compile -C build
```
