### PR TITLE
feat(api): introduce wirelog/wirelog-advanced.h public surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to wirelog are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`wirelog/wirelog-advanced.h`** (#717, #703): New public header exposing the fine-grained `wirelog_session_*` API as the stable peer of `wl_easy`. Eight thin wrappers (`create` / `destroy` / `insert` / `remove` / `step` / `set_delta_cb` / `snapshot` / `make_compound`) over the internal session primitives. Backend selection through the `wirelog_backend_kind_t` enum (`DEFAULT` / `COLUMNAR`) — no vtable exposure. Inline `.dl` facts are seeded eagerly at `wirelog_session_create()` time, matching the wl_easy contract from #718. Internal `wl_session_*` and `wl_compute_backend_t` remain private.
+- **CI guard** (#717): `scripts/ci/check-advanced-header.sh` (suite `abi`) fails when `wirelog/wirelog-advanced.h` includes any internal header.
+
 ### Fixed
 
 - **wl_easy inline-fact materialization** (#718): `wl_easy_open` now seeds inline `.dl` facts into the columnar session at first lazy build, matching the CLI driver's order-of-operations. Previously the wl_easy facade dropped every static fact silently, so snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows.
 
 ### Documentation
 
-- **`docs/SEMANTICS.md`** (#718): New document recording the engine's observable semantic-model decisions and the path toward 1.0 stabilization. First entry: inline `.dl` fact loading rules and the z-set host insert/remove model (status: Current).
+- **README.md** (#717): replace the now-misleading `wl_session_*` / `wirelog/session.h` advisory with `wirelog_session_*` / `wirelog/wirelog-advanced.h`. The internal session header is explicitly called out as private.
+- **`docs/SEMANTICS.md`** (#717, #718): record observable semantic-model decisions and the path toward 1.0 stabilization. Inline `.dl` fact loading rules + z-set host insert/remove model (status: Current). Promote the cross-facade parity section to Current now that the advanced surface ships.
 
 ## [0.30.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to wirelog are documented in this file.
 ### Documentation
 
 - **README.md** (#717): replace the now-misleading `wl_session_*` / `wirelog/session.h` advisory with `wirelog_session_*` / `wirelog/wirelog-advanced.h`. The internal session header is explicitly called out as private.
-- **`docs/SEMANTICS.md`** (#717, #718): record observable semantic-model decisions and the path toward 1.0 stabilization. Inline `.dl` fact loading rules + z-set host insert/remove model (status: Current). Promote the cross-facade parity section to Current now that the advanced surface ships.
+- **`docs/SEMANTICS.md`** (#718): new document recording the engine's observable semantic-model decisions and the path toward 1.0 stabilization. First entry: inline `.dl` fact loading rules and the z-set host insert/remove model (status: Current).
+- **`docs/SEMANTICS.md`** (#717): promote the cross-facade parity section from Future to Current now that the advanced surface ships.
+- **`wirelog/wirelog.h`** (#717): expand the `wirelog_executor_t` docstring to clarify that it is the batch facade and to point at `wirelog_session_t` / `wl_easy_session_t` for incremental delta-callback workflows.
 
 ## [0.30.0] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ meson setup build && meson compile -C build
 meson test -C build
 ```
 
-For fine-grained control over plans, backends, or worker counts, use the `wl_session_*` primitives in `wirelog/session.h`.
+For fine-grained control over plans, backends, or worker counts, use the `wirelog_session_*` API in [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h). The internal `wl_session_*` primitives in `wirelog/session.h` are not part of the installed surface and may change without notice.
 
 ## Features
 
@@ -257,7 +257,7 @@ external-consumer audit.
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [CLA.md](CLA.md) -- Contributor License Agreement (required for dual licensing)
-- API: [`wirelog/wl_easy.h`](wirelog/wl_easy.h) (simple) | [`wirelog/session.h`](wirelog/session.h) (advanced)
+- API: [`wirelog/wl_easy.h`](wirelog/wl_easy.h) (simple) | [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h) (advanced)
 
 ## License
 

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -76,16 +76,18 @@ Two patterns are supported:
   weighted aggregates) are subject to the engine's
   multiplicity-tracking rules, not promised by this document.
 
-### Forward compatibility (Future work — not yet shipped)
+### Cross-facade parity (Status: Current)
 
-`wirelog/wirelog-advanced.h` and the public `wirelog_session_*` surface
-do not exist in the tree yet. They are planned per
-`stable-release-plan.md` §3 and, when they land, are intended to share
-this exact semantic model: open-time inline-fact seeding, z-set host
-insert/remove, optional pre-check via `wirelog_program_get_facts`. The
-intent here is to avoid drift between the easy facade and the future
-advanced surface; this paragraph is non-binding until those headers
-actually ship.
+`wirelog/wirelog-advanced.h` ships the public `wirelog_session_*` surface
+as the advanced peer of `wl_easy`. Both facades share this exact
+semantic model: open-time inline-fact seeding, z-set host insert/remove,
+optional pre-check via `wirelog_program_get_facts`. This is the contract
+that prevents behavioral drift between the easy and advanced surfaces.
+
+Internal `wl_session_*` and `wl_compute_backend_t` remain private. The
+advanced API exposes backend selection through the
+`wirelog_backend_kind_t` enum (`DEFAULT`, `COLUMNAR`); new backends
+will appear as additive enum values in future minor releases.
 
 ### References
 

--- a/meson.build
+++ b/meson.build
@@ -227,6 +227,7 @@ wirelog_sources += wirelog_workqueue_src
 wirelog_sources += wirelog_io_src
 wirelog_sources += wirelog_string_ops_src
 wirelog_sources += wirelog_wl_easy_src
+wirelog_sources += wirelog_advanced_src
 wirelog_sources += wirelog_util_log_src
 
 #Public headers
@@ -238,6 +239,7 @@ wirelog_public_headers = [
   'wirelog/wirelog-optimizer.h',
   'wirelog/wirelog-export.h',
   'wirelog/wl_easy.h',
+  'wirelog/wirelog-advanced.h',
 ]
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==

--- a/scripts/ci/check-advanced-header.sh
+++ b/scripts/ci/check-advanced-header.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# check-advanced-header.sh - Issue #717 / #703 ABI guard.
+#
+# wirelog/wirelog-advanced.h is a public header.  It must not include
+# any internal header that the project keeps unshipped (session.h,
+# backend.h, exec_plan.h, exec_plan_gen.h, intern.h, session_facts.h,
+# wirelog-internal.h).  External consumers see only what this script
+# allows; any leak here is a 1.0 ABI risk.
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+HEADER="$REPO_ROOT/wirelog/wirelog-advanced.h"
+
+die() {
+    printf 'check-advanced-header: %s\n' "$1" >&2
+    exit 1
+}
+
+[ -f "$HEADER" ] || die "header not found: $HEADER"
+
+FORBIDDEN='session\.h|backend\.h|exec_plan\.h|exec_plan_gen\.h|intern\.h|session_facts\.h|wirelog-internal\.h'
+
+leak=$(grep -nE "^[[:space:]]*#include.*($FORBIDDEN)" "$HEADER" || true)
+if [ -n "$leak" ]; then
+    printf 'check-advanced-header: internal header leaked into public surface:\n%s\n' "$leak" >&2
+    exit 1
+fi
+
+printf 'check-advanced-header: OK\n'
+exit 0

--- a/scripts/ci/check-advanced-header.sh
+++ b/scripts/ci/check-advanced-header.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 # check-advanced-header.sh - Issue #717 / #703 ABI guard.
 #
-# wirelog/wirelog-advanced.h is a public header.  It must not include
-# any internal header that the project keeps unshipped (session.h,
-# backend.h, exec_plan.h, exec_plan_gen.h, intern.h, session_facts.h,
-# wirelog-internal.h).  External consumers see only what this script
-# allows; any leak here is a 1.0 ABI risk.
+# wirelog/wirelog-advanced.h is a public header.  Internal headers
+# anywhere in the wirelog/ tree must NOT leak through it.  The check
+# is allowlist-based: any quoted include not on the allowlist fails.
+# System includes (<stdint.h>, <stddef.h>, ...) are unconstrained.
 
 set -e
 
@@ -20,11 +19,14 @@ die() {
 
 [ -f "$HEADER" ] || die "header not found: $HEADER"
 
-FORBIDDEN='session\.h|backend\.h|exec_plan\.h|exec_plan_gen\.h|intern\.h|session_facts\.h|wirelog-internal\.h'
+ALLOWED='#include[[:space:]]*"wirelog/(wirelog\.h|wirelog-types\.h|wirelog-parser\.h|wirelog-ir\.h|wirelog-optimizer\.h|wirelog-export\.h|wl_easy\.h|wirelog-advanced\.h|io/io_adapter\.h)"[[:space:]]*$'
 
-leak=$(grep -nE "^[[:space:]]*#include.*($FORBIDDEN)" "$HEADER" || true)
-if [ -n "$leak" ]; then
-    printf 'check-advanced-header: internal header leaked into public surface:\n%s\n' "$leak" >&2
+quoted_includes=$(grep -nE '^[[:space:]]*#include[[:space:]]*"' "$HEADER" || true)
+suspicious=$(printf '%s\n' "$quoted_includes" | grep -vE "$ALLOWED" || true)
+
+if [ -n "$suspicious" ]; then
+    printf 'check-advanced-header: internal or unlisted header in public surface:\n%s\n' "$suspicious" >&2
+    printf '\nallowed quoted includes (allowlist):\n  wirelog/wirelog.h\n  wirelog/wirelog-types.h\n  wirelog/wirelog-parser.h\n  wirelog/wirelog-ir.h\n  wirelog/wirelog-optimizer.h\n  wirelog/wirelog-export.h\n  wirelog/wl_easy.h\n  wirelog/wirelog-advanced.h\n  wirelog/io/io_adapter.h\n' >&2
     exit 1
 fi
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -367,6 +367,12 @@ if not is_windows
        find_program(meson.project_source_root() / 'scripts/ci/check-wl-easy-opts-symbol.sh'),
        args: [meson.project_build_root()],
        suite: 'abi')
+  # Issue #717 / #703: wirelog/wirelog-advanced.h must not leak any
+  # internal header (session.h, backend.h, exec_plan*.h, intern.h,
+  # session_facts.h, wirelog-internal.h) into the installed surface.
+  test('advanced_abi_header',
+       find_program(meson.project_source_root() / 'scripts/ci/check-advanced-header.sh'),
+       suite: 'abi')
 endif
 
 test_intern_exe = executable(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3566,6 +3566,26 @@ test_wl_easy_inline_facts_exe = executable(
 
 test('wl_easy_inline_facts', test_wl_easy_inline_facts_exe)
 
+# Issue #717 / #703: behavioral-parity test for the advanced session API.
+test_wirelog_advanced_exe = executable(
+  'test_wirelog_advanced',
+  files('test_wirelog_advanced.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  '../wirelog/wl_easy.c',
+  '../wirelog/wirelog_advanced.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('wirelog_advanced', test_wirelog_advanced_exe)
+
 # ============================================================================
 # Baseline .input Fixture Snapshot Tests (Issue #448)
 # ============================================================================

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -130,10 +130,10 @@ test_create_invalid_backend(void)
     wirelog_error_t err
         = wirelog_session_create(prog, (wirelog_backend_kind_t)999, 1, &s);
     int rc = 0;
-    if (err == WIRELOG_OK || s != NULL) {
+    if (err != WIRELOG_ERR_EXEC || s != NULL) {
         fprintf(stderr,
-            "T3: bad backend should reject, got err=%d s=%p\n", err,
-            (void *)s);
+            "T3: bad backend should reject with ERR_EXEC, got err=%d s=%p\n",
+            err, (void *)s);
         rc = 1;
     }
     wirelog_program_free(prog);
@@ -270,6 +270,17 @@ test_null_safety(void)
         rc = 1;
     if (wirelog_session_set_delta_cb(NULL, NULL, NULL) != WIRELOG_ERR_EXEC)
         rc = 1;
+    if (wirelog_session_snapshot(NULL, count_rows, NULL) != WIRELOG_ERR_EXEC)
+        rc = 1;
+    uint64_t handle = WIRELOG_COMPOUND_HANDLE_NULL + 1;
+    if (wirelog_session_make_compound(NULL, "f", 1, NULL, &handle)
+        != WIRELOG_ERR_EXEC)
+        rc = 1;
+    if (handle != WIRELOG_COMPOUND_HANDLE_NULL) {
+        fprintf(stderr,
+            "T7: make_compound(NULL) must pre-clear handle_out\n");
+        rc = 1;
+    }
 
     wirelog_program_t *prog = parse_or_die(PROG_SRC, "T7");
     if (!prog)

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -1,0 +1,310 @@
+/*
+ * test_wirelog_advanced.c - public wirelog_session_* surface tests (#717).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * Behavioral parity tests for the advanced session API.  Each test
+ * exercises one observable wl_easy-equivalent invariant so the two
+ * facades cannot drift apart silently.
+ */
+
+#include "wirelog/wirelog-advanced.h"
+#include "wirelog/wirelog.h"
+#include "wirelog/intern.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+static const char *PROG_SRC =
+    ".decl edge(a:symbol,b:symbol)\n"
+    ".decl path(a:symbol,b:symbol)\n"
+    "path(X,Y) :- edge(X,Y).\n"
+    "path(X,Z) :- path(X,Y), edge(Y,Z).\n";
+
+static const char *PROG_RBAC_SRC =
+    ".decl role_permission(role:symbol,perm:symbol)\n"
+    ".decl member_of(user:symbol,role:symbol,scope:symbol)\n"
+    ".decl effective_permission(role:symbol,perm:symbol)\n"
+    ".decl has_permission(user:symbol,perm:symbol,scope:symbol)\n"
+    "role_permission(\"wr.system_admin\", \"wr.policy.write\").\n"
+    "effective_permission(R, P) :- role_permission(R, P).\n"
+    "has_permission(U, P, S) :- "
+    "  member_of(U, R, S), effective_permission(R, P).\n";
+
+struct count_state {
+    uint32_t rows;
+};
+
+struct delta_state {
+    uint32_t inserts;
+    uint32_t removes;
+};
+
+static void
+count_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    struct count_state *st = (struct count_state *)user_data;
+    st->rows++;
+}
+
+static void
+count_deltas(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    struct delta_state *st = (struct delta_state *)user_data;
+    if (diff > 0)
+        st->inserts++;
+    else if (diff < 0)
+        st->removes++;
+}
+
+static wirelog_program_t *
+parse_or_die(const char *src, const char *what)
+{
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "%s: parse failed err=%d\n", what, err);
+        return NULL;
+    }
+    return prog;
+}
+
+/* T1: create / destroy with default backend; program ownership stays
+ *     with the caller (destroy must not free it). */
+static int
+test_create_destroy_basic(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T1");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s);
+    int rc = 0;
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T1 create err=%d\n", err);
+        rc = 1;
+    }
+    wirelog_session_destroy(s);
+    /* Program must still be valid after session destroy. */
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T2: explicit columnar selection works the same as DEFAULT. */
+static int
+test_create_columnar(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T2");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_COLUMNAR, 1, &s);
+    int rc = (err == WIRELOG_OK && s) ? 0 : 1;
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T3: invalid backend value rejects with WIRELOG_ERR_EXEC and *out is NULL. */
+static int
+test_create_invalid_backend(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T3");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = (wirelog_session_t *)0xdeadbeef;
+    wirelog_error_t err
+        = wirelog_session_create(prog, (wirelog_backend_kind_t)999, 1, &s);
+    int rc = 0;
+    if (err == WIRELOG_OK || s != NULL) {
+        fprintf(stderr,
+            "T3: bad backend should reject, got err=%d s=%p\n", err,
+            (void *)s);
+        rc = 1;
+    }
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T4: inline `.dl` facts must materialize into snapshot derivations on
+ *     the advanced facade just like wl_easy (#718 contract carries over). */
+static int
+test_inline_facts_seeded(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_RBAC_SRC, "T4");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s);
+    if (err != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    struct count_state st = { 0 };
+    err = wirelog_session_snapshot(s, count_rows, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T4 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows == 0) {
+        fprintf(stderr,
+            "T4: expected static-fact-derived rows, got 0\n");
+        rc = 1;
+    }
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T5: delta callback fires on host insert + step. */
+static int
+test_insert_step_delta(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T5");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    struct delta_state st = { 0, 0 };
+    if (wirelog_session_set_delta_cb(s, count_deltas, &st) != WIRELOG_OK) {
+        wirelog_session_destroy(s);
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    /* Intern via the program's intern table.  A and B as new symbols. */
+    wl_intern_t *intern
+        = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t a = wl_intern_put(intern, "a");
+    int64_t b = wl_intern_put(intern, "b");
+    if (a < 0 || b < 0) {
+        wirelog_session_destroy(s);
+        wirelog_program_free(prog);
+        return 1;
+    }
+    int64_t row[2] = { a, b };
+    int rc = 0;
+    if (wirelog_session_insert(s, "edge", row, 1, 2) != WIRELOG_OK) {
+        fprintf(stderr, "T5 insert err\n");
+        rc = 1;
+    } else if (wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T5 step err\n");
+        rc = 1;
+    } else if (st.inserts == 0) {
+        fprintf(stderr, "T5: expected delta inserts > 0, got 0\n");
+        rc = 1;
+    }
+
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T6: insert / remove pair leaves the relation back at zero. */
+static int
+test_insert_remove_roundtrip(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T6");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    wl_intern_t *intern
+        = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t a = wl_intern_put(intern, "a");
+    int64_t b = wl_intern_put(intern, "b");
+    int64_t row[2] = { a, b };
+
+    int rc = 0;
+    if (wirelog_session_insert(s, "edge", row, 1, 2) != WIRELOG_OK
+        || wirelog_session_remove(s, "edge", row, 1, 2) != WIRELOG_OK) {
+        fprintf(stderr, "T6 insert/remove failed\n");
+        rc = 1;
+    }
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* T7: NULL-safe destroy and NULL-guard returns. */
+static int
+test_null_safety(void)
+{
+    int rc = 0;
+    wirelog_session_destroy(NULL); /* must not crash */
+
+    if (wirelog_session_step(NULL) != WIRELOG_ERR_EXEC)
+        rc = 1;
+    if (wirelog_session_insert(NULL, "r", NULL, 0, 0) != WIRELOG_ERR_EXEC)
+        rc = 1;
+    if (wirelog_session_remove(NULL, "r", NULL, 0, 0) != WIRELOG_ERR_EXEC)
+        rc = 1;
+    if (wirelog_session_set_delta_cb(NULL, NULL, NULL) != WIRELOG_ERR_EXEC)
+        rc = 1;
+
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T7");
+    if (!prog)
+        return rc | 1;
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(NULL, WIRELOG_BACKEND_DEFAULT, 1, &s);
+    if (err != WIRELOG_ERR_EXEC || s != NULL) {
+        fprintf(stderr, "T7 create(NULL prog) leaked: err=%d s=%p\n",
+            err, (void *)s);
+        rc = 1;
+    }
+    err = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, NULL);
+    if (err != WIRELOG_ERR_EXEC) {
+        fprintf(stderr, "T7 create(NULL out) wrong err=%d\n", err);
+        rc = 1;
+    }
+    wirelog_program_free(prog);
+    return rc;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+    failures += test_create_destroy_basic();
+    failures += test_create_columnar();
+    failures += test_create_invalid_backend();
+    failures += test_inline_facts_seeded();
+    failures += test_insert_step_delta();
+    failures += test_insert_remove_roundtrip();
+    failures += test_null_safety();
+    if (failures == 0)
+        printf("test_wirelog_advanced: OK\n");
+    else
+        printf("test_wirelog_advanced: %d failure(s)\n", failures);
+    return failures;
+}

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -126,6 +126,12 @@ wirelog_string_ops_src = files('string_ops.c', )
 
 wirelog_wl_easy_src = files('wl_easy.c', )
 
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+#Advanced session API (Issue #717 / #703)
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+
+wirelog_advanced_src = files('wirelog_advanced.c', )
+
 #==================================================================================
 # Util / Logger Module (Issue #287 - GST_DEBUG-style structured logging)
 #==================================================================================

--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -1,0 +1,244 @@
+/*
+ * wirelog-advanced.h - wirelog fine-grained session API (Issue #717 / #703)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+/**
+ * @file wirelog-advanced.h
+ *
+ * Fine-grained session API.  This header is the public counterpart to the
+ * convenience facade in <wirelog/wl_easy.h>: it lets a host pick the
+ * compute backend, the worker count, and drive the session through the
+ * same insert / remove / step / snapshot / set_delta_cb / make_compound
+ * surface that wl_easy wraps.
+ *
+ * Status: Current.  The signatures and semantics here are stable for the
+ * 0.x series and are intended to freeze at 1.0; see docs/SEMANTICS.md and
+ * stable-release-plan.md §3.
+ *
+ * The internal wl_session_* primitives in wirelog/session.h are not part
+ * of the installed public surface and may change without notice between
+ * minor releases.  External users must use this header (or wl_easy.h).
+ */
+
+#ifndef WIRELOG_ADVANCED_H
+#define WIRELOG_ADVANCED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "wirelog/wirelog.h"
+#include "wirelog/wirelog-types.h"
+
+#include <stdint.h>
+
+/**
+ * wirelog_session_t:
+ *
+ * Opaque advanced-session handle.  Allocated by wirelog_session_create()
+ * and released by wirelog_session_destroy().  The pointer width and
+ * struct layout are unspecified; callers must not sizeof, dereference,
+ * or cast the handle.
+ *
+ * Thread safety: A wirelog_session_t is NOT thread-safe.  Any two
+ * concurrent calls on the same session pointer race on the underlying
+ * program, plan and session state.  Callers MUST serialize access (e.g.
+ * with an external mutex) if they share a session across threads.
+ * Independent sessions created by separate wirelog_session_create()
+ * calls may be used on different threads provided no derived state
+ * (rows, callback user_data, intern ids) is shared between them.
+ */
+typedef struct wirelog_session wirelog_session_t;
+
+/**
+ * wirelog_backend_kind_t:
+ *
+ * Selector for the compute backend used by a session.  Backends are
+ * ABI-additive: new values may appear in future minor releases, but
+ * existing values never change.  Callers that switch on this enum
+ * should default to a conservative path for unknown values.
+ *
+ * - WIRELOG_BACKEND_DEFAULT: let the engine pick.  Today this maps to
+ *   the columnar backend; future releases may change the default
+ *   without breaking ABI.
+ * - WIRELOG_BACKEND_COLUMNAR: explicit columnar (Pure C11) backend.
+ */
+typedef enum {
+    WIRELOG_BACKEND_DEFAULT  = 0,
+    WIRELOG_BACKEND_COLUMNAR = 1,
+} wirelog_backend_kind_t;
+
+/**
+ * wirelog_session_create:
+ * @program:     Parsed and (optionally) optimized program.  The session
+ *               BORROWS the program; the caller retains ownership and
+ *               MUST keep it alive for the lifetime of the session and
+ *               free it via wirelog_program_free() AFTER calling
+ *               wirelog_session_destroy().
+ * @backend:     Compute backend selector.  Pass WIRELOG_BACKEND_DEFAULT
+ *               unless a specific backend is required.
+ * @num_workers: Worker count.  0 maps to 1 (single-threaded).
+ * @out:         (out) Receives the new session handle on success; set
+ *               to NULL on any error.
+ *
+ * Build the execution plan, instantiate the chosen backend, and seed
+ * any inline `.dl` facts declared in @program into the session as base
+ * rows (the same contract documented for wl_easy_open in #718 — see
+ * docs/SEMANTICS.md "Inline `.dl` facts").  All work happens before
+ * this call returns; there is no lazy-build path on the advanced API.
+ *
+ * Optimizer choice: this call assumes @program has already been run
+ * through whichever optimizer passes the caller wants.  Use
+ * wirelog_optimize() (the existing public entry point) before
+ * wirelog_session_create() if you want fusion / JPP / SIP applied.
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on bad arguments or
+ * backend selection, WIRELOG_ERR_INVALID_IR on plan generation failure,
+ * WIRELOG_ERR_MEMORY on allocation failure.
+ */
+wirelog_error_t
+wirelog_session_create(wirelog_program_t *program,
+    wirelog_backend_kind_t backend, uint32_t num_workers,
+    wirelog_session_t **out);
+
+/**
+ * wirelog_session_destroy:
+ * @session: Session to free (NULL-safe).
+ *
+ * Release the session and its plan.  Does NOT free the program passed
+ * to wirelog_session_create(); the caller still owns it.
+ */
+void
+wirelog_session_destroy(wirelog_session_t *session);
+
+/**
+ * wirelog_session_insert:
+ * @session:  Session.
+ * @relation: Relation name (must not be NULL).
+ * @data:     Row-major int64_t values; length = @num_rows * @num_cols.
+ * @num_rows: Number of rows to insert.
+ * @num_cols: Number of columns per row (must match the relation arity).
+ *
+ * Insert rows into @relation.  Each insert increments z-set
+ * multiplicity by +1; a host that re-inserts a row already present
+ * from inline `.dl` seeding will observe multiplicity +2 (see
+ * docs/SEMANTICS.md).
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
+ */
+wirelog_error_t
+wirelog_session_insert(wirelog_session_t *session, const char *relation,
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols);
+
+/**
+ * wirelog_session_remove:
+ * @session:  Session.
+ * @relation: Relation name (must not be NULL).
+ * @data:     Row-major int64_t values; length = @num_rows * @num_cols.
+ * @num_rows: Number of rows to retract.
+ * @num_cols: Number of columns per row.
+ *
+ * Retract rows from @relation.  Each remove decrements z-set
+ * multiplicity by -1.
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure or if
+ * the backend does not support retraction.
+ */
+wirelog_error_t
+wirelog_session_remove(wirelog_session_t *session, const char *relation,
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols);
+
+/**
+ * wirelog_session_step:
+ * @session: Session.
+ *
+ * Advance the session by one step.  Triggers the delta callback (if
+ * registered) for any insertions/removals derived since the previous
+ * step.
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
+ */
+wirelog_error_t
+wirelog_session_step(wirelog_session_t *session);
+
+/**
+ * wirelog_session_set_delta_cb:
+ * @session:   Session.
+ * @callback:  Delta callback (may be NULL to clear).
+ * @user_data: Opaque user data passed to @callback.
+ *
+ * Register a delta callback.  Inline `.dl` facts loaded by
+ * wirelog_session_create() are already in base by the time this call
+ * runs, so the first wirelog_session_step() after registration does
+ * NOT emit synthetic deltas for static rows.
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on NULL @session.
+ */
+wirelog_error_t
+wirelog_session_set_delta_cb(wirelog_session_t *session,
+    wl_on_delta_fn callback, void *user_data);
+
+/**
+ * wirelog_session_snapshot:
+ * @session:   Session.
+ * @callback:  Per-tuple callback (must not be NULL).
+ * @user_data: Opaque user data passed to @callback.
+ *
+ * Evaluate the current state and forward every IDB tuple to @callback.
+ * Like wl_easy_snapshot(), this is an *evaluating* call; do NOT mix
+ * with wirelog_session_step() on the same insert batch (step() and
+ * snapshot() each derive IDB rows independently and combining them
+ * produces duplicates).
+ *
+ * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
+ */
+wirelog_error_t
+wirelog_session_snapshot(wirelog_session_t *session, wl_on_tuple_fn callback,
+    void *user_data);
+
+/**
+ * wirelog_session_make_compound:
+ * @session:    Session.
+ * @functor:    Compound functor name.
+ * @arity:      Number of compound arguments.
+ * @args:       Argument values; length = @arity.
+ * @handle_out: (out) Session-local compound handle on success;
+ *              WIRELOG_COMPOUND_HANDLE_NULL on failure.
+ *
+ * Allocate a handle-backed side-tier compound and append its row to
+ * the auto-created `__compound_<functor>_<arity>` side relation.
+ * Handles are valid only for this session; they MUST NOT be persisted
+ * across wirelog_session_destroy() / wirelog_session_create() pairs.
+ *
+ * Returns: WIRELOG_OK on success; WIRELOG_ERR_COMPOUND_SATURATED if
+ * the arena epoch saturated; WIRELOG_ERR_COMPOUND_BUSY if the arena is
+ * temporarily frozen; WIRELOG_ERR_MEMORY on allocation failure;
+ * WIRELOG_ERR_EXEC on invalid arguments or session-side errors.
+ */
+wirelog_error_t
+wirelog_session_make_compound(wirelog_session_t *session, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WIRELOG_ADVANCED_H */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -293,6 +293,7 @@ wirelog_config_threads(void);
 #include "wirelog/wirelog-ir.h"
 #include "wirelog/wirelog-optimizer.h"
 #include "wirelog/wl_easy.h"
+#include "wirelog/wirelog-advanced.h"
 #include "wirelog/io/io_adapter.h"
 
 #endif /* WIRELOG_H */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -76,7 +76,12 @@ typedef struct wirelog_result wirelog_result_t;
 /**
  * wirelog_executor_t:
  *
- * Opaque handle to the execution engine.
+ * Opaque handle to the batch execution engine: parse + optimize + run +
+ * collect IDB results in one shot via wirelog_evaluate().  For
+ * incremental sessions with delta callbacks and z-set semantics, use
+ * wirelog_session_t (in wirelog/wirelog-advanced.h) or
+ * wl_easy_session_t (in wirelog/wl_easy.h) instead.  These three
+ * facades are independent surfaces; do not mix handles across them.
  */
 typedef struct wirelog_executor wirelog_executor_t;
 

--- a/wirelog/wirelog_advanced.c
+++ b/wirelog/wirelog_advanced.c
@@ -1,0 +1,191 @@
+/*
+ * wirelog_advanced.c - implementation of the fine-grained session API.
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <https://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+
+#include "wirelog/wirelog-advanced.h"
+
+#include "wirelog/backend.h"
+#include "wirelog/exec_plan.h"
+#include "wirelog/exec_plan_gen.h"
+#include "wirelog/session.h"
+#include "wirelog/session_facts.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+struct wirelog_session {
+    wirelog_program_t *prog; /* borrowed; caller frees after destroy */
+    wl_plan_t *plan;         /* owned */
+    wl_session_t *inner;     /* owned */
+};
+
+static const wl_compute_backend_t *
+resolve_backend(wirelog_backend_kind_t kind)
+{
+    switch (kind) {
+    case WIRELOG_BACKEND_DEFAULT:
+    case WIRELOG_BACKEND_COLUMNAR:
+        return wl_backend_columnar();
+    default:
+        return NULL;
+    }
+}
+
+wirelog_error_t
+wirelog_session_create(wirelog_program_t *program,
+    wirelog_backend_kind_t backend, uint32_t num_workers,
+    wirelog_session_t **out)
+{
+    if (!program || !out)
+        return WIRELOG_ERR_EXEC;
+    *out = NULL;
+
+    const wl_compute_backend_t *be = resolve_backend(backend);
+    if (!be)
+        return WIRELOG_ERR_EXEC;
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(program, &plan);
+    if (rc != 0 || !plan) {
+        if (plan)
+            wl_plan_free(plan);
+        return WIRELOG_ERR_INVALID_IR;
+    }
+
+    wl_session_t *inner = NULL;
+    rc = wl_session_create(be, plan, num_workers > 0 ? num_workers : 1,
+            &inner);
+    if (rc != 0 || !inner) {
+        wl_plan_free(plan);
+        return (rc == ENOMEM) ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
+    }
+
+    /* Issue #718 contract: inline `.dl` facts must be observable in
+     * snapshots and IDB derivations without further host action.  Seed
+     * them eagerly here (delta callback is not yet installed, so the
+     * non-incremental insert path is taken and no synthetic static
+     * deltas appear on the first step()). */
+    rc = wl_session_load_facts(inner, program);
+    if (rc != 0) {
+        wl_session_destroy(inner);
+        wl_plan_free(plan);
+        return WIRELOG_ERR_EXEC;
+    }
+
+    wirelog_session_t *s
+        = (wirelog_session_t *)calloc(1, sizeof(wirelog_session_t));
+    if (!s) {
+        wl_session_destroy(inner);
+        wl_plan_free(plan);
+        return WIRELOG_ERR_MEMORY;
+    }
+    s->prog = program;
+    s->plan = plan;
+    s->inner = inner;
+    *out = s;
+    return WIRELOG_OK;
+}
+
+void
+wirelog_session_destroy(wirelog_session_t *session)
+{
+    if (!session)
+        return;
+    if (session->inner)
+        wl_session_destroy(session->inner);
+    if (session->plan)
+        wl_plan_free(session->plan);
+    /* session->prog is borrowed; caller frees after destroy. */
+    free(session);
+}
+
+wirelog_error_t
+wirelog_session_insert(wirelog_session_t *session, const char *relation,
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols)
+{
+    if (!session || !relation || !data)
+        return WIRELOG_ERR_EXEC;
+    int rc = wl_session_insert(session->inner, relation, data, num_rows,
+            num_cols);
+    return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;
+}
+
+wirelog_error_t
+wirelog_session_remove(wirelog_session_t *session, const char *relation,
+    const int64_t *data, uint32_t num_rows, uint32_t num_cols)
+{
+    if (!session || !relation || !data)
+        return WIRELOG_ERR_EXEC;
+    int rc = wl_session_remove(session->inner, relation, data, num_rows,
+            num_cols);
+    return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;
+}
+
+wirelog_error_t
+wirelog_session_step(wirelog_session_t *session)
+{
+    if (!session)
+        return WIRELOG_ERR_EXEC;
+    int rc = wl_session_step(session->inner);
+    return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;
+}
+
+wirelog_error_t
+wirelog_session_set_delta_cb(wirelog_session_t *session,
+    wl_on_delta_fn callback, void *user_data)
+{
+    if (!session)
+        return WIRELOG_ERR_EXEC;
+    wl_session_set_delta_cb(session->inner, callback, user_data);
+    return WIRELOG_OK;
+}
+
+wirelog_error_t
+wirelog_session_snapshot(wirelog_session_t *session, wl_on_tuple_fn callback,
+    void *user_data)
+{
+    if (!session || !callback)
+        return WIRELOG_ERR_EXEC;
+    int rc = wl_session_snapshot(session->inner, callback, user_data);
+    return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;
+}
+
+wirelog_error_t
+wirelog_session_make_compound(wirelog_session_t *session, const char *functor,
+    uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
+{
+    if (handle_out)
+        *handle_out = WIRELOG_COMPOUND_HANDLE_NULL;
+    if (!session || !functor || !args || arity == 0 || !handle_out)
+        return WIRELOG_ERR_EXEC;
+
+    int rc = wl_session_make_compound(session->inner, functor, arity, args,
+            handle_out);
+    if (rc == 0)
+        return WIRELOG_OK;
+    if (rc == ENOSPC)
+        return WIRELOG_ERR_COMPOUND_SATURATED;
+    if (rc == EBUSY)
+        return WIRELOG_ERR_COMPOUND_BUSY;
+    if (rc == ENOMEM)
+        return WIRELOG_ERR_MEMORY;
+    return WIRELOG_ERR_EXEC;
+}

--- a/wirelog/wirelog_advanced.c
+++ b/wirelog/wirelog_advanced.c
@@ -54,9 +54,11 @@ wirelog_session_create(wirelog_program_t *program,
     wirelog_backend_kind_t backend, uint32_t num_workers,
     wirelog_session_t **out)
 {
-    if (!program || !out)
+    if (!out)
         return WIRELOG_ERR_EXEC;
     *out = NULL;
+    if (!program)
+        return WIRELOG_ERR_EXEC;
 
     const wl_compute_backend_t *be = resolve_backend(backend);
     if (!be)


### PR DESCRIPTION
## Summary

Resolve the surface contradiction reported in #717 and the matching release-plan blocker #703. README previously advertised `wl_session_*` (in `wirelog/session.h`) as the public "fine-grained" API; that header itself declares INTERNAL and the meson public-header list does not install it. AGENTS.md reserves `wl_*` for internals.

Introduce `wirelog/wirelog-advanced.h` as the public peer of `wl_easy.h`, exposing eight `wirelog_session_*` thin wrappers over the existing internal `wl_session_*` primitives:

- `create / destroy / insert / remove / step / set_delta_cb / snapshot / make_compound`

Backend selection through the public enum `wirelog_backend_kind_t` (`DEFAULT=0`, `COLUMNAR=1`); the internal `wl_compute_backend_t` vtable stays internal. Session handle is opaque (`struct wirelog_session` defined only in the implementation file). `wirelog_session_create()` borrows `wirelog_program_t` (caller retains ownership and must `wirelog_program_free()` after `_destroy`), builds the plan internally, and seeds inline `.dl` facts eagerly so snapshots and IDB derivations observe them without further host action — matching the `wl_easy` contract from #718.

CI: `scripts/ci/check-advanced-header.sh` (suite `abi`) is an allowlist-based gate that fails closed when `wirelog/wirelog-advanced.h` quoted-includes anything outside the nine permitted public headers.

## Commits

- `084bcc3 feat(api): add wirelog/wirelog-advanced.h public surface` — header, impl, meson wiring (sources + public_headers + umbrella include), forbiddenlist CI guard.
- `5f0ce15 test: cover wirelog_session_* advanced API` — `tests/test_wirelog_advanced.c` with 7 behavioral-parity cases.
- `a7f9e80 docs: point public docs at wirelog-advanced.h` — README lines 49 + 260, SEMANTICS.md cross-facade-parity promotion (Future → Current), CHANGELOG.
- `b9d19dd fix(api): tighten wirelog_session_* contract per review` — review-driven SEV-2 fixes: `*out=NULL` ordering on NULL-program path; T3 pins `WIRELOG_ERR_EXEC` exactly; T7 NULL safety extends to `snapshot` and `make_compound` (with handle pre-clear lock); CI guard inverted to allowlist; `wirelog_executor_t` docstring expanded to clarify the three independent execution facades; CHANGELOG #718 entry preserved alongside additive #717 line.

## Test plan

- [x] `meson test -C build wirelog_advanced` — 7/7 OK
- [x] `meson test -C build wl_easy_inline_facts wl_easy` — regressions clean
- [x] `meson test -C build --suite abi` — 5/5 OK (including the new `advanced_abi_header` allowlist gate)
- [x] `meson test -C build` full suite — 212 OK / 0 FAIL / 7 skipped
- [x] Symbol probe: `nm -D --defined-only build/libwirelog.so | grep wirelog_session_` shows all eight new symbols exported
- [ ] CI matrix on push (Linux GCC + Clang, ARM64, macOS, Windows MSVC) — pending

## Out of scope (follow-up)

- wl_easy ↔ CLI optimizer-pipeline alignment (subsumption + magic_sets gap). Tracked separately.
- `tests/conformance/` scaffold (stable-release-plan §7.1).
- Version-macro autogen + `WIRELOG_AVAILABLE_SINCE` macro adoption (#688).
- `wirelog_compound_arg_t` size-versioning ADR.
- `wl_on_tuple_fn` / `wl_on_delta_fn` prefix renames (existing public typedefs; deprecation cycle).
- Single-canonical-form choice between `wirelog_easy_make_compound` and `wirelog_session_make_compound` for 1.0.

Closes #717.
Closes #703.