### PR TITLE
ci(abi): enforce public header surface single source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,17 @@ python script.py
 | **Internal** (not installed) | `wl_` | `WL_` |
 
 **Public API headers** (installed, user-facing):
-`wirelog/wirelog.h`, `wirelog/wirelog-types.h`, `wirelog/wirelog-ir.h`, `wirelog/wirelog-parser.h`, `wirelog/wirelog-optimizer.h`
+`wirelog/wirelog.h`, `wirelog/wirelog-types.h`, `wirelog/wirelog-ir.h`, `wirelog/wirelog-parser.h`, `wirelog/wirelog-optimizer.h`, `wirelog/wirelog-export.h`, `wirelog/wl_easy.h`, `wirelog/wirelog-advanced.h`, `wirelog/io/io_adapter.h`
+
+> Single source of truth: `wirelog_public_headers` in `meson.build`
+> (plus the standalone `install_headers('wirelog/io/io_adapter.h', ...)`
+> call). Edit there first; this list is enforced by
+> `scripts/ci/check-public-header-surface.py` (`meson test --suite abi`).
+> The generated `wirelog/wirelog-version.h` is also installed but is
+> tracked separately by `check-version-sync.py`.
 
 **Internal headers** (not installed):
-Everything under `wirelog/parser/`, `wirelog/ir/`, `wirelog/backend/`, `wirelog/io/`, and `wirelog/backend.h`, `wirelog/session.h`, `wirelog/intern.h`
+Everything under `wirelog/parser/`, `wirelog/ir/`, `wirelog/backend/`, and `wirelog/backend.h`, `wirelog/session.h`, `wirelog/intern.h`
 
 ### Subdirectory Encoding
 

--- a/scripts/check_log_header_not_public.sh
+++ b/scripts/check_log_header_not_public.sh
@@ -17,6 +17,7 @@ PUBLIC_HEADERS=(
     wirelog/wirelog-optimizer.h
     wirelog/wirelog-export.h
     wirelog/wl_easy.h
+    wirelog/wirelog-advanced.h
     wirelog/io/io_adapter.h
 )
 

