### PR TITLE
ci: add CLA-bot workflow (closes #702)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,51 @@
+name: "CLA Assistant"
+
+# Issue #702 / #713 (Blocker B15 / Risk C10): wirelog ships under
+# LGPL-3.0-or-later + commercial dual licensing.  Every contributor
+# must sign the CLA at CLA.md so CleverPlant retains the sublicense
+# rights the dual-license model depends on.  This workflow drives the
+# contributor-assistant action to gate every PR on a signed CLA and
+# stores signatures inside this repository at signatures/version1/cla.json.
+#
+# Operational prerequisite (post-merge): a fine-grained PERSONAL_ACCESS_TOKEN
+# secret named CLA_SIGN_TOKEN must be registered at the repository or
+# organization level.  The PAT needs `repo:contents:write` and
+# `pull_requests:write` on this repository so the action can append to
+# the signatures file and post status checks.  See docs/SECURITY_MODEL.md
+# §3 for the export-control posture; the CLA itself does not introduce
+# cryptographic surface.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Top-level minimum-rights baseline; the CLAssistant job below grants
+# the additional scopes the action needs.
+permissions:
+  contents: read
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the wirelog CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGN_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/semantic-reasoning/wirelog/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: dependabot[bot],renovate[bot],github-actions[bot]
+          custom-pr-sign-comment: 'I have read the wirelog CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the wirelog CLA. Thank you for your contribution.'
+          custom-notsigned-prcomment: 'Thank you for your contribution. Before this PR can be merged, you (and any other contributors on this PR) must sign the [wirelog CLA](https://github.com/semantic-reasoning/wirelog/blob/main/CLA.md) by replying with the comment shown below. Once signed, your signature is recorded in `signatures/version1/cla.json` and you will not have to repeat this for future PRs.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to wirelog are documented in this file.
 
 - **wl_easy inline-fact materialization** (#718): `wl_easy_open` now seeds inline `.dl` facts into the columnar session at first lazy build, matching the CLI driver's order-of-operations. Previously the wl_easy facade dropped every static fact silently, so snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows.
 
+### Added
+
+- **CLA-bot automation** (#702): `.github/workflows/cla.yml` runs the `contributor-assistant/github-action` on every PR. The bot blocks merging until every contributor has signed the wirelog CLA (recorded in `signatures/version1/cla.json`), protecting the LGPL-3.0-or-later + commercial dual-license model. Operational prerequisite documented inside the workflow file: a `CLA_SIGN_TOKEN` PAT secret with `contents:write` + `pull_requests:write` must be registered after merge.
+
 ### Documentation
 
 - **`docs/SECURITY_MODEL.md`** (#701): new document recording the threat model, the mbedTLS-enabled build's license stack (Apache-2.0 + Apache-2.0 sub-dependencies on top of LGPL-3.0-or-later wirelog), and a good-faith export-control self-classification (ECCN 5D002.c.1 + License Exception ENC for `mbedTLS=enabled`; EAR99 for the default `disabled` build). Linked from README.md and from the `mbedTLS` option description in `meson_options.txt`.


### PR DESCRIPTION
## Summary

Closes #702 (Blocker B15: CLA enforcement automation).  wirelog's LGPL-3.0-or-later + commercial dual-license model depends on every contributor signing the CLA at `CLA.md`; until now this was a manual / honor-system gate.  This PR wires `contributor-assistant/github-action@v2.6.1` (the standard CLA bot used by jfrog/charts and others) into a new `.github/workflows/cla.yml`.

## What the workflow does

- Triggers on every PR (`opened` / `synchronize` / `closed`) and on every issue/PR comment.
- Posts a sign-instruction comment when an unsigned contributor opens a PR; signatures are recorded in `signatures/version1/cla.json` inside this repo.
- Re-checks on `recheck` comment and on the magic phrase `I have read the wirelog CLA Document and I hereby sign the CLA`.
- Allowlists `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`.
- Custom signed/not-signed/all-signed PR comment text identifies the wirelog CLA explicitly so contributors know which agreement they are signing.

## Operational prerequisite (post-merge)

Register a fine-grained PAT secret named **`CLA_SIGN_TOKEN`** at the repository or organization level with the following scopes (on this repository):

- `contents:write` — needed so the bot can append to `signatures/version1/cla.json`.
- `pull_requests:write` — needed so the bot can post sign-instruction comments and update PR statuses.

Until that secret is registered, `cla.yml` runs will fail loudly (the `PERSONAL_ACCESS_TOKEN` env will be empty) rather than silently bypass the gate.

## Acceptance match (#702)

- [x] CLA bot active on PRs (workflow file landed, runs on `pull_request_target`).
- [x] `CLA.md` referenced from bot config (`path-to-document` points at the raw `CLA.md` URL, custom comments use the wirelog CLA name).
- [x] Bot allowlist excludes only known automated accounts.
- [ ] **Post-merge**: register `CLA_SIGN_TOKEN` secret.
- [ ] **Post-merge**: verify on a sample PR.
- [ ] **Post-merge**: 30-day continuous activity (acceptance criterion); tracked separately, not blocking the merge of this workflow.

## Test plan

- [x] `yaml.safe_load` parses the workflow cleanly (no syntax errors).
- [x] No code change; build / test suites unaffected.
- [ ] Sample-PR verification — runs after PAT secret registration on a follow-up PR.

## Out of scope

- DCO enforcement (a DCO trailer would NOT preserve the sublicense rights the dual-license model needs; CLA is the correct mechanism for this project — see issue #702 thread).
- CLA.md text changes.
- Migration of any prior signatures the project may have collected manually.

Closes #702.