### PR TITLE
fix(parser): free prior columns and input metadata on duplicate .decl / .input

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -111,6 +111,17 @@ test_stratify_exe = executable(
   dependencies: [threads_dep],
 )
 
+test_parse_duplicate_decl_no_leak_exe = executable(
+  'test_parse_duplicate_decl_no_leak',
+  files('test_parse_duplicate_decl_no_leak.c'),
+  parser_src,
+  ir_src,
+  io_src,
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+
 # ============================================================================
 # Register Tests
 # ============================================================================
@@ -120,6 +131,7 @@ test('parser', test_parser_exe)
 test('ir', test_ir_exe)
 test('program', test_program_exe)
 test('stratify', test_stratify_exe)
+test('parse_duplicate_decl_no_leak', test_parse_duplicate_decl_no_leak_exe)
 
 test_fusion_exe = executable(
   'test_fusion',

--- a/tests/test_parse_duplicate_decl_no_leak.c
+++ b/tests/test_parse_duplicate_decl_no_leak.c
@@ -1,0 +1,87 @@
+/*
+ * test_parse_duplicate_decl_no_leak.c
+ *
+ * Regression test for issue #724.
+ *
+ * When a program text contains the same `.decl` for a given relation more
+ * than once (e.g. produced by concatenating templates that share a
+ * declaration), `collect_decl` re-runs against an existing relation entry
+ * and overwrites `rel->columns` without freeing the previously allocated
+ * column array and per-column `name` strings. The same hazard applies to
+ * `collect_input`: a duplicate `.input` overwrites `input_io_scheme`,
+ * `input_param_names`, and `input_param_values`.
+ *
+ * Build hosts that load multi-file template bundles (notably wyrelog,
+ * which concatenates `bootstrap.dl` and `decision.dl` and ships duplicate
+ * declarations such as `login_skip_mfa_authz`) trip this leak on every
+ * `wirelog_parse_string` call. ASAN-instrumented CI then aborts the
+ * downstream test binary even though the input program is well-formed.
+ *
+ * The body below exercises duplicate `.decl` and duplicate `.input` and
+ * destroys the program. Under ASAN/LSan the leak surfaces as a hard
+ * test failure; without sanitizers the test passes trivially as long
+ * as parsing succeeds, which is still useful coverage.
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int
+expect_parse_ok(const char *src, const char *case_name)
+{
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog || err != WIRELOG_OK) {
+        fprintf(stderr, "%s: parse failed (err=%d)\n", case_name, err);
+        if (prog)
+            wirelog_program_free(prog);
+        return 1;
+    }
+    wirelog_program_free(prog);
+    return 0;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+
+    /* T1: same .decl for the same relation twice in one program.
+     * This is the wyrelog template-bundle pattern. */
+    failures += expect_parse_ok(
+        ".decl r(a: int64, b: int64)\n"
+        ".decl r(a: int64, b: int64)\n",
+        "T1 duplicate .decl");
+
+    /* T2: same .decl with a divergent column shape. The parser today
+     * accepts and overwrites ("second .decl wins"); the only contract
+     * the test asserts is that the previously allocated columns array
+     * and the column-name strings are reclaimed. */
+    failures += expect_parse_ok(
+        ".decl r(a: int64)\n"
+        ".decl r(x: int64, y: int64, z: int64)\n",
+        "T2 duplicate .decl with divergent shape");
+
+    /* T3: same .input for the same relation twice, with io scheme +
+     * extra parameters. The duplicate must reclaim the previously
+     * allocated input_io_scheme / input_param_names / input_param_values. */
+    failures += expect_parse_ok(
+        ".decl r(a: symbol)\n"
+        ".input r(io=\"csv\", filename=\"a.csv\")\n"
+        ".input r(io=\"csv\", filename=\"b.csv\")\n",
+        "T3 duplicate .input");
+
+    if (failures != 0) {
+        printf("test_parse_duplicate_decl_no_leak: %d failure(s)\n", failures);
+        return 1;
+    }
+    printf("test_parse_duplicate_decl_no_leak: OK\n");
+    return 0;
+}

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -393,6 +393,18 @@ collect_decl(struct wirelog_program *prog,
     }
 
     if (col_count > 0) {
+        /* Issue #724: a second .decl for the same relation overwrites the
+         * columns array.  Free any prior allocation so the per-column
+         * name strings and the array itself do not leak when programs
+         * are assembled by concatenating templates that share a
+         * declaration. */
+        if (rel->columns) {
+            for (uint32_t i = 0; i < rel->column_count; i++)
+                free((char *)rel->columns[i].name);
+            free(rel->columns);
+            rel->columns = NULL;
+            rel->column_count = 0;
+        }
         rel->columns
             = (wirelog_column_t *)calloc(col_count, sizeof(wirelog_column_t));
         if (!rel->columns)
@@ -463,6 +475,24 @@ collect_input(struct wirelog_program *prog,
     }
 
     rel->has_input = true;
+
+    /* Issue #724: a second .input for the same relation overwrites the
+     * input_io_scheme and input_param_names/values arrays.  Reclaim the
+     * prior allocations so concatenated template bundles that share an
+     * .input directive do not leak. */
+    free(rel->input_io_scheme);
+    rel->input_io_scheme = NULL;
+    if (rel->input_param_names) {
+        for (uint32_t i = 0; i < rel->input_param_count; i++) {
+            free(rel->input_param_names[i]);
+            free(rel->input_param_values[i]);
+        }
+        free(rel->input_param_names);
+        free(rel->input_param_values);
+        rel->input_param_names = NULL;
+        rel->input_param_values = NULL;
+        rel->input_param_count = 0;
+    }
 
     /* Extract input parameters.  The "io" key is consumed as a reserved
      * parameter to populate input_io_scheme and is NOT passed through


### PR DESCRIPTION
## Summary

- `wirelog/ir/program.c::collect_decl` and `collect_input` now free
  the previously allocated `rel->columns` (and per-column `name`
  strdup) and `rel->input_io_scheme` / `input_param_names` /
  `input_param_values` before reassigning them. This mirrors the
  existing free-before-reassign pattern in `collect_output`
  (program.c:557).
- Adds `tests/test_parse_duplicate_decl_no_leak.c` exercising
  duplicate `.decl` (same shape and divergent shape) and duplicate
  `.input` (with `io=` scheme and extra parameters). Under
  ASAN/LSan, the leak surfaces as a hard test failure; without
  sanitizers the test passes trivially as long as parse succeeds,
  which still validates non-crash behavior.
- Registers the new test in `tests/meson.build`.

## Investigation note (re: issue #724)

Issue #724 was filed as a "delta callback not fired" regression with
a deterministic bisect to commit `61ee71b`. A pure-wirelog
reproducer for the stated mechanism could not be constructed; the
wyrelog `test-handle-engine-pair` cited in the issue passes its
test logic and only aborts under ASAN/LSan because of an
**unrelated parser memory leak** that is exercised whenever a host
loads a multi-file template bundle containing duplicate declarations.

wyrelog's `wyl_engine_load_templates` concatenates `bootstrap.dl`
and `decision.dl`, both of which declare
`.decl login_skip_mfa_authz(user: symbol)`, producing a duplicate
declaration in the wirelog program. `collect_decl` then reassigned
`rel->columns` without freeing the prior allocation, and ASAN's
leak detector (which `halt_on_error=1`) aborted the test runner
after the test logic itself had completed cleanly.

The fix reclaims the orphaned allocations on every duplicate
`.decl` / `.input`. Verified by rebuilding wyrelog against this
patched wirelog: `meson test -C builddir-asan handle-engine-pair`
goes from ASAN SIGABRT (137+ bytes leaked over the test run) to
clean pass in 9.54s.

## Test plan

- [x] `meson test -C build` (non-ASAN): 214 PASS, 0 FAIL,
      7 SKIPPED.
- [x] `meson test -C build-asan` covering parser, program, ir,
      stratify, parse_duplicate_decl_no_leak, side_compound_delta,
      delta_callback, diff_integration, wl_easy,
      wl_easy_inline_facts: 10/10 PASS under
      `b_sanitize=address`.
- [x] New test `parse_duplicate_decl_no_leak`: 137-byte ASAN leak
      pre-fix, `OK` post-fix.
- [x] Downstream wyrelog `test-handle-engine-pair` (ASAN, full
      LSan): rebuilds and passes against patched wirelog (was
      previously SIGABRT).
- [x] Commit hygiene: WHAT/WHY surface, no `Co-Authored-By`, no
      emoji, no internal phase labels, atomic commit.

Closes #724