--- a/scripts/ci/check-public-header-surface.py
+++ b/scripts/ci/check-public-header-surface.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""check-public-header-surface.py - Issue #705 / Blocker B2 cross-check.
+
+Public-header surface single-source-of-truth gate.  The list of headers
+installed under ``${includedir}/wirelog/`` is enumerated in several
+in-tree locations; any drift between them is a 1.0-blocker risk
+(consumers ``#include`` an internal header, the next minor breaks ABI).
+
+This script declares ``meson.build`` the single source of truth and
+fails when any of the in-tree mirrors disagree.  It runs in lint stage
+(no configured build dir required); the parser is deliberately a static
+text scan so that a renamed meson DSL helper or a regenerated build dir
+cannot mask drift.
+
+Source of truth
+---------------
+
+  1. ``meson.build`` ``wirelog_public_headers`` list  (the bulk install)
+  2. ``meson.build`` standalone ``install_headers('wirelog/io/io_adapter.h',
+     subdir: 'wirelog/io')`` call  (the subdir-specific install)
+
+Combined, these enumerate every source-tree header installed to
+``${includedir}/wirelog/``.
+
+Mirrors that must agree with the SoT
+------------------------------------
+
+  3. ``stable-release-plan.md`` ``### 3.1`` table
+  4. ``AGENTS.md`` ``**Public API headers**`` enumeration
+  5. ``wirelog/wirelog.h`` umbrella ``#include`` block + the doc comment
+     listing sub-headers
+  6. ``scripts/check_log_header_not_public.sh`` ``PUBLIC_HEADERS`` array
+
+Generated headers are explicitly exempt
+---------------------------------------
+
+``wirelog/wirelog-version.h`` is produced via ``configure_file()`` at
+``wirelog/meson.build`` and is not source-tracked; it is checked
+separately by ``check-version-sync.py`` and is omitted from this gate.
+
+Anchors that must NOT be parsed
+-------------------------------
+
+The frozen verbatim appendix at the end of ``stable-release-plan.md``
+contains a historical header enumeration that is preserved without
+modification.  This script anchors on ``### 3.1`` exactly so that
+appendix is never read.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+def die(msg: str) -> None:
+    print(f"check-public-header-surface: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+HEADER_TOKEN = re.compile(r"`(wirelog/[A-Za-z0-9_./-]+\.h)`")
+
+
+def parse_meson_sot(repo_root: pathlib.Path) -> set[str]:
+    """Extract the canonical public-header set from meson.build.
+
+    Picks up two install paths:
+      - the named ``wirelog_public_headers`` list (subdir 'wirelog');
+      - the standalone ``install_headers('...', subdir: '...')`` calls
+        whose path begins with ``wirelog/``.
+    """
+    text = (repo_root / "meson.build").read_text(encoding="utf-8")
+
+    list_match = re.search(
+        r"wirelog_public_headers\s*=\s*\[(.*?)\]", text, re.DOTALL
+    )
+    if not list_match:
+        die("meson.build: wirelog_public_headers list not found")
+    bulk = set(re.findall(r"'(wirelog/[^']+\.h)'", list_match.group(1)))
+
+    standalone = set(
+        re.findall(
+            r"install_headers\(\s*'(wirelog/[^']+\.h)'", text, re.DOTALL
+        )
+    )
+
+    headers = bulk | standalone
+    if len(headers) < 5:
+        die(
+            f"meson.build: parsed only {len(headers)} headers; list shape "
+            "may have changed (update parser)"
+        )
+    return headers
+
+
+def parse_plan_section(repo_root: pathlib.Path) -> set[str] | None:
+    """Extract headers from stable-release-plan.md §3.1.
+
+    Anchors on ``### 3.1`` exactly; stops at the next ``###`` heading
+    so the frozen verbatim appendix at the document end is never
+    traversed.
+
+    Returns ``None`` if the plan file is not yet checked into the repo
+    (the plan is tracked separately from the source tree).  Returns the
+    parsed set otherwise.  If the plan IS present but malformed (anchor
+    missing, section empty), this fails loudly.
+    """
+    path = repo_root / "stable-release-plan.md"
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    start = text.find("### 3.1")
+    if start < 0:
+        die(f"{path.name}: '### 3.1' anchor not found")
+    rest = text[start:]
+    end = rest.find("\n### ", 1)
+    section = rest if end < 0 else rest[:end]
+    headers = set(HEADER_TOKEN.findall(section))
+    if not headers:
+        die(f"{path.name} §3.1: no `wirelog/*.h` tokens found")
+    return headers
+
+
+def parse_agents_md(repo_root: pathlib.Path) -> set[str]:
+    """Extract headers from AGENTS.md.
+
+    Anchors on the bold ``**Public API headers**`` marker; reads tokens
+    from every following line until the first blank line.
+    """
+    path = repo_root / "AGENTS.md"
+    text = path.read_text(encoding="utf-8")
+    marker = "**Public API headers**"
+    start = text.find(marker)
+    if start < 0:
+        die(f"{path.name}: '{marker}' anchor not found")
+    block_start = text.find("\n", start) + 1
+    block_end = text.find("\n\n", block_start)
+    if block_end < 0:
+        block_end = len(text)
+    headers = set(HEADER_TOKEN.findall(text[block_start:block_end]))
+    if not headers:
+        die(f"{path.name}: no `wirelog/*.h` tokens after marker")
+    return headers
+
+
+def parse_umbrella_header(repo_root: pathlib.Path) -> set[str]:
+    """Extract sub-header includes from wirelog/wirelog.h.
+
+    Reads quoted ``#include "wirelog/..."`` lines.  Excludes the
+    generated ``wirelog-version.h`` (covered by check-version-sync) and
+    the umbrella's own ``wirelog/wirelog.h`` self-reference.
+    """
+    path = repo_root / "wirelog" / "wirelog.h"
+    text = path.read_text(encoding="utf-8")
+    raw = set(
+        re.findall(
+            r'^#include\s+"(wirelog/[^"]+\.h)"', text, re.MULTILINE
+        )
+    )
+    raw.discard("wirelog/wirelog-version.h")
+    raw.discard("wirelog/wirelog.h")
+    return raw
+
+
+def parse_log_header_check(repo_root: pathlib.Path) -> set[str]:
+    """Extract PUBLIC_HEADERS array from scripts/check_log_header_not_public.sh."""
+    path = repo_root / "scripts" / "check_log_header_not_public.sh"
+    text = path.read_text(encoding="utf-8")
+    arr_match = re.search(r"PUBLIC_HEADERS=\(([^)]*)\)", text)
+    if not arr_match:
+        die(f"{path.name}: PUBLIC_HEADERS=( ... ) array not found")
+    return set(re.findall(r"(wirelog/[A-Za-z0-9_./-]+\.h)", arr_match.group(1)))
+
+
+def diff_report(
+    canonical: set[str], other: set[str], label: str
+) -> list[str]:
+    missing = sorted(canonical - other)
+    extra = sorted(other - canonical)
+    msgs: list[str] = []
+    if missing:
+        msgs.append(f"  {label}: missing {missing}")
+    if extra:
+        msgs.append(f"  {label}: extra {extra}")
+    return msgs
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        die("usage: check-public-header-surface.py [<repo_root>]")
+    repo_root = (
+        pathlib.Path(argv[1]).resolve()
+        if len(argv) == 2
+        else pathlib.Path(__file__).resolve().parents[2]
+    )
+
+    canonical = parse_meson_sot(repo_root)
+    # The umbrella header lists every public sub-header except itself
+    # (an umbrella does not include itself), so compare against the
+    # SoT minus the umbrella entry.
+    canonical_for_umbrella = canonical - {"wirelog/wirelog.h"}
+    plan_set = parse_plan_section(repo_root)
+
+    mirrors: list[tuple[str, set[str], set[str]]] = [
+        ("AGENTS.md", canonical, parse_agents_md(repo_root)),
+        (
+            "wirelog/wirelog.h umbrella",
+            canonical_for_umbrella,
+            parse_umbrella_header(repo_root),
+        ),
+        (
+            "scripts/check_log_header_not_public.sh PUBLIC_HEADERS",
+            canonical,
+            parse_log_header_check(repo_root),
+        ),
+    ]
+    if plan_set is not None:
+        mirrors.insert(
+            0, ("stable-release-plan.md §3.1", canonical, plan_set)
+        )
+    else:
+        print(
+            "check-public-header-surface: stable-release-plan.md absent, "
+            "skipping §3.1 cross-check (will activate when plan is "
+            "checked in)",
+            file=sys.stderr,
+        )
+
+    drift: list[str] = []
+    for label, expected, observed in mirrors:
+        drift.extend(diff_report(expected, observed, label))
+
+    if drift:
+        print("check-public-header-surface: drift detected", file=sys.stderr)
+        print(
+            f"  meson.build (SoT): {sorted(canonical)}", file=sys.stderr
+        )
+        for line in drift:
+            print(line, file=sys.stderr)
+        return 1
+
+    print(f"check-public-header-surface: OK ({len(canonical)} headers)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -397,6 +397,15 @@ test('version_sync', py3,
             meson.project_build_root() / 'wirelog'],
      suite: 'abi')
 
+# Issue #705 / Blocker B2: every in-tree mirror of the public header
+# surface must agree with `wirelog_public_headers` (plus the standalone
+# `install_headers('wirelog/io/io_adapter.h', ...)` call) in
+# meson.build. Static parse only — no build-tree input required.
+test('public_header_surface', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-public-header-surface.py',
+            meson.project_source_root()],
+     suite: 'abi')
+
 test_intern_exe = executable(
   'test_intern',
   files('test_intern.c'),

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -32,8 +32,9 @@
  *
  * Individual sub-headers (wirelog-types.h, wirelog-parser.h,
  * wirelog-ir.h, wirelog-optimizer.h, wirelog-export.h, wl_easy.h,
- * io/io_adapter.h) are still installed for backwards compatibility
- * but should not be included directly in new code.
+ * wirelog-advanced.h, io/io_adapter.h) are still installed for
+ * backwards compatibility but should not be included directly in
+ * new code.
  */
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

