### PR TITLE
docs(cla): align CLA license spelling with LGPL-3.0-or-later

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -18,7 +18,7 @@ By submitting a contribution (via pull request, patch, or any other means) to th
 
 You hereby grant to CleverPlant a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works under any license terms, including without limitation:
 
-- The GNU Lesser General Public License v3.0 (LGPL-3.0)
+- The GNU Lesser General Public License v3.0 or later (LGPL-3.0-or-later)
 - Any commercial or proprietary license
 
 ## 3. Grant of Patent License
@@ -39,7 +39,7 @@ You represent that:
 
 You acknowledge that wirelog is distributed under a dual licensing model:
 
-1. **Open Source**: GNU Lesser General Public License v3.0 (LGPL-3.0)
+1. **Open Source**: GNU Lesser General Public License v3.0 or later (LGPL-3.0-or-later)
 2. **Commercial**: Proprietary license offered by CleverPlant
 
 Your Contributions may be distributed under either or both of these licenses. CleverPlant retains the right to offer commercial licenses that include your Contributions.


### PR DESCRIPTION
## Summary

Bring `CLA.md` §2 (grant of copyright license) and §5
(dual-licensing notice) into alignment with the rest of the
project, which already spells the open-source target license as
`LGPL-3.0-or-later` in `LICENSE.md`, `README.md`, and per-file SPDX
headers (cf. fb91f9e).

## Why this matters (not cosmetic)

`LGPL-3.0` is a deprecated SPDX identifier equivalent to today's
`LGPL-3.0-only`. The CLA's grant of copyright license enumerated
"LGPL-3.0" verbatim, so on a literal reading the contributor only
authorized CleverPlant to sublicense their work under LGPL v3.0
specifically — not LGPL v3.1, v4.0, or any later version that the
FSF may publish. The project itself ships under
`LGPL-3.0-or-later`, which permits redistribution under any later
LGPL.

This commit makes the CLA grant match the project's distribution
license. Existing signatures cover the broader grant because the
narrower wording was a typo, not a deliberate scope restriction
(the rest of the project's license stack has always been
`-or-later`); but for new contributors and any future audit, the
text now states the intended scope explicitly.

## Companion change

The CLA document served by https://cla-assistant.io
(https://gist.github.com/justinjoy/8cd757afcd38ab38c8931ae1cfe17a29)
is updated in lockstep so contributors sign the same text recorded
in this repo.

## Test plan

- [x] `git diff CLA.md` shows exactly two single-line replacements
      in §2 and §5; no other content changes.
- [x] Companion Gist refreshed and reviewed for matching wording.