### PR TITLE
Fix side compound delta quiescence

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1820,6 +1820,24 @@ test_delta_callback_exe = executable(
 
 test('delta_callback', test_delta_callback_exe)
 
+test_side_compound_delta_exe = executable(
+  'test_side_compound_delta',
+  files('test_side_compound_delta.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  csv_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('side_compound_delta', test_side_compound_delta_exe)
+
 # ============================================================================
 # Delta Retraction Tests (Issue #158)
 # ============================================================================

--- a/tests/test_diff_integration.c
+++ b/tests/test_diff_integration.c
@@ -2415,6 +2415,63 @@ test_edge_last_inserted_relation_updated(void)
     PASS();
 }
 
+static void
+test_edge_multiple_plain_inserts_force_full_eval(void)
+{
+    TEST("edge: multiple plain inserts force full snapshot evaluation");
+
+    const char *two_rel_src =
+        ".decl a(x: int32)\n"
+        "a(1).\n"
+        ".decl b(x: int32)\n"
+        "b(10).\n"
+        ".decl ra(x: int32)\n"
+        "ra(x) :- a(x).\n"
+        ".decl rb(x: int32)\n"
+        "rb(x) :- b(x).\n"
+        ".output ra\n"
+        ".output rb\n";
+
+    wirelog_program_t *prog;
+    wl_plan_t *plan;
+    wl_session_t *sess;
+
+    int rc = make_session(two_rel_src, &prog, &plan, &sess);
+    ASSERT(rc == 0, "session creation failed");
+
+    struct multi_rel_ctx c0 = { "ra", "rb", 0, 0 };
+    rc = wl_session_snapshot(sess, multi_count_cb, &c0);
+    ASSERT(rc == 0, "initial snapshot failed");
+    ASSERT(c0.count_a == 1 && c0.count_b == 1,
+        "initial snapshot must include both outputs");
+
+    int64_t new_a[1] = { 2 };
+    int64_t new_b[1] = { 20 };
+    rc = wl_session_insert(sess, "a", new_a, 1, 1);
+    ASSERT(rc == 0, "plain insert into a failed");
+    rc = wl_session_insert(sess, "b", new_b, 1, 1);
+    ASSERT(rc == 0, "plain insert into b failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    ASSERT(cs->last_inserted_relation != NULL
+        && strcmp(cs->last_inserted_relation, "b") == 0,
+        "last_inserted_relation must preserve the latest insert");
+    ASSERT(cs->pending_full_input_eval == true,
+        "multiple pending input relations must force full evaluation");
+
+    struct multi_rel_ctx c1 = { "ra", "rb", 0, 0 };
+    rc = wl_session_snapshot(sess, multi_count_cb, &c1);
+    ASSERT(rc == 0, "snapshot after multiple plain inserts failed");
+    printf("(ra_before=%" PRId64 " ra_after=%" PRId64
+        " rb_before=%" PRId64 " rb_after=%" PRId64 ") ",
+        c0.count_a, c1.count_a, c0.count_b, c1.count_b);
+    ASSERT(c1.count_a > c0.count_a && c1.count_b > c0.count_b,
+        "snapshot must include changes from both pending input relations");
+
+    teardown(sess, plan, prog);
+    PASS();
+}
+
 /* Test 49: TC correctness for star graph (one node connected to many) */
 static void
 test_edge_star_graph_correctness(void)
@@ -2587,6 +2644,7 @@ main(void)
     test_edge_empty_output_relation();
     test_edge_no_insert_guard_stays_false();
     test_edge_last_inserted_relation_updated();
+    test_edge_multiple_plain_inserts_force_full_eval();
     test_edge_star_graph_correctness();
     test_edge_outer_epoch_tracks_inserts();
 

--- a/tests/test_side_compound_delta.c
+++ b/tests/test_side_compound_delta.c
@@ -1,0 +1,229 @@
+/*
+ * test_side_compound_delta.c - Delta callback regression for side compounds
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog-types.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_DELTAS 64
+#define MAX_COLS 8
+
+typedef struct {
+    int count;
+    char relations[MAX_DELTAS][64];
+    int64_t rows[MAX_DELTAS][MAX_COLS];
+    uint32_t ncols[MAX_DELTAS];
+    int32_t diffs[MAX_DELTAS];
+} delta_collector_t;
+
+static void
+collect_delta(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    delta_collector_t *c = (delta_collector_t *)user_data;
+    if (c->count >= MAX_DELTAS)
+        return;
+    int idx = c->count++;
+    strncpy(c->relations[idx], relation, sizeof(c->relations[idx]) - 1);
+    c->relations[idx][sizeof(c->relations[idx]) - 1] = '\0';
+    c->ncols[idx] = ncols;
+    c->diffs[idx] = diff;
+    for (uint32_t i = 0; i < ncols && i < MAX_COLS; i++)
+        c->rows[idx][i] = row[i];
+}
+
+static wl_plan_t *
+build_plan(const char *src)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0)
+        return NULL;
+    return plan;
+}
+
+static bool
+has_delta(const delta_collector_t *deltas, const char *relation, int32_t diff)
+{
+    for (int i = 0; i < deltas->count; i++) {
+        if (strcmp(deltas->relations[i], relation) == 0
+            && deltas->diffs[i] == diff)
+            return true;
+    }
+    return false;
+}
+
+static bool
+has_row_delta(const delta_collector_t *deltas, const char *relation,
+    const int64_t *row, uint32_t ncols, int32_t diff)
+{
+    for (int i = 0; i < deltas->count; i++) {
+        if (strcmp(deltas->relations[i], relation) != 0
+            || deltas->ncols[i] != ncols || deltas->diffs[i] != diff)
+            continue;
+        bool same = true;
+        for (uint32_t c = 0; c < ncols; c++) {
+            if (deltas->rows[i][c] != row[c]) {
+                same = false;
+                break;
+            }
+        }
+        if (same)
+            return true;
+    }
+    return false;
+}
+
+static int
+run_case(uint32_t workers, bool pre_empty_step)
+{
+    const char *src =
+        ".decl __compound_guard_1(handle: int64, arg0: int64)\n"
+        ".decl __compound_guard_cmp_3(handle: int64, arg0: int64, arg1: int64, arg2: int64)\n"
+        ".decl __compound_guard_and_2(handle: int64, arg0: int64, arg1: int64)\n"
+        ".decl source(handle: int64, root: int64)\n"
+        ".decl cmp(handle: int64, field: int64, op: int64, value: int64)\n"
+        ".decl and_node(handle: int64, left: int64, right: int64)\n"
+        "source(H, R) :- __compound_guard_1(H, R).\n"
+        "cmp(H, F, O, V) :- __compound_guard_cmp_3(H, F, O, V).\n"
+        "and_node(H, L, R) :- __compound_guard_and_2(H, L, R).\n";
+
+    wl_plan_t *plan = build_plan(src);
+    if (!plan) {
+        fprintf(stderr, "could not build plan\n");
+        return 1;
+    }
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, workers, &session);
+    if (rc != 0 || !session) {
+        fprintf(stderr, "could not create session: %d\n", rc);
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    delta_collector_t deltas;
+    memset(&deltas, 0, sizeof(deltas));
+    wl_session_set_delta_cb(session, collect_delta, &deltas);
+
+    if (pre_empty_step) {
+        rc = wl_session_step(session);
+        if (rc != 0 || deltas.count != 0) {
+            fprintf(stderr,
+                "empty pre-step failed: workers=%u rc=%d deltas=%d\n",
+                workers, rc, deltas.count);
+            wl_session_destroy(session);
+            wl_plan_free(plan);
+            return 1;
+        }
+    }
+
+    uint64_t guard = 0;
+    uint64_t cmp = 0;
+    uint64_t and_node = 0;
+    wirelog_compound_arg_t guard_args[] = {
+        { WIRELOG_TYPE_INT64, 10 },
+    };
+    wirelog_compound_arg_t cmp_args[] = {
+        { WIRELOG_TYPE_INT64, 20 },
+        { WIRELOG_TYPE_INT64, 21 },
+        { WIRELOG_TYPE_INT64, 22 },
+    };
+    wirelog_compound_arg_t and_args[] = {
+        { WIRELOG_TYPE_INT64, 30 },
+        { WIRELOG_TYPE_INT64, 31 },
+    };
+
+    rc = wl_session_make_compound(session, "guard", 1, guard_args, &guard);
+    if (rc == 0)
+        rc = wl_session_make_compound(session, "guard_cmp", 3, cmp_args, &cmp);
+    if (rc == 0)
+        rc = wl_session_make_compound(session, "guard_and", 2, and_args,
+                &and_node);
+    if (rc != 0 || guard == 0 || cmp == 0 || and_node == 0) {
+        fprintf(stderr, "could not create compounds: workers=%u rc=%d\n",
+            workers, rc);
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    rc = wl_session_step(session);
+    int count_after_first_step = deltas.count;
+    if (rc == 0)
+        rc = wl_session_step(session);
+    int count_after_second_step = deltas.count;
+    if (rc == 0)
+        rc = wl_session_step(session);
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+
+    if (rc != 0) {
+        fprintf(stderr, "step failed: workers=%u rc=%d\n", workers, rc);
+        return 1;
+    }
+    int64_t expected_source[] = { (int64_t)guard, 10 };
+    int64_t expected_cmp[] = { (int64_t)cmp, 20, 21, 22 };
+    int64_t expected_and[] = { (int64_t)and_node, 30, 31 };
+    if (count_after_first_step != 3
+        || !has_row_delta(&deltas, "source", expected_source, 2, +1)
+        || !has_row_delta(&deltas, "cmp", expected_cmp, 4, +1)
+        || !has_row_delta(&deltas, "and_node", expected_and, 3, +1)
+        || has_delta(&deltas, "source", -1) || has_delta(&deltas, "cmp", -1)
+        || has_delta(&deltas, "and_node", -1)) {
+        fprintf(stderr,
+            "expected exact initial projection deltas: workers=%u got=%d\n",
+            workers, count_after_first_step);
+        return 1;
+    }
+    if (count_after_second_step != count_after_first_step
+        || deltas.count != count_after_first_step) {
+        fprintf(stderr,
+            "side compound projection emitted extra deltas: workers=%u first=%d second=%d third=%d\n",
+            workers, count_after_first_step, count_after_second_step,
+            deltas.count);
+        return 1;
+    }
+
+    return 0;
+}
+
+int
+main(void)
+{
+    if (run_case(1, false) != 0)
+        return 1;
+    if (run_case(4, false) != 0)
+        return 1;
+    if (run_case(1, true) != 0)
+        return 1;
+    return 0;
+}

--- a/wirelog/columnar/compound_side.c
+++ b/wirelog/columnar/compound_side.c
@@ -23,6 +23,35 @@
 /* Column-name buffer size: "arg" + up to 10-digit decimal + NUL. */
 #define WL_COMPOUND_SIDE_COLNAME_MAX 16u
 
+static int
+side_rel_set_schema(col_rel_t *rel, uint32_t arity)
+{
+    uint32_t ncols = arity + 1; /* +1 for the handle column */
+    char **names_owned = (char **)calloc(ncols, sizeof(char *));
+    if (!names_owned)
+        return ENOMEM;
+    char *names_buf
+        = (char *)malloc((size_t)ncols * WL_COMPOUND_SIDE_COLNAME_MAX);
+    if (!names_buf) {
+        free(names_owned);
+        return ENOMEM;
+    }
+
+    char *slot0 = names_buf;
+    snprintf(slot0, WL_COMPOUND_SIDE_COLNAME_MAX, "handle");
+    names_owned[0] = slot0;
+    for (uint32_t i = 1; i < ncols; i++) {
+        char *slot = names_buf + (size_t)i * WL_COMPOUND_SIDE_COLNAME_MAX;
+        snprintf(slot, WL_COMPOUND_SIDE_COLNAME_MAX, "arg%u", i - 1);
+        names_owned[i] = slot;
+    }
+
+    int rc = col_rel_set_schema(rel, ncols, (const char *const *)names_owned);
+    free(names_owned);
+    free(names_buf);
+    return rc;
+}
+
 int
 wl_compound_side_name(const char *functor, uint32_t arity,
     char *buf, size_t bufsz)
@@ -56,6 +85,14 @@ wl_compound_side_ensure(wl_col_session_t *sess, const char *functor,
     /* Idempotent: return existing relation if present. */
     col_rel_t *existing = session_find_rel(sess, name);
     if (existing) {
+        uint32_t ncols = arity + 1u;
+        if (existing->ncols == 0) {
+            int rc = side_rel_set_schema(existing, arity);
+            if (rc != 0)
+                return rc;
+        } else if (existing->ncols != ncols) {
+            return EINVAL;
+        }
         if (out_rel)
             *out_rel = existing;
         return 0;
@@ -67,39 +104,7 @@ wl_compound_side_ensure(wl_col_session_t *sess, const char *functor,
     if (rc != 0)
         return rc;
 
-    uint32_t ncols = arity + 1; /* +1 for the handle column */
-    /* Build the column-name array as a heap-allocated pointer array
-     * backed by a single contiguous buffer.  col_rel_set_schema takes
-     * its own copies; we free both the pointer array and the backing
-     * buffer unconditionally after the call. */
-    char **names_owned = (char **)calloc(ncols, sizeof(char *));
-    if (!names_owned) {
-        col_rel_destroy(rel);
-        return ENOMEM;
-    }
-    char *names_buf
-        = (char *)malloc((size_t)ncols * WL_COMPOUND_SIDE_COLNAME_MAX);
-    if (!names_buf) {
-        free(names_owned);
-        col_rel_destroy(rel);
-        return ENOMEM;
-    }
-
-    /* Column 0: "handle"; columns 1..N: "arg{i-1}" */
-    {
-        char *slot0 = names_buf + 0 * WL_COMPOUND_SIDE_COLNAME_MAX;
-        snprintf(slot0, WL_COMPOUND_SIDE_COLNAME_MAX, "handle");
-        names_owned[0] = slot0;
-        for (uint32_t i = 1; i < ncols; i++) {
-            char *slot = names_buf + (size_t)i * WL_COMPOUND_SIDE_COLNAME_MAX;
-            snprintf(slot, WL_COMPOUND_SIDE_COLNAME_MAX, "arg%u", i - 1);
-            names_owned[i] = slot;
-        }
-    }
-
-    rc = col_rel_set_schema(rel, ncols, (const char *const *)names_owned);
-    free(names_owned);
-    free(names_buf);
+    rc = side_rel_set_schema(rel, arity);
     if (rc != 0) {
         col_rel_destroy(rel);
         return rc;

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -886,6 +886,14 @@ typedef struct wl_col_session_t {
      * NULL when no incremental insert preceded the current step (all strata
      * evaluated normally via affected_mask = UINT64_MAX). */
     const char *last_inserted_relation;
+    /* True when an input relation changed since the last successful step.
+     * This includes hidden side-compound storage writes, which are EDB-like
+     * dependencies for plans that scan __compound_* relations. */
+    bool pending_input_change;
+    /* True when more than one inserted input relation is pending, so affected
+     * stratum selection must conservatively evaluate every stratum while
+     * preserving last_inserted_relation as the most recent input name. */
+    bool pending_full_input_eval;
     /* Current fixed-point iteration counter within col_eval_stratum.
      * Set at the start of each iteration; operators use this to distinguish
      * iteration 0 (base case: FORCE_DELTA falls back to full relation) from

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -120,6 +120,20 @@ session_invalidate_relation_caches(wl_col_session_t *sess, const char *name)
     sess->filt_cache_count = out;
 }
 
+static void
+session_note_inserted_input(wl_col_session_t *sess, const char *relation,
+    bool advance_epoch)
+{
+    session_invalidate_relation_caches(sess, relation);
+    if (advance_epoch)
+        sess->outer_epoch++;
+    if (sess->last_inserted_relation
+        && strcmp(sess->last_inserted_relation, relation) != 0)
+        sess->pending_full_input_eval = true;
+    sess->last_inserted_relation = relation;
+    sess->pending_input_change = true;
+}
+
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
@@ -1014,6 +1028,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     }
 
     sess->rel_cap = 16;
+    sess->pending_input_change = true;
     sess->rels = (col_rel_t **)calloc(sess->rel_cap, sizeof(col_rel_t *));
     if (!sess->rels) {
         free(sess);
@@ -1657,11 +1672,7 @@ col_session_insert(wl_session_t *session, const char *relation,
             return rc;
     }
 
-    /* Enable incremental re-evaluation mode: mark this relation as the
-     * insertion point for affected stratum detection. This activates
-     * frontier persistence in col_session_snapshot, enabling the per-iteration
-     * skip condition to reduce iterations on subsequent snapshots. */
-    COL_SESSION(session)->last_inserted_relation = relation;
+    session_note_inserted_input(sess, relation, false);
 
     return 0;
 }
@@ -1749,6 +1760,7 @@ col_session_make_compound(wl_session_t *session, const char *functor,
         return rc;
     }
 
+    session_note_inserted_input(sess, side_rel->name, true);
     *handle_out = handle;
     return 0;
 }
@@ -1804,21 +1816,8 @@ col_session_insert_incremental(wl_session_t *session, const char *relation,
             return rc;
     }
 
-    /* Invalidate arrangement caches for the modified relation so subsequent
-     * re-evaluation rebuilds hash indices with the new rows (issue #92). */
-    col_session_invalidate_arrangements(session, relation);
-
-    /* Issue #103: Increment outer_epoch to mark a new insertion epoch.
-     * This epoch counter distinguishes different insertion phases for 2D frontier
-     * tracking: (outer_epoch, iteration) pairs ensure iterations are skipped only
-     * within the same epoch. Wrapping at UINT32_MAX is acceptable (continues
-     * distinguishing epochs across multiple insertions). */
     wl_col_session_t *sess = COL_SESSION(session);
-    sess->outer_epoch++;
-
-    /* Record the inserted relation so col_session_step can skip unaffected
-     * strata (Phase 4 affected-stratum skip optimization). */
-    sess->last_inserted_relation = relation;
+    session_note_inserted_input(sess, relation, true);
     return 0;
 }
 
@@ -1989,11 +1988,12 @@ next_del_incr:;
      * so subsequent re-evaluation rebuilds hash indices without the removed
      * rows.  Without this, cached arrangements contain stale entries that
      * produce phantom join matches during full re-eval retraction. */
-    col_session_invalidate_arrangements(session, relation);
+    session_invalidate_relation_caches(sess, relation);
 
     /* Mark removal for affected-stratum calculation */
     sess->last_removed_relation = relation;
     sess->outer_epoch++;
+    sess->pending_input_change = true;
 
     return 0;
 }
@@ -2019,12 +2019,18 @@ col_session_step(wl_session_t *session)
     wl_col_session_t *sess = COL_SESSION(session);
     const wl_plan_t *plan = sess->plan;
 
+    if (sess->delta_cb && !sess->pending_input_change
+        && sess->last_inserted_relation == NULL
+        && sess->last_removed_relation == NULL)
+        return 0;
+
     /* Compute affected strata bitmask (Phase 4 incremental skip).
      * When last_inserted_relation is set (incremental path), only evaluate
      * strata that transitively depend on the inserted relation.  When NULL
      * (regular step), UINT64_MAX means all strata are evaluated. */
     uint64_t affected_mask = UINT64_MAX;
-    if (sess->last_inserted_relation != NULL) {
+    if (!sess->pending_full_input_eval &&
+        sess->last_inserted_relation != NULL) {
         affected_mask = col_compute_affected_strata(
             session, sess->last_inserted_relation);
     }
@@ -2119,6 +2125,8 @@ col_session_step(wl_session_t *session)
 
     /* Reset after successful eval so next plain session_step runs all strata */
     sess->last_inserted_relation = NULL;
+    sess->pending_input_change = false;
+    sess->pending_full_input_eval = false;
     return 0;
 }
 
@@ -2216,7 +2224,8 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
      * On the first snapshot (total_iterations == 0), always evaluate all strata
      * to establish the baseline. */
     uint64_t affected_mask = UINT64_MAX;
-    if (sess->last_inserted_relation != NULL && sess->total_iterations > 0) {
+    if (!sess->pending_full_input_eval && sess->last_inserted_relation != NULL
+        && sess->total_iterations > 0) {
         affected_mask = col_compute_affected_strata(
             session, sess->last_inserted_relation);
 
@@ -2341,8 +2350,9 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
      * OR incremental evaluation (last_inserted_relation != NULL). */
     bool snapshot_tdd_eligible = (affected_mask == UINT64_MAX
         && sess->num_workers > 1
-        && (sess->last_inserted_relation != NULL ||
-        sess->total_iterations == 0));
+        && ((!sess->pending_full_input_eval
+        && sess->last_inserted_relation != NULL)
+        || sess->total_iterations == 0));
     sess->tdd_decision_tracking_active = true;
     for (uint32_t si = 0; si < plan->stratum_count; si++) {
         if ((affected_mask & ((uint64_t)1 << si)) == 0)
@@ -2545,6 +2555,8 @@ col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
     /* Reset after successful eval so next plain snapshot runs all strata */
     sess->last_inserted_relation = NULL;
     sess->delta_seeded = false;
+    sess->pending_input_change = false;
+    sess->pending_full_input_eval = false;
 
     /* Issue #83: Update base_nrows for all relations after convergence.
      * This marks the current state as "stable" so the next incremental


### PR DESCRIPTION
## Summary
- Treat side compound creation as an input mutation so __compound_* storage invalidates relation caches, advances the input epoch, and marks pending work for delta evaluation.
- Initialize schemas for declared __compound_* relations before appending side-compound rows.
- Add a regression test for issue #675 covering exact projection deltas, repeated no-input step quiescence, workers=4, and side mutation after an empty step.

## Root cause
Side compound rows are EDB-like inputs, but wl_session_make_compound appended them directly to hidden __compound_* relations without the mutation bookkeeping used by normal inserts. Delta-mode step could then re-run destructive set-diff evaluation without a real input change or miss the correct affected-input state.

## Validation
- meson compile -C build
- meson test -C build side_compound_delta delta_callback delta_retraction delta_propagation compound_side_relation wl_easy --print-errorlogs

Closes #675
