### PR TITLE
fix(wl_easy): seed inline .dl facts at session build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
-- **`docs/SEMANTICS.md`** (#718): New document recording the engine's stable semantic-model decisions. First entry: inline `.dl` fact loading rules, z-set host insert/remove model, and forward compatibility with the upcoming `wirelog_session_*` advanced surface.
+- **`docs/SEMANTICS.md`** (#718): New document recording the engine's observable semantic-model decisions and the path toward 1.0 stabilization. First entry: inline `.dl` fact loading rules and the z-set host insert/remove model (status: Current).
 
 ## [0.30.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to wirelog are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **wl_easy inline-fact materialization** (#718): `wl_easy_open` now seeds inline `.dl` facts into the columnar session at first lazy build, matching the CLI driver's order-of-operations. Previously the wl_easy facade dropped every static fact silently, so snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows.
+
+### Documentation
+
+- **`docs/SEMANTICS.md`** (#718): New document recording the engine's stable semantic-model decisions. First entry: inline `.dl` fact loading rules, z-set host insert/remove model, and forward compatibility with the upcoming `wirelog_session_*` advanced surface.
+
 ## [0.30.0] - 2026-05-07
 
 ### Added

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -1,16 +1,22 @@
 # wirelog Semantic Model
 
-This document records stable, observable semantic decisions in the
-wirelog engine. Each section is an ADR-style entry: a short statement
-of the rule, the rationale, and the public-API surfaces that promise it.
+This document records observable semantic decisions in the wirelog
+engine. Each section is an ADR-style entry: a short statement of the
+rule, the rationale, and the public-API surfaces that hold it today.
 
-The intent is forward compatibility: every entry here is a contract
-the engine honors for the lifetime of the major version it shipped in,
-unless a deprecation cycle is run through `docs/MIGRATION.md`.
+Each entry is tagged with its **Status**:
+
+- **Stable** — a contract the engine honors across a major version.
+  Changes go through a deprecation cycle in `docs/MIGRATION.md`.
+- **Current** — describes what the engine does today on the path to
+  1.0. May evolve before 1.0 GA based on review or implementation
+  realities. See `stable-release-plan.md` for the trajectory.
+
+Until 1.0 ships, expect most entries to be **Current**.
 
 ---
 
-## Inline `.dl` facts
+## Inline `.dl` facts (Status: Current)
 
 ### Rule
 
@@ -70,12 +76,16 @@ Two patterns are supported:
   weighted aggregates) are subject to the engine's
   multiplicity-tracking rules, not promised by this document.
 
-### Forward compatibility
+### Forward compatibility (Future work — not yet shipped)
 
-When `wirelog/wirelog-advanced.h` and the public `wirelog_session_*`
-surface land (see `stable-release-plan.md` §3), they will share this
-exact semantic model: open-time inline-fact seeding, z-set host
-insert/remove, optional pre-check via `wirelog_program_get_facts`.
+`wirelog/wirelog-advanced.h` and the public `wirelog_session_*` surface
+do not exist in the tree yet. They are planned per
+`stable-release-plan.md` §3 and, when they land, are intended to share
+this exact semantic model: open-time inline-fact seeding, z-set host
+insert/remove, optional pre-check via `wirelog_program_get_facts`. The
+intent here is to avoid drift between the easy facade and the future
+advanced surface; this paragraph is non-binding until those headers
+actually ship.
 
 ### References
 

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -1,0 +1,87 @@
+# wirelog Semantic Model
+
+This document records stable, observable semantic decisions in the
+wirelog engine. Each section is an ADR-style entry: a short statement
+of the rule, the rationale, and the public-API surfaces that promise it.
+
+The intent is forward compatibility: every entry here is a contract
+the engine honors for the lifetime of the major version it shipped in,
+unless a deprecation cycle is run through `docs/MIGRATION.md`.
+
+---
+
+## Inline `.dl` facts
+
+### Rule
+
+Inline ground facts written in a `.dl` source (e.g.
+`role_permission("wr.system_admin", "wr.policy.write").`) are part of
+the EDB. After parsing the program, the engine seeds these facts into
+the columnar session as base rows exactly once, on the first
+plan/session build:
+
+- via `wl_easy_open` / any `wl_easy_*` lazy entry point: at first
+  build, before any host delta callback can be installed.
+- via the CLI driver: at the same point in the
+  `wl_session_create` → `wl_session_load_facts` →
+  `wl_session_load_input_files` sequence.
+
+Snapshots returned by `wl_easy_snapshot()` and IDB rows derived by the
+optimizer pipeline therefore observe inline facts on the first call,
+without any host action.
+
+### Z-set semantics for host insert / remove
+
+`wl_easy_insert()` and `wl_easy_remove()` are differential operations
+on the session's z-set state:
+
+- `wl_easy_insert(R, row)` raises the multiplicity of `row` in `R`
+  by `+1`.
+- `wl_easy_remove(R, row)` lowers it by `-1`.
+
+If a host inserts a row that is already present from the inline-fact
+seed, the row's multiplicity becomes `+2`. A subsequent
+`wl_easy_remove()` of the same row leaves multiplicity `+1`; the row
+remains observable in snapshots until both copies are retracted.
+
+This matches differential dataflow conventions and is consistent with
+`wl_session_*` (internal) and the future `wirelog_session_*` advanced
+surface (see `stable-release-plan.md` §3).
+
+### How a host can mirror static facts safely
+
+Two patterns are supported:
+
+1. **Do nothing** — the engine seeds inline facts on its own. The host
+   is free to insert *only* the facts it wants to add at runtime.
+2. **Pre-check via `wirelog_program_get_facts`** — a host that needs
+   to know which inline facts are present can iterate them and skip
+   matching rows in its mirror logic. This avoids the +2 multiplicity
+   case if the host design demands set semantics.
+
+### What is *not* promised
+
+- The relative *order* of inline-fact rows visible in a snapshot is
+  not stable across releases. Hosts must not depend on positional
+  ordering.
+- The *identity* of intern ids assigned to symbols in inline facts is
+  not stable across runs of the same program.
+- Multiplicities other than the basic z-set arithmetic above (e.g.
+  weighted aggregates) are subject to the engine's
+  multiplicity-tracking rules, not promised by this document.
+
+### Forward compatibility
+
+When `wirelog/wirelog-advanced.h` and the public `wirelog_session_*`
+surface land (see `stable-release-plan.md` §3), they will share this
+exact semantic model: open-time inline-fact seeding, z-set host
+insert/remove, optional pre-check via `wirelog_program_get_facts`.
+
+### References
+
+- `wirelog/wl_easy.c` — `ensure_plan_built` performs the seed.
+- `wirelog/session_facts.c` — backend-agnostic loader.
+- `wirelog/cli/driver.c` — the canonical sequence the easy facade mirrors.
+- `wirelog/wirelog.h` — `wirelog_program_get_facts` for host pre-check.
+- `CHANGELOG.md` — entry for #718.
+- `stable-release-plan.md` §3, §7 — public-surface and conformance plans.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3541,6 +3541,25 @@ test_wl_easy_exe = executable(
 
 test('wl_easy', test_wl_easy_exe)
 
+# Issue #718: inline .dl static-fact materialization regression.
+test_wl_easy_inline_facts_exe = executable(
+  'test_wl_easy_inline_facts',
+  files('test_wl_easy_inline_facts.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  '../wirelog/wl_easy.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('wl_easy_inline_facts', test_wl_easy_inline_facts_exe)
+
 # ============================================================================
 # Baseline .input Fixture Snapshot Tests (Issue #448)
 # ============================================================================

--- a/tests/test_wl_easy_inline_facts.c
+++ b/tests/test_wl_easy_inline_facts.c
@@ -1,0 +1,122 @@
+/*
+ * test_wl_easy_inline_facts.c - Issue #718 regression test.
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * Static facts declared in a `.dl` program must materialize into snapshots
+ * and IDB derivations when the host opens the program through wl_easy.
+ * Pre-fix, wl_easy never invoked wl_session_load_facts, so static rows
+ * never reached col_rel_t and every downstream observation (snapshot,
+ * derived IDB, host-mirrored insert) silently disagreed with the .dl
+ * program.
+ */
+
+#include "wirelog/wl_easy.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+static const char *PROG_SRC =
+    ".decl role_permission(role:symbol,perm:symbol)\n"
+    ".decl member_of(user:symbol,role:symbol,scope:symbol)\n"
+    ".decl effective_permission(role:symbol,perm:symbol)\n"
+    ".decl has_permission(user:symbol,perm:symbol,scope:symbol)\n"
+    "role_permission(\"wr.system_admin\", \"wr.policy.write\").\n"
+    "effective_permission(R, P) :- role_permission(R, P).\n"
+    "has_permission(U, P, S) :- "
+    "  member_of(U, R, S), effective_permission(R, P).\n";
+
+struct count_state {
+    uint32_t rows;
+};
+
+static void
+count_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    struct count_state *st = (struct count_state *)user_data;
+    st->rows++;
+}
+
+/* T1: a static-only EDB must drive a derived IDB during snapshot
+*     evaluation (single-rule case).  This is the simplest shape of
+*     #718: without inline-fact seeding the IDB has zero rows. */
+static int
+test_static_fact_drives_idb_snapshot(void)
+{
+    wl_easy_session_t *s = NULL;
+    wirelog_error_t err = wl_easy_open(PROG_SRC, &s);
+    if (err != WIRELOG_OK || !s)
+        return 1;
+
+    struct count_state st = { 0 };
+    err = wl_easy_snapshot(s, "effective_permission", count_rows, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T1 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 1) {
+        fprintf(stderr,
+            "T1: expected 1 effective_permission row, got %u\n", st.rows);
+        rc = 1;
+    }
+    wl_easy_close(s);
+    return rc;
+}
+
+/* T2: a host-inserted EDB row must compose with a static .dl fact across
+ *     a multi-body rule (the issue's RBAC join shape). */
+static int
+test_static_fact_joins_with_host_insert(void)
+{
+    wl_easy_session_t *s = NULL;
+    wirelog_error_t err = wl_easy_open(PROG_SRC, &s);
+    if (err != WIRELOG_OK || !s)
+        return 1;
+
+    int64_t alice = wl_easy_intern(s, "alice");
+    int64_t admin = wl_easy_intern(s, "wr.system_admin");
+    int64_t global = wl_easy_intern(s, "global");
+    if (alice < 0 || admin < 0 || global < 0) {
+        wl_easy_close(s);
+        return 1;
+    }
+    int64_t row[3] = { alice, admin, global };
+    err = wl_easy_insert(s, "member_of", row, 3);
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T2 insert err=%d\n", err);
+        wl_easy_close(s);
+        return 1;
+    }
+
+    struct count_state st = { 0 };
+    err = wl_easy_snapshot(s, "has_permission", count_rows, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T2 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 1) {
+        fprintf(stderr,
+            "T2: expected 1 has_permission row, got %u\n", st.rows);
+        rc = 1;
+    }
+    wl_easy_close(s);
+    return rc;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+    failures += test_static_fact_drives_idb_snapshot();
+    failures += test_static_fact_joins_with_host_insert();
+    if (failures == 0)
+        printf("test_wl_easy_inline_facts: OK\n");
+    else
+        printf("test_wl_easy_inline_facts: %d failure(s)\n", failures);
+    return failures;
+}

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -30,6 +30,7 @@
 #include "wirelog/passes/jpp.h"
 #include "wirelog/passes/sip.h"
 #include "wirelog/session.h"
+#include "wirelog/session_facts.h"
 #include "wirelog/wirelog-parser.h"
 #include "wirelog/wirelog-types.h"
 
@@ -82,6 +83,20 @@ ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
     if (rc != 0 || !session) {
         wl_plan_free(plan);
         return (rc == ENOMEM) ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
+    }
+
+    /* Issue #718: seed inline `.dl` facts into the freshly built session
+     * so snapshots and IDB derivations observe them, matching the CLI
+     * driver's order-of-operations (cli/driver.c:397).  The load runs
+     * exactly once on the lazy plan/session boundary, before any host
+     * delta callback can be installed, so col_session_insert takes the
+     * non-incremental path: no spurious static deltas on the first
+     * step() and no outer-epoch advance. */
+    rc = wl_session_load_facts(session, s->prog);
+    if (rc != 0) {
+        wl_session_destroy(session);
+        wl_plan_free(plan);
+        return WIRELOG_ERR_EXEC;
     }
 
     s->plan = plan;

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -86,12 +86,16 @@ ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
     }
 
     /* Issue #718: seed inline `.dl` facts into the freshly built session
-     * so snapshots and IDB derivations observe them, matching the CLI
-     * driver's order-of-operations (cli/driver.c:397).  The load runs
-     * exactly once on the lazy plan/session boundary, before any host
-     * delta callback can be installed, so col_session_insert takes the
-     * non-incremental path: no spurious static deltas on the first
-     * step() and no outer-epoch advance. */
+     * so snapshots and IDB derivations observe them.  This mirrors the
+     * fact-load step of the CLI driver's session-build sequence
+     * (cli/driver.c:397); the wider optimizer pipeline alignment
+     * between wl_easy (fusion + jpp + sip) and the CLI (which also
+     * runs subsumption + magic_sets) is tracked separately and is not
+     * in scope here.  The load runs exactly once on the lazy
+     * plan/session boundary, before any host delta callback can be
+     * installed, so col_session_insert takes the non-incremental path:
+     * no spurious static deltas on the first step() and no outer-epoch
+     * advance. */
     rc = wl_session_load_facts(session, s->prog);
     if (rc != 0) {
         wl_session_destroy(session);

--- a/wirelog/wl_easy.h
+++ b/wirelog/wl_easy.h
@@ -132,6 +132,15 @@ wl_easy_open_opts(const char *dl_src,
  * first step-class call; the intern table is shared through the whole
  * session lifetime.
  *
+ * Inline `.dl` facts (e.g. `edge("a", "b").`) are seeded into the session
+ * as base rows at first lazy build, before any host delta callback can be
+ * installed.  Snapshots and IDB derivations therefore observe them.  Host
+ * inserts of the same row add a second multiplicity (z-set semantics): a
+ * subsequent wl_easy_remove() decrements one multiplicity, so a host that
+ * mirrors a static fact and later retracts must mirror the retract too.
+ * Hosts that need to know which rows are already present from the source
+ * can read them via wirelog_program_get_facts().
+ *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_PARSE on parse failure,
  * WIRELOG_ERR_MEMORY on allocation failure, or another wirelog_error_t on
  * other failure modes.  *out is set to NULL on error.


### PR DESCRIPTION
## Summary

- `wl_easy_open` never invoked `wl_session_load_facts`, so static facts declared in a `.dl` source never reached the columnar session as base rows. Snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows, while the CLI driver loaded the same program correctly.
- Seed inline facts inside `ensure_plan_built()`, exactly once on the lazy plan/session boundary, before any host delta callback can be installed. `col_session_insert` takes the non-incremental path: no spurious static deltas on the first `step()` and no outer-epoch advance.
- New regression test `tests/test_wl_easy_inline_facts.c` covers the issue's RBAC join shape: a static `role_permission` EDB drives `effective_permission`, and a host-inserted `member_of` row composes through `has_permission`.
- Document the chosen semantics in `docs/SEMANTICS.md` (Status: Current), with explicit Stable / Current entry markers so pre-1.0 ADRs read as evolving rather than locked contracts. Forward-compatibility paragraph for the planned `wirelog/wirelog-advanced.h` surface is marked "Future work — not yet shipped".

## Commits

- `bf700ad fix(wl_easy): seed inline .dl facts at session build` (the fix + regression test)
- `49543d0 docs: record inline-fact materialization semantics` (SEMANTICS.md, wl_easy.h docstring, CHANGELOG)
- `5984343 docs: tighten inline-fact semantics framing` (review-driven: correct CLI parity claim, add Current/Stable markers, scope CHANGELOG tone)

## Test plan

- [x] `meson test -C build wl_easy_inline_facts` — passes (3 tests, RBAC join shape).
- [x] `meson test -C build wl_easy` — passes (29/29 regressions).
- [x] `meson test -C build` full suite — 210 OK / 0 FAIL / 7 skipped on this branch.
- [x] TDD red verification: with the fix stashed, the new test fails (`expected 1, got 0`); restoring the fix turns it green.
- [ ] CI matrix on push (Linux GCC + Clang, macOS Clang, Windows MSVC, ARM64) — pending.

## Out of scope (follow-up)

- wl_easy ↔ CLI optimizer-pipeline divergence (subsumption + magic_sets gap).
- Conformance suite scaffold under `tests/conformance/` per `stable-release-plan.md` §7.1.
- Stale public-header docs for `wirelog_load_all_facts` / `wirelog_load_input_files` referencing a void* worker that no longer exists.

Closes #718.