### PR TITLE
rename: wl_intern_t -> wirelog_intern_t on public umbrella header (#760)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **Public-API typedef renamed for v1.0 prefix conformance** (#760):
+  the `wirelog/wirelog.h` umbrella header no longer exposes the
+  internal-style `wl_intern_t` typedef name.  The new public name is
+  `wirelog_intern_t`; `wirelog_program_get_intern()` returns
+  `const wirelog_intern_t *`.  The internal header
+  `wirelog/intern.h` keeps `typedef struct wl_intern wl_intern_t;`
+  for in-tree callers (both names alias the same struct).  Two
+  docstrings that previously named the internal `wl_dd_load_edb()`
+  helper are rephrased to refer to it as the project's internal
+  EDB-load helper.  Source-incompatible for downstream consumers
+  using `wl_intern_t` after including only `wirelog/wirelog.h`;
+  migrate via a textual rename to `wirelog_intern_t`.  Part of
+  public-API prefix audit epic #755.
 - **Callback typedefs renamed for v1.0 prefix conformance** (#758): the
   public-API callback typedefs `wl_on_delta_fn` and `wl_on_tuple_fn`
   in `wirelog/wirelog-types.h` are renamed to `wirelog_on_delta_fn` and

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,30 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### Public-API typedef rename: wl_intern_t -> wirelog_intern_t (#760)
+
+The `wirelog/wirelog.h` umbrella header previously exposed
+`typedef struct wl_intern wl_intern_t;` -- an internal-style
+`wl_*` typedef name on a public installed header.  The struct
+tag (`struct wl_intern`) is internal and stays internal; only
+the typedef name on the public surface changes:
+
+| Old (internal-style on public surface) | New (public conforming) |
+|---|---|
+| `wl_intern_t` (in `wirelog/wirelog.h`) | `wirelog_intern_t` |
+
+`wirelog_program_get_intern()` now returns
+`const wirelog_intern_t *` instead of `const wl_intern_t *`.
+The internal header `wirelog/intern.h` continues to declare
+`typedef struct wl_intern wl_intern_t;` for in-tree callers
+(both names alias the same struct), so internal code is
+unchanged.
+
+Two docstrings in `wirelog/wirelog.h` previously referenced the
+internal helper `wl_dd_load_edb()` by name; they are rephrased
+to refer to "the project's internal EDB-load helper" without
+naming the internal symbol on the public surface.
+
 ### Callback typedef rename (#758)
 
 Public-API callback typedefs lose their internal `wl_*` prefix to

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -150,7 +150,12 @@ wirelog_program_free(wirelog_program_t *program);
 /* Symbol Interning                                                         */
 /* ======================================================================== */
 
-typedef struct wl_intern wl_intern_t;
+/* Public-API typedef for the program's symbol intern table.  The
+ * underlying struct (`struct wl_intern`) is internal and remains
+ * accessible inside the project tree as `wl_intern_t` via
+ * `wirelog/intern.h`; downstream consumers see only the
+ * conformant public name. */
+typedef struct wl_intern wirelog_intern_t;
 
 /**
  * Get the program's symbol intern table for reverse-mapping
@@ -159,7 +164,7 @@ typedef struct wl_intern wl_intern_t;
  * @param prog  Compiled program
  * @return Intern table (owned by program, do not free), or NULL
  */
-const wl_intern_t *
+const wirelog_intern_t *
 wirelog_program_get_intern(const wirelog_program_t *prog);
 
 /* ======================================================================== */
@@ -188,8 +193,9 @@ wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
  * Load all inline facts from the program into a DD worker.
  *
  * Iterates over all relations with inline facts (fact_count > 0) and
- * calls wl_dd_load_edb() for each.  This bridges the parser's fact
- * storage with the DD execution engine.
+ * loads each batch into the DD execution engine via the project's
+ * internal EDB-load helper.  This bridges the parser's fact storage
+ * with the DD execution engine.
  *
  * @param prog    Compiled program with inline facts
  * @param worker  DD worker handle to load facts into
@@ -203,7 +209,7 @@ wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
  *
  * Iterates over all relations with has_input=true, reads the "filename"
  * and "delimiter" parameters, parses the CSV file, and loads the data
- * into the DD worker via wl_dd_load_edb().
+ * into the DD worker via the project's internal EDB-load helper.
  *
  * @param prog    Compiled program with .input directives
  * @param worker  DD worker handle to load facts into


### PR DESCRIPTION
## Summary

`wirelog/wirelog.h` (public installed header) re-declared the
internal-style `wl_intern_t` typedef.  This PR renames the
public-surface typedef to `wirelog_intern_t` per
`AGENTS.md:17-20`; the underlying struct tag (`struct wl_intern`)
and the internal `wirelog/intern.h` typedef remain unchanged so
in-tree callers are not affected.

Two docstrings naming the internal helper `wl_dd_load_edb()` on
the public umbrella are rephrased to refer to it generically.

## Test plan

- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] `grep -nE 'wl_intern_t|wl_dd_load_edb' wirelog/wirelog.h`:
      zero matches (typedef renamed; docstrings rephrased)
- [x] CHANGELOG `[Unreleased]` records the rename
- [x] `docs/MIGRATION.md` 0.30 -> 1.0 section gains the entry
- [ ] CI: full default + abi + sanitizer matrix

Closes #760.  Part of public-API prefix audit epic #755.