### PR TITLE
rename: wl_on_{delta,tuple}_fn -> wirelog_on_{delta,tuple}_fn (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to wirelog are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Callback typedefs renamed for v1.0 prefix conformance** (#758): the
+  public-API callback typedefs `wl_on_delta_fn` and `wl_on_tuple_fn`
+  in `wirelog/wirelog-types.h` are renamed to `wirelog_on_delta_fn` and
+  `wirelog_on_tuple_fn` respectively, matching the `AGENTS.md:17-20`
+  rule that public typedefs use the `wirelog_` prefix.  Source-
+  incompatible for downstream consumers of the
+  `wirelog_session_set_delta_cb` / `wirelog_session_snapshot` /
+  `wl_easy_set_delta_cb` / `wl_easy_snapshot` parameter types.  Migrate
+  via a textual rename; no signature change.  Tracked under
+  `docs/MIGRATION.md` 0.30 -> 1.0 section.  Part of public-API prefix
+  audit epic #755.
+
 ### Performance
 
 - **CRDT W=8 -6.3% via leading-key cache in compact_runs heap** (PR #731): the K-way merge in `col_rel_compact_runs` now shadows the leading column with a stack-resident `int64_t lead_key[]` array parallel to the heap entries; the inner sift-down comparator short-circuits on column 0 instead of indirecting through `col_rel_row_cmp` for every comparison. CRDT W=8 5-rep median moves from 19.43s to 18.20s (-6.3%); first time `W=8 < W=1` on the dev box. No row-layout change, no sort-algorithm change, no public-header surface impact. Cross-workload (DOOP / CSPA / Polonius / Galen / DDISASM) tuple counts and gold relations preserved.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,33 @@ steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
 
+## 0.30 -> 1.0
+
+This section accumulates the API renames and behaviour pins landing
+during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
+for the full scope.  Entries are filed atomically as the renames land;
+#745 then consolidates the narrative for the GA migration guide.
+
+### Callback typedef rename (#758)
+
+Public-API callback typedefs lose their internal `wl_*` prefix to
+match `AGENTS.md:17-20`:
+
+| Old (internal-style) | New (public conforming) |
+|---|---|
+| `wl_on_delta_fn` | `wirelog_on_delta_fn` |
+| `wl_on_tuple_fn` | `wirelog_on_tuple_fn` |
+
+Both typedefs live in `wirelog/wirelog-types.h` and are consumed by
+`wirelog/wirelog-advanced.h` (`wirelog_session_set_delta_cb`,
+`wirelog_session_snapshot`) and `wirelog/wl_easy.h`
+(`wl_easy_set_delta_cb`, `wl_easy_snapshot`).  Function-pointer
+parameter declarations rename to the new typedef names; the function
+signatures are otherwise unchanged.  Source-incompatible; existing
+callers update via a textual rename.
+
+---
+
 ## Compound Terms and RDF Named Graphs (Issue #530 / #535)
 
 Wirelog gains two additive features in this release. Both are strictly

--- a/examples/08-delta-queries/README.md
+++ b/examples/08-delta-queries/README.md
@@ -66,7 +66,7 @@ or retracted (diff = -1) when `wl_easy_step()` is called.
 ### 2. Callback Signature
 
 ```c
-typedef void (*wl_on_delta_fn)(
+typedef void (*wirelog_on_delta_fn)(
     const char *relation,  /* output relation name     */
     const int64_t *row,    /* column values (IDs)      */
     uint32_t ncols,        /* number of columns        */

--- a/tests/fpga_backend.c
+++ b/tests/fpga_backend.c
@@ -75,7 +75,7 @@ typedef struct {
     fpga_rel_t *relations;
     uint32_t rel_count;
     uint32_t rel_cap;
-    wl_on_delta_fn delta_cb;
+    wirelog_on_delta_fn delta_cb;
     void *delta_user_data;
 } wl_fpga_session_t;
 
@@ -947,7 +947,7 @@ fpga_session_remove(wl_session_t *session, const char *relation,
 }
 
 static void
-fpga_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
+fpga_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     void *user_data)
 {
     wl_fpga_session_t *s = (wl_fpga_session_t *)session;
@@ -1112,7 +1112,7 @@ fpga_session_step(wl_session_t *session)
 }
 
 static int
-fpga_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
+fpga_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     void *user_data)
 {
     wl_fpga_session_t *s = (wl_fpga_session_t *)session;

--- a/tests/test_delta_arrangement.c
+++ b/tests/test_delta_arrangement.c
@@ -40,29 +40,29 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                      \
-    do {                                                \
-        test_count++;                                   \
-        printf("TEST %d: %s ... ", test_count, (name)); \
-    } while (0)
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                    \
-    do {                             \
-        fail_count++;                \
-        printf("FAIL: %s\n", (msg)); \
-        return;                      \
-    } while (0)
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond))      \
+        do {                  \
+            if (!(cond))      \
             FAIL(msg);    \
-    } while (0)
+        } while (0)
 
 /* ----------------------------------------------------------------
  * Private session mirror (partial)
@@ -79,7 +79,7 @@ static int fail_count = 0;
  *   col_rel_t    **rels          (8)
  *   uint32_t       nrels         (4)
  *   uint32_t       rel_cap       (4)
- *   wl_on_delta_fn delta_cb      (8)  -- function pointer
+ *   wirelog_on_delta_fn delta_cb      (8)  -- function pointer
  *   void          *delta_data    (8)
  *   wl_arena_t    *eval_arena    (8)
  *   col_mat_cache_t mat_cache    (sizeof(col_mat_cache_t))
@@ -132,7 +132,7 @@ count_cb(const char *rel, const int64_t *row, uint32_t nc, void *u)
 
 static int
 run_program(const char *src, const char *rel, int64_t *out_count,
-            uint32_t *out_iters, wl_session_t **out_sess_keep)
+    uint32_t *out_iters, wl_session_t **out_sess_keep)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -201,12 +201,12 @@ test_delta_arr_tc_3edge(void)
     TEST("TC 3-edge: delta arrangement probe produces 6 tuples");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 3). r(3, 4).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 3). r(3, 4).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count = 0;
     ASSERT(run_program(src, "r", &count, NULL, NULL) == 0,
-           "TC 3-edge program failed");
+        "TC 3-edge program failed");
     ASSERT(count == 6, "expected 6 tuples from 3-edge TC");
 
     PASS();
@@ -224,12 +224,12 @@ test_delta_arr_tc_2cycle(void)
     TEST("TC 2-cycle: delta arrangement self-join = 4 tuples");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 1).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 1).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count = 0;
     ASSERT(run_program(src, "r", &count, NULL, NULL) == 0,
-           "2-cycle program failed");
+        "2-cycle program failed");
     ASSERT(count == 4, "expected 4 tuples from 2-cycle TC");
 
     PASS();
@@ -249,15 +249,15 @@ test_delta_arr_5node_chain(void)
     TEST("5-node chain: stale delta detected and rebuilt, 10 tuples");
 
     const char *src = ".decl e(x: int32, y: int32)\n"
-                      "e(1, 2). e(2, 3). e(3, 4). e(4, 5).\n"
-                      ".decl reach(x: int32, y: int32)\n"
-                      "reach(x, y) :- e(x, y).\n"
-                      "reach(x, z) :- reach(x, y), reach(y, z).\n";
+        "e(1, 2). e(2, 3). e(3, 4). e(4, 5).\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(x, y) :- e(x, y).\n"
+        "reach(x, z) :- reach(x, y), reach(y, z).\n";
 
     int64_t count = 0;
     uint32_t iters = 0;
     ASSERT(run_program(src, "reach", &count, &iters, NULL) == 0,
-           "5-node chain program failed");
+        "5-node chain program failed");
     ASSERT(count == 10, "expected 10 tuples from 5-node chain");
     ASSERT(iters >= 2, "5-node chain needs at least 2 iterations");
 
@@ -276,14 +276,14 @@ test_delta_arr_complete_graph_dedup(void)
     TEST("Complete 3-node graph: delta arrangement dedup = 9 tuples (KI-1)");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 1). r(1, 3). r(3, 1). r(2, 3). r(3, 2).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 1). r(1, 3). r(3, 1). r(2, 3). r(3, 2).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count = 0;
     ASSERT(run_program(src, "r", &count, NULL, NULL) == 0,
-           "complete-graph program failed");
+        "complete-graph program failed");
     ASSERT(count == 9,
-           "expected 9 tuples (KI-1 regression check with delta arrangement)");
+        "expected 9 tuples (KI-1 regression check with delta arrangement)");
 
     PASS();
 }
@@ -304,18 +304,18 @@ test_delta_arr_worker_isolation(void)
     TEST("Worker isolation: main session darr_count == 0 after evaluation");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 3). r(3, 4).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 3). r(3, 4).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     wl_session_t *sess = NULL;
     int64_t count = 0;
     ASSERT(run_program(src, "r", &count, NULL, &sess) == 0,
-           "TC 3-edge program failed");
+        "TC 3-edge program failed");
     ASSERT(count == 6, "expected 6 tuples");
 
     uint32_t darr_count = col_session_get_darr_count(sess);
     ASSERT(darr_count == 0,
-           "darr_count must be 0 on main session: delta caches are per-worker");
+        "darr_count must be 0 on main session: delta caches are per-worker");
 
     wl_session_destroy(sess);
     PASS();

--- a/wirelog/backend.h
+++ b/wirelog/backend.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-/* wl_on_tuple_fn / wl_on_delta_fn now live in wirelog-types.h (single source of truth). */
+/* wirelog_on_tuple_fn / wirelog_on_delta_fn now live in wirelog-types.h (single source of truth). */
 
 /**
  * wl_session_t:
@@ -80,10 +80,11 @@ typedef struct {
 
     int (*session_step)(wl_session_t *session);
 
-    void (*session_set_delta_cb)(wl_session_t *session, wl_on_delta_fn callback,
+    void (*session_set_delta_cb)(wl_session_t *session,
+        wirelog_on_delta_fn callback,
         void *user_data);
 
-    int (*session_snapshot)(wl_session_t *session, wl_on_tuple_fn callback,
+    int (*session_snapshot)(wl_session_t *session, wirelog_on_tuple_fn callback,
         void *user_data);
 } wl_compute_backend_t;
 

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -764,7 +764,7 @@ typedef struct wl_col_session_t {
     uint32_t *rel_hash_next;      /* owned collision chain pointers           */
     uint32_t rel_hash_nbuckets;   /* current bucket count (power of 2)       */
     uint32_t rel_hash_chain_cap;  /* allocated capacity of rel_hash_next[]  */
-    wl_on_delta_fn delta_cb;   /* delta callback (NULL = disabled)       */
+    wirelog_on_delta_fn delta_cb;   /* delta callback (NULL = disabled)       */
     void *delta_data;          /* opaque user context for delta_cb       */
     wl_arena_t *eval_arena;    /* arena for per-iteration temporaries    */
     col_mat_cache_t mat_cache; /* materialization cache (US-006)        */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2144,7 +2144,7 @@ col_session_step(wl_session_t *session)
  * @param user_data: Opaque pointer passed through to callback
  */
 static void
-col_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
+col_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     void *user_data)
 {
     if (!session)
@@ -2174,7 +2174,7 @@ col_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
  * @return 0 on success, EINVAL if session/callback NULL, non-zero on eval error
  */
 static int
-col_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
+col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     void *user_data)
 {
     if (!session || !callback)

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -89,7 +89,7 @@ wl_session_step(wl_session_t *session)
 }
 
 void
-wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
+wl_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     void *user_data)
 {
     if (!session || !session->backend
@@ -99,7 +99,7 @@ wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
 }
 
 int
-wl_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
+wl_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     void *user_data)
 {
     if (!session || !session->backend || !session->backend->session_snapshot)

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -159,7 +159,7 @@ wl_session_step(wl_session_t *session);
  * on output records as the session advances via wl_session_step.
  */
 void
-wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
+wl_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     void *user_data);
 
 /**
@@ -176,7 +176,7 @@ wl_session_set_delta_cb(wl_session_t *session, wl_on_delta_fn callback,
  *   -1 on execution failure or invalid session.
  */
 int
-wl_session_snapshot(wl_session_t *session, wl_on_tuple_fn callback,
+wl_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     void *user_data);
 
 #ifdef __cplusplus

--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -195,7 +195,7 @@ wirelog_session_step(wirelog_session_t *session);
  */
 wirelog_error_t
 wirelog_session_set_delta_cb(wirelog_session_t *session,
-    wl_on_delta_fn callback, void *user_data);
+    wirelog_on_delta_fn callback, void *user_data);
 
 /**
  * wirelog_session_snapshot:
@@ -212,7 +212,8 @@ wirelog_session_set_delta_cb(wirelog_session_t *session,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wirelog_session_snapshot(wirelog_session_t *session, wl_on_tuple_fn callback,
+wirelog_session_snapshot(wirelog_session_t *session,
+    wirelog_on_tuple_fn callback,
     void *user_data);
 
 /**

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -130,7 +130,7 @@ typedef bool wirelog_bool_t;
 /* ======================================================================== */
 
 /**
- * wl_on_tuple_fn:
+ * wirelog_on_tuple_fn:
  *
  * Callback invoked once per computed output tuple.
  *
@@ -139,11 +139,11 @@ typedef bool wirelog_bool_t;
  * @ncols:     Number of columns in the row.
  * @user_data: Opaque pointer passed through from the caller.
  */
-typedef void (*wl_on_tuple_fn)(const char *relation, const int64_t *row,
+typedef void (*wirelog_on_tuple_fn)(const char *relation, const int64_t *row,
     uint32_t ncols, void *user_data);
 
 /**
- * wl_on_delta_fn:
+ * wirelog_on_delta_fn:
  *
  * Callback invoked when a tuple is inserted/removed in an incremental session.
  *
@@ -153,7 +153,7 @@ typedef void (*wl_on_tuple_fn)(const char *relation, const int64_t *row,
  * @diff:      +1 for insertion, -1 for removal.
  * @user_data: Opaque pointer passed through from the caller.
  */
-typedef void (*wl_on_delta_fn)(const char *relation, const int64_t *row,
+typedef void (*wirelog_on_delta_fn)(const char *relation, const int64_t *row,
     uint32_t ncols, int32_t diff, void *user_data);
 
 /* ======================================================================== */

--- a/wirelog/wirelog_advanced.c
+++ b/wirelog/wirelog_advanced.c
@@ -152,7 +152,7 @@ wirelog_session_step(wirelog_session_t *session)
 
 wirelog_error_t
 wirelog_session_set_delta_cb(wirelog_session_t *session,
-    wl_on_delta_fn callback, void *user_data)
+    wirelog_on_delta_fn callback, void *user_data)
 {
     if (!session)
         return WIRELOG_ERR_EXEC;
@@ -161,7 +161,8 @@ wirelog_session_set_delta_cb(wirelog_session_t *session,
 }
 
 wirelog_error_t
-wirelog_session_snapshot(wirelog_session_t *session, wl_on_tuple_fn callback,
+wirelog_session_snapshot(wirelog_session_t *session,
+    wirelog_on_tuple_fn callback,
     void *user_data)
 {
     if (!session || !callback)

--- a/wirelog/wl_easy.c
+++ b/wirelog/wl_easy.c
@@ -358,7 +358,8 @@ wl_easy_step(wl_easy_session_t *s)
 }
 
 wirelog_error_t
-wl_easy_set_delta_cb(wl_easy_session_t *s, wl_on_delta_fn cb, void *user_data)
+wl_easy_set_delta_cb(wl_easy_session_t *s, wirelog_on_delta_fn cb,
+    void *user_data)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
@@ -444,7 +445,7 @@ wl_easy_banner(const char *label)
 
 typedef struct {
     const char *wanted;
-    wl_on_tuple_fn user_cb;
+    wirelog_on_tuple_fn user_cb;
     void *user_data;
 } wl_easy_snapshot_filter_t;
 
@@ -462,7 +463,8 @@ snapshot_trampoline(const char *relation, const int64_t *row, uint32_t ncols,
 }
 
 wirelog_error_t
-wl_easy_snapshot(wl_easy_session_t *s, const char *relation, wl_on_tuple_fn cb,
+wl_easy_snapshot(wl_easy_session_t *s, const char *relation,
+    wirelog_on_tuple_fn cb,
     void *user_data)
 {
     if (!s || !relation || !cb)

--- a/wirelog/wl_easy.h
+++ b/wirelog/wl_easy.h
@@ -280,7 +280,8 @@ wl_easy_step(wl_easy_session_t *s);
  * plan/session build failure.  A NULL @s returns WIRELOG_ERR_EXEC.
  */
 wirelog_error_t
-wl_easy_set_delta_cb(wl_easy_session_t *s, wl_on_delta_fn cb, void *user_data);
+wl_easy_set_delta_cb(wl_easy_session_t *s, wirelog_on_delta_fn cb,
+    void *user_data);
 
 /**
  * wl_easy_print_delta:
@@ -331,7 +332,8 @@ wl_easy_banner(const char *label);
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_snapshot(wl_easy_session_t *s, const char *relation, wl_on_tuple_fn cb,
+wl_easy_snapshot(wl_easy_session_t *s, const char *relation,
+    wirelog_on_tuple_fn cb,
     void *user_data);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Public-API callback typedefs `wl_on_delta_fn` and `wl_on_tuple_fn`
in `wirelog/wirelog-types.h` carried internal `wl_*` prefixes on
a public installed header, violating the `AGENTS.md:17-20`
naming-convention rule (public typedefs use `wirelog_*`).

This PR renames the typedefs atomically across all 28 references
(13 files: 4 public headers, 7 internal sources, 2 tests, 1
example doc).  Function signatures and parameter shapes are
unchanged; only the typedef name moves.

## Test plan

- [x] `grep -rE '\bwl_on_(delta|tuple)_fn\b'` returns zero
      matches across the entire repo
- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] CHANGELOG `[Unreleased]` records the rename under "Changed"
- [x] `docs/MIGRATION.md` gains a `0.30 -> 1.0` stub section with
      the rename table
- [ ] CI: `meson test -C build --suite abi` (header SSoT)
- [ ] CI: full default suite on the GitHub runner

## Cross-references

Closes #758.  Part of public-API prefix audit epic #755.
Sequencing: lands first; #756 (wl_easy_*) rebases on this when
it lands next.