### PR TITLE
docs(security): mbedTLS license stack and ECCN self-classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+- **`docs/SECURITY_MODEL.md`** (#701): new document recording the threat model, the mbedTLS-enabled build's license stack (Apache-2.0 + Apache-2.0 sub-dependencies on top of LGPL-3.0-or-later wirelog), and a good-faith export-control self-classification (ECCN 5D002.c.1 + License Exception ENC for `mbedTLS=enabled`; EAR99 for the default `disabled` build). Linked from README.md and from the `mbedTLS` option description in `meson_options.txt`.
 - **README.md** (#717): replace the now-misleading `wl_session_*` / `wirelog/session.h` advisory with `wirelog_session_*` / `wirelog/wirelog-advanced.h`. The internal session header is explicitly called out as private.
 - **`docs/SEMANTICS.md`** (#718): new document recording the engine's observable semantic-model decisions and the path toward 1.0 stabilization. First entry: inline `.dl` fact loading rules and the z-set host insert/remove model (status: Current).
 - **`docs/SEMANTICS.md`** (#717): promote the cross-facade parity section from Future to Current now that the advanced surface ships.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ external-consumer audit.
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) -- system design, optimizer pipeline, execution model
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
+- [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification
 - [CLA.md](CLA.md) -- Contributor License Agreement (required for dual licensing)
 - API: [`wirelog/wl_easy.h`](wirelog/wl_easy.h) (simple) | [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h) (advanced)
 

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -1,0 +1,171 @@
+# wirelog Security Model
+
+This document records wirelog's threat model, the cryptographic and
+export-control posture of its build options, and the third-party
+dependency license stack that downstream packagers and integrators
+need to be aware of.
+
+> **Not legal advice.** The export-classification statements below are
+> the project's **good-faith self-classification** under U.S. EAR
+> guidance and the upstream mbedTLS project's published posture.
+> Downstream redistributors must perform their own classification under
+> the laws of every jurisdiction in which they distribute wirelog.
+
+Companion documents:
+
+- `SECURITY.md` — vulnerability reporting and disclosure channel.
+- `docs/SEMANTICS.md` — engine semantic-model decisions.
+- `docs/THREADING.md` (planned) — concurrency model.
+
+---
+
+## 1. Threat model
+
+wirelog is an embedded Datalog engine. It is intended to run as a
+**library inside a host application**, on the same machine as the
+host, with the host owning the I/O boundary. Specifically:
+
+- **Trusted**: the program text fed to `wirelog_parse` /
+  `wirelog_parse_string`, the row data passed to
+  `wirelog_session_insert` and `wl_easy_insert`, the I/O adapter
+  callbacks the host registers via `wl_io_register_adapter`.
+- **Untrusted**: nothing in the default surface. wirelog does not
+  open sockets, accept network connections, or fork helper processes.
+- **Optional crypto**: when built with `-DmbedTLS=enabled` (default
+  is `disabled`), wirelog links against system mbedTLS to provide
+  cryptographic hash, HMAC, and UUID built-ins. The crypto surface
+  is described in §3.
+
+Out of scope for the default build: side-channel attacks, malicious
+peer authentication, transport-layer security (no transport exists),
+secure-multi-party computation, hardware-attested execution.
+
+## 2. Default build (no cryptographic code)
+
+Build option `mbedTLS=disabled` (the default) produces a wirelog
+library that contains **no cryptographic primitives** beyond:
+
+- `xxHash3` (non-cryptographic hash; BSD-2-Clause).
+- `CRC-32` (data-integrity check, not a security primitive;
+  ethernet and Castagnoli variants both BSD-style royalty-free).
+
+Neither is a cryptographic mechanism in the export-control sense.
+
+**Self-classification (default build)**: **EAR99** (no encryption
+controls). License exception not required. This is the posture for
+all CI artifacts the project ships unless a release explicitly
+advertises mbedTLS support.
+
+## 3. mbedTLS-enabled build
+
+When the build is configured with `-DmbedTLS=enabled` (or
+`-DmbedTLS=auto` and the system mbedTLS is detected), wirelog adds:
+
+- Cryptographic hash families: SHA-1, SHA-2 (224/256/384/512), SHA-3.
+- HMAC over the same hash families.
+- UUIDv4 generation backed by a CSPRNG.
+
+These functions become callable as Datalog built-ins; the host has no
+control over whether a `.dl` program calls them once mbedTLS is
+linked in.
+
+### 3.1 License stack
+
+mbedTLS upstream ships under a **dual-license**: Apache-2.0 OR
+GPL-2.0-or-later (the user picks at distribution time). wirelog uses
+mbedTLS as a dynamically linked dependency — the user takes the
+Apache-2.0 path by default.
+
+| Layer | Component | License |
+|---|---|---|
+| wirelog itself | this repository | LGPL-3.0-or-later (or commercial) |
+| Hash built-in | xxHash3 | BSD-2-Clause |
+| CRC-32 | in-tree | LGPL-3.0-or-later |
+| Optional crypto | system mbedTLS | Apache-2.0 (default) or GPL-2.0-or-later |
+| Optional crypto | mbedTLS sub-deps (`mbedx509`, `tfpsacrypto`) | Apache-2.0 |
+
+LGPL-3.0-or-later is compatible with Apache-2.0 in the *consumer*
+direction (consumer of mbedTLS may be LGPL-licensed). Downstream
+redistributors of an `mbedTLS=enabled` build must include the
+upstream Apache-2.0 NOTICE for mbedTLS plus the mbedx509/tfpsacrypto
+notices.
+
+### 3.2 Export-control self-classification
+
+**Self-classification (mbedTLS-enabled build)**: **ECCN 5D002.c.1**
+("information security" software providing encryption functions),
+qualifying for **License Exception ENC** under U.S. 15 CFR 740.17,
+sub-paragraph (b)(1) (publicly available encryption source code,
+mass-market notification path).
+
+This mirrors the upstream mbedTLS project's published stance: mbedTLS
+is freely available source code, subject to ENC mass-market notice
+filing rather than a license requirement, and is generally exportable
+to all destinations except those embargoed under the EAR.
+
+**What this means for downstream redistributors:**
+
+1. If you redistribute a wirelog binary that was built with
+   `mbedTLS=enabled` from the United States, you should be aware that
+   the artifact carries cryptographic functionality and falls under
+   ECCN 5D002.c.1. Most commercial mass-market redistribution paths
+   are covered by License Exception ENC notification (a one-time
+   email to BIS and NSA per 15 CFR 740.17(b)(1)).
+2. From other jurisdictions (EU, UK, Japan, etc.), determine the
+   equivalent classification under the local export regime. The EU
+   counterpart is the EU Dual-Use Regulation Annex I Category 5
+   Part 2, with similar mass-market exemptions.
+3. **Do not redistribute to embargoed destinations** without checking
+   the current sanctions lists (OFAC SDN, EU consolidated list, etc.).
+4. The project does not file Annual Self-Classification Reports
+   (ASRs) on behalf of downstream redistributors. Each redistributor
+   is responsible for its own filings.
+
+The project ships **all artifacts as `mbedTLS=disabled` by default**.
+Distros and packagers that turn mbedTLS on must update their own
+classification records accordingly.
+
+### 3.3 User responsibility
+
+You are responsible for:
+
+- Choosing the correct build option for your distribution channel
+  (`mbedTLS=disabled` if you do not need the crypto built-ins).
+- Performing the export-control classification under **your**
+  jurisdiction.
+- Filing any required notifications (US ENC notification, EU dual-use
+  reporting, Japanese METI, etc.) for the artifact you ship.
+- Including the upstream mbedTLS NOTICE files when you redistribute
+  an `mbedTLS=enabled` build.
+
+The project provides this self-classification in good faith and as a
+starting point; it is not a substitute for review by qualified export
+counsel for your specific distribution model.
+
+---
+
+## 4. References
+
+- **mbedTLS upstream** — <https://github.com/Mbed-TLS/mbedtls>
+  (license, ECCN, Annual Self-Classification posture).
+- **U.S. EAR §740.17(b)(1)** — License Exception ENC for
+  publicly-available encryption source code.
+- **U.S. CCL 5D002** — Encryption software classification.
+- **EU Regulation 2021/821** — Dual-use export-control regime,
+  Annex I Category 5 Part 2.
+- **Apache License 2.0 NOTICE** — required attribution for mbedTLS
+  redistributions.
+- **`meson_options.txt`** — the `mbedTLS` build option entry repeats
+  the headline disclosure inline.
+- **`SECURITY.md`** — vulnerability reporting channel.
+
+---
+
+## 5. Status
+
+This document is **Status: Current**. The threat-model section is
+expected to be promoted to Stable at 1.0 GA. The export-classification
+self-statements track upstream mbedTLS posture; they will be reviewed
+each release cycle and updated if the upstream classification changes.
+
+Refs: `#701`, `stable-release-plan.md` §10, §11.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -94,14 +94,31 @@ notices.
 
 **Self-classification (mbedTLS-enabled build)**: **ECCN 5D002.c.1**
 ("information security" software providing encryption functions),
-qualifying for **License Exception ENC** under U.S. 15 CFR 740.17,
-sub-paragraph (b)(1) (publicly available encryption source code,
-mass-market notification path).
+matching the international **Wassenaar Arrangement 5.A.2 / 5.D.2**
+control list. wirelog has **not** requested a CCATS (Commodity
+Classification Automated Tracking System) determination from BIS;
+the classification above is the project's own good-faith assessment.
+
+Two U.S. EAR pathways apply to publicly-available source code:
+
+- **§740.13(e) TSU** (Technology and Software — Unrestricted) covers
+  publicly-available encryption source code with **no notification
+  requirement**. This is the safest baseline for a downstream
+  redistributor that has not separately filed the §740.17 notice.
+- **§740.17(b)(1) ENC** (Encryption commodities, software, and
+  technology) covers publicly-available encryption source code under
+  the ENC license exception, but is conditioned on a **one-time
+  email notification** to BIS and the ENC Encryption Request
+  Coordinator. A redistributor that has filed that notification may
+  cite §740.17(b)(1); otherwise §740.13(e) TSU is the cleaner cite.
+
+Either pathway permits export to most destinations; both exclude
+EAR-embargoed countries.
 
 This mirrors the upstream mbedTLS project's published stance: mbedTLS
-is freely available source code, subject to ENC mass-market notice
-filing rather than a license requirement, and is generally exportable
-to all destinations except those embargoed under the EAR.
+is freely available source code, generally exportable subject to the
+above EAR pathways and not requiring an export license for the
+default redistribution channel.
 
 **What this means for downstream redistributors:**
 
@@ -111,10 +128,18 @@ to all destinations except those embargoed under the EAR.
    ECCN 5D002.c.1. Most commercial mass-market redistribution paths
    are covered by License Exception ENC notification (a one-time
    email to BIS and NSA per 15 CFR 740.17(b)(1)).
-2. From other jurisdictions (EU, UK, Japan, etc.), determine the
-   equivalent classification under the local export regime. The EU
-   counterpart is the EU Dual-Use Regulation Annex I Category 5
-   Part 2, with similar mass-market exemptions.
+2. From other jurisdictions, determine the equivalent classification
+   under the local export regime:
+   - **EU**: Regulation 2021/821 Annex I Category 5 Part 2, with
+     similar publicly-available-source and mass-market exemptions.
+   - **UK** (post-Brexit): Strategic Export Control regime under the
+     Export Control Order 2008 (as amended); UK Strategic Export
+     Control Lists Annex 1 Category 5 Part 2 mirrors the Wassenaar
+     5.A.2 / 5.D.2 controls.
+   - **Japan**: METI Foreign Exchange and Foreign Trade Act, with
+     publicly-available-software exemptions paralleling the EAR's.
+   - All Wassenaar Arrangement participating states have closely
+     analogous controls in their own dual-use frameworks.
 3. **Do not redistribute to embargoed destinations** without checking
    the current sanctions lists (OFAC SDN, EU consolidated list, etc.).
 4. The project does not file Annual Self-Classification Reports
@@ -148,11 +173,20 @@ counsel for your specific distribution model.
 
 - **mbedTLS upstream** — <https://github.com/Mbed-TLS/mbedtls>
   (license, ECCN, Annual Self-Classification posture).
-- **U.S. EAR §740.17(b)(1)** — License Exception ENC for
-  publicly-available encryption source code.
+- **U.S. EAR §740.13(e) TSU** — unrestricted publicly-available
+  encryption source code, no notification required.
+- **U.S. EAR §740.17(b)(1) ENC** — License Exception ENC pathway for
+  publicly-available encryption source code, conditioned on the
+  one-time BIS / ENC-Coordinator notification.
 - **U.S. CCL 5D002** — Encryption software classification.
+- **Wassenaar Arrangement 5.A.2 / 5.D.2** — international control
+  list parent of the EAR / EU / UK / JP cryptography controls.
 - **EU Regulation 2021/821** — Dual-use export-control regime,
   Annex I Category 5 Part 2.
+- **UK Export Control Order 2008** — UK Strategic Export Control
+  Lists Annex 1 Category 5 Part 2 (post-Brexit).
+- **Japan FEFTA** — METI Foreign Exchange and Foreign Trade Act,
+  publicly-available-software exemptions.
 - **Apache License 2.0 NOTICE** — required attribution for mbedTLS
   redistributions.
 - **`meson_options.txt`** — the `mbedTLS` build option entry repeats

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -56,7 +56,7 @@ option(
   type: 'combo',
   choices: ['disabled', 'enabled', 'auto'],
   value: 'disabled',
-  description: 'Use system-installed mbedTLS for cryptographic functions. auto=enabled if found, else disabled'
+  description: 'Use system-installed mbedTLS for cryptographic functions. auto=enabled if found, else disabled. Enabling links Apache-2.0 mbedTLS and brings cryptography into the build (see docs/SECURITY_MODEL.md): the artifact then carries ECCN 5D002.c.1 under U.S. EAR; downstream redistributors are responsible for any export filings under their own jurisdiction. Default-disabled builds carry no cryptographic code (EAR99).'
 )
 
 option(


### PR DESCRIPTION
## Summary

Document the cryptographic / export-control posture introduced by the optional mbedTLS dependency, completing #701 (Blocker B14).

The default `mbedTLS=disabled` build carries no cryptographic code (EAR99). The `mbedTLS=enabled` build links Apache-2.0 mbedTLS plus its sub-dependencies and brings cryptography into the binary, raising the artifact's classification to ECCN 5D002.c.1 (Wassenaar 5.A.2 / 5.D.2). Two U.S. EAR pathways are documented side-by-side: §740.13(e) TSU (no-notification baseline for publicly-available source) and §740.17(b)(1) ENC (notification path). EU/UK/JP analogues named. Explicit "not legal advice" disclaimer at the top; "your responsibility" framing for downstream redistributors throughout.

## Commits

- `a2f8fc3 docs(security): mbedTLS license stack and ECCN self-classification` — new `docs/SECURITY_MODEL.md`, `meson_options.txt` mbedTLS option description extended, README link, CHANGELOG entry.
- `1a03f79 docs(security): broaden EAR pathway, add Wassenaar / UK / CCATS notes` — review-driven precision: replace the ENC b)(1)-only cite with a TSU §740.13(e) + ENC §740.17(b)(1) pair (TSU is the safer baseline when no BIS notification is on file); add Wassenaar 5.A.2/5.D.2 international parent; UK post-Brexit Strategic Export Control regime; explicit no-CCATS-requested statement.

## Acceptance match (#701)

- [x] `docs/SECURITY_MODEL.md` created.
- [x] `meson_options.txt` mbedTLS entry updated with the disclosure summary.
- [x] README links to `docs/SECURITY_MODEL.md` from the documentation index.
- [x] CHANGELOG `[Unreleased] > Documentation` entry added.

## Test plan

- [x] `meson setup --reconfigure build` clean (the option-description change is metadata-only).
- [x] `meson test -C build wl_easy wirelog_advanced` regressions still green.
- [x] `meson test -C build --suite abi` 6/6 OK (no behavior change).
- [x] Critic short-pass review: ACCEPT-WITH-NIT, three minors all addressed in commit 2.
- [ ] CI matrix on push — pending.

## Out of scope (follow-up)

- BIS notification filing (project responsibility for any release that ships the mbedTLS-enabled build officially).
- CCATS request for an authoritative classification.
- SBOM inclusion of mbedTLS license metadata (tracked separately for #715 / SBOM automation).
- Doxygen docs cross-link.

Closes #701.