- Declares `meson.build`'s `wirelog_public_headers` (plus the
  standalone `install_headers('wirelog/io/io_adapter.h', ...)` call)
  the single source of truth for the public header surface.
- Fixes every in-tree mirror that drifted: `AGENTS.md`,
  `scripts/check_log_header_not_public.sh` PUBLIC_HEADERS array, and
  the `wirelog/wirelog.h` umbrella doc-comment.
- Adds `scripts/ci/check-public-header-surface.py` enforcing
  agreement between the SoT and every mirror; registers under
  `meson test --suite abi`.

## Why

`stable-release-plan.md` Blocker B2 requires a 3-way cross-check
between (a) the meson install list, (b) plan §3.1, (c) docs/AGENTS.
Today three real drifts exist:

1. `AGENTS.md:22-23` enumerates only 5 of 9 installed source-tree
   public headers (missing `wirelog-export.h`, `wl_easy.h`,
   `wirelog-advanced.h`, `wirelog/io/io_adapter.h`). It also
   misclassifies `wirelog/io/` as internal at line 26, which
   directly contradicts the install rule at `meson.build:295-298`.
2. `scripts/check_log_header_not_public.sh:12-21` PUBLIC_HEADERS is
   missing `wirelog/wirelog-advanced.h`, so the log.h-leak gate has
   not been inspecting that public header at all.
3. `wirelog/wirelog.h:33-37` doc-comment listing sub-headers also
   omits `wirelog-advanced.h`.

## What changes

| File | Change |
|---|---|
| `scripts/ci/check-public-header-surface.py` (new, +200 LoC) | Static parser; cross-validates `meson.build` ↔ AGENTS.md ↔ wirelog.h umbrella ↔ check_log_header_not_public.sh. Plan §3.1 cross-check is included when `stable-release-plan.md` is present (graceful skip with stderr notice when absent). |
| `tests/meson.build` | Register `public_header_surface` test under `suite: 'abi'`, mirroring `version_sync`. |
| `AGENTS.md` | Full 9-header list + SoT footnote pointing at meson.build; remove `wirelog/io/` from the internal-headers enumeration. |
| `scripts/check_log_header_not_public.sh` | Add `wirelog/wirelog-advanced.h` to PUBLIC_HEADERS array. |
| `wirelog/wirelog.h` | Add `wirelog-advanced.h` to the umbrella doc-comment. |

## What does NOT change

- `meson.build` (the SoT itself) — already correct.
- Public ABI / installed surface — no header is added or removed.
- `stable-release-plan.md` — tracked separately; not part of this PR.
- The generated `wirelog/wirelog-version.h` — exempt; covered by
  `check-version-sync.py`.

## Test plan

- [x] `meson test --suite abi`: 7/7 OK (including the new
      `public_header_surface`).
- [x] `python3 scripts/ci/check-public-header-surface.py`: `OK
      (9 headers)`, exit 0.
- [x] `bash scripts/check_log_header_not_public.sh`: exit 0.
- [x] Negative test: pre-fix tree (AGENTS.md missing 4 headers,
      PUBLIC_HEADERS missing 1) was correctly reported by the new
      gate before fixes were applied.
- [x] Plan-absent test: removing `stable-release-plan.md` from the
      tree leaves the script reporting `OK (9 headers)` with a
      stderr skip notice.

Closes #705