### PR TITLE
rename: WL_PUBLIC -> WIRELOG_PUBLIC export-attribute macro (#759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **Export-attribute macro renamed for v1.0 prefix conformance**
+  (#759): `wirelog/wirelog-export.h` no longer defines
+  `WL_PUBLIC`; the new public name is `WIRELOG_PUBLIC`.
+  `WIRELOG_API` continues as the alias and remains the recommended
+  attribute name for new public-API declarations.  Source-
+  incompatible for downstream code that referenced `WL_PUBLIC`
+  directly; migrate via a textual rename to `WIRELOG_PUBLIC` (or
+  switch to `WIRELOG_API`).  Part of public-API prefix audit
+  epic #755.
 - **String-fn enum constants renamed for v1.0 prefix conformance**
   (#757): the 12 `WL_STR_FN_*` enum constants in
   `wirelog/wirelog-types.h` (declaring the string-op kinds shipped

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,27 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### Export-attribute macro rename: WL_PUBLIC -> WIRELOG_PUBLIC (#759)
+
+`wirelog/wirelog-export.h` previously defined `WL_PUBLIC` as
+the symbol-visibility / dllexport attribute macro that gates
+every exported function on the public surface
+(`WL_PUBLIC int wirelog_session_create(...)`, etc.).  The
+`WL_*` prefix on a public macro contradicts `AGENTS.md:17-20`.
+
+The macro is renamed in a clean break:
+
+| Old | New |
+|---|---|
+| `WL_PUBLIC` (in `wirelog/wirelog-export.h`) | `WIRELOG_PUBLIC` |
+
+`WIRELOG_API` continues as the existing alias (now defined as
+`#define WIRELOG_API WIRELOG_PUBLIC`), and remains the
+recommended attribute name for new public-API declarations.
+Source-incompatible for downstream code that referenced
+`WL_PUBLIC` directly; migrate via a textual rename to
+`WIRELOG_PUBLIC` (or, preferred, switch to `WIRELOG_API`).
+
 ### String-fn enum constants rename (#757)
 
 The 12 `WL_STR_FN_*` enum constants in `wirelog/wirelog-types.h`

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -117,14 +117,15 @@ typedef struct wl_io_adapter {
  *   wl_io_find_adapter        pointer to adapter, or NULL if not found
  */
 
-WL_PUBLIC int wl_io_register_adapter(const wl_io_adapter_t *adapter) WL_IO_USED;
+WIRELOG_PUBLIC int wl_io_register_adapter(
+    const wl_io_adapter_t *adapter) WL_IO_USED;
 
-WL_PUBLIC int wl_io_unregister_adapter(const char *scheme) WL_IO_USED;
+WIRELOG_PUBLIC int wl_io_unregister_adapter(const char *scheme) WL_IO_USED;
 
-WL_PUBLIC const wl_io_adapter_t *wl_io_find_adapter(
+WIRELOG_PUBLIC const wl_io_adapter_t *wl_io_find_adapter(
     const char *scheme) WL_IO_USED;
 
-WL_PUBLIC const char *wl_io_last_error(void);
+WIRELOG_PUBLIC const char *wl_io_last_error(void);
 
 /* ======================================================================== */
 /* Plugin Entry Point (Path B, Issue #461)                                  */

--- a/wirelog/wirelog-export.h
+++ b/wirelog/wirelog-export.h
@@ -11,20 +11,20 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
   #ifdef WIRELOG_BUILDING
-    #define WL_PUBLIC __declspec(dllexport)
+    #define WIRELOG_PUBLIC __declspec(dllexport)
   #else
-    #define WL_PUBLIC __declspec(dllimport)
+    #define WIRELOG_PUBLIC __declspec(dllimport)
   #endif
 #elif defined(__GNUC__) && __GNUC__ >= 4
-  #define WL_PUBLIC __attribute__((visibility("default")))
+  #define WIRELOG_PUBLIC __attribute__((visibility("default")))
 #else
-  #define WL_PUBLIC
+  #define WIRELOG_PUBLIC
 #endif
 
-/* Public-API attribute macro.  Alias of WL_PUBLIC defined unconditionally
+/* Public-API attribute macro.  Alias of WIRELOG_PUBLIC defined unconditionally
  * above; new code should prefer WIRELOG_API for clarity.  The full
  * adoption sweep across existing prototypes is tracked separately. */
-#define WIRELOG_API WL_PUBLIC
+#define WIRELOG_API WIRELOG_PUBLIC
 
 /* WIRELOG_DEPRECATED_SINCE(major, minor): annotate APIs scheduled for
  * removal.  Expands to a compile-time deprecation warning on


### PR DESCRIPTION
## Summary

`wirelog/wirelog-export.h` defined the public symbol-visibility /
dllexport macro as `WL_PUBLIC`, using the internal `WL_*` prefix
on what is arguably the most foundational public macro in the
build.  This PR renames it to `WIRELOG_PUBLIC` per
`AGENTS.md:17-20`.

`WIRELOG_API` continues as the existing alias and remains the
recommended attribute name for new public-API declarations.

## Test plan

- [x] `grep -rE '\bWL_PUBLIC\b'` returns zero matches
- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] CHANGELOG `[Unreleased]` records the rename
- [x] `docs/MIGRATION.md` 0.30 -> 1.0 section gains the entry
- [ ] CI: full default + abi + sanitizer matrix

Closes #759.  Part of public-API prefix audit epic #755.