### PR TITLE
rename: wl_easy facade -> wirelog_easy, move to wirelog-easy.{c,h} (#756)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ python script.py
 | **Internal** (not installed) | `wl_` | `WL_` |
 
 **Public API headers** (installed, user-facing):
-`wirelog/wirelog.h`, `wirelog/wirelog-types.h`, `wirelog/wirelog-ir.h`, `wirelog/wirelog-parser.h`, `wirelog/wirelog-optimizer.h`, `wirelog/wirelog-export.h`, `wirelog/wl_easy.h`, `wirelog/wirelog-advanced.h`, `wirelog/io/io_adapter.h`
+`wirelog/wirelog.h`, `wirelog/wirelog-types.h`, `wirelog/wirelog-ir.h`, `wirelog/wirelog-parser.h`, `wirelog/wirelog-optimizer.h`, `wirelog/wirelog-export.h`, `wirelog/wirelog-easy.h`, `wirelog/wirelog-advanced.h`, `wirelog/io/io_adapter.h`
 
 > Single source of truth: `wirelog_public_headers` in `meson.build`
 > (plus the standalone `install_headers('wirelog/io/io_adapter.h', ...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **wl_easy facade renamed and moved for v1.0 prefix conformance**
+  (#756): the `wl_easy` convenience facade is renamed across its
+  entire surface from `wl_easy_*` / `WL_EASY_*` to
+  `wirelog_easy_*` / `WIRELOG_EASY_*`.  The header and source
+  files move from `wirelog/wl_easy.h` / `wirelog/wl_easy.c` to
+  `wirelog/wirelog-easy.h` / `wirelog/wirelog-easy.c`; test files
+  move accordingly.  `AGENTS.md` public-headers list and
+  `meson.build` SSoT entries update with the move.  Source-
+  incompatible across the entire facade; downstream consumers
+  update `#include` paths plus a textual symbol rename.  Part of
+  public-API prefix audit epic #755.
 - **Export-attribute macro renamed for v1.0 prefix conformance**
   (#759): `wirelog/wirelog-export.h` no longer defines
   `WL_PUBLIC`; the new public name is `WIRELOG_PUBLIC`.
@@ -42,7 +53,7 @@ All notable changes to wirelog are documented in this file.
   rule that public typedefs use the `wirelog_` prefix.  Source-
   incompatible for downstream consumers of the
   `wirelog_session_set_delta_cb` / `wirelog_session_snapshot` /
-  `wl_easy_set_delta_cb` / `wl_easy_snapshot` parameter types.  Migrate
+  `wirelog_easy_set_delta_cb` / `wirelog_easy_snapshot` parameter types.  Migrate
   via a textual rename; no signature change.  Tracked under
   `docs/MIGRATION.md` 0.30 -> 1.0 section.  Part of public-API prefix
   audit epic #755.
@@ -55,12 +66,12 @@ All notable changes to wirelog are documented in this file.
 
 - **CRDT median-time perf gate** (PR #731): `tests/test_crdt_perf_gate.c` registered under `meson test --suite perf`. Drives the same Datalog source as `bench_flowlog --workload crdt` through the public `wirelog_*` API, asserts tuple count == 1,301,914 before any timing assertion, asserts coefficient of variation <= 3% (else SKIP), asserts median wall <= `WL_CRDT_PERF_GATE_TARGET_MS` (19,840 ms = baseline 18,890 ms x 1.05). Three-mode SKIP/SKIP/FAIL behaviour: SKIP by default; FAIL-loud under `WIRELOG_PERF_REQUIRE=1` when the cpufreq governor is not `performance` OR when the build is not `-Dwirelog_log_max_level=error` (per #731 follow-up commit). The escalator pattern lets dev hosts run `meson test --suite perf` cleanly while merge runners that opt into REQUIRE mode catch misconfiguration loud.
 - **`bench/bench_crdt_workload.h`** (PR #731): the CRDT verification template is moved out of `bench_flowlog.c` into a shared header so the bench driver and the perf gate cannot drift on rule structure.
-- **`wirelog/wirelog-advanced.h`** (#717, #703): New public header exposing the fine-grained `wirelog_session_*` API as the stable peer of `wl_easy`. Eight thin wrappers (`create` / `destroy` / `insert` / `remove` / `step` / `set_delta_cb` / `snapshot` / `make_compound`) over the internal session primitives. Backend selection through the `wirelog_backend_kind_t` enum (`DEFAULT` / `COLUMNAR`) — no vtable exposure. Inline `.dl` facts are seeded eagerly at `wirelog_session_create()` time, matching the wl_easy contract from #718. Internal `wl_session_*` and `wl_compute_backend_t` remain private.
+- **`wirelog/wirelog-advanced.h`** (#717, #703): New public header exposing the fine-grained `wirelog_session_*` API as the stable peer of `wirelog_easy`. Eight thin wrappers (`create` / `destroy` / `insert` / `remove` / `step` / `set_delta_cb` / `snapshot` / `make_compound`) over the internal session primitives. Backend selection through the `wirelog_backend_kind_t` enum (`DEFAULT` / `COLUMNAR`) — no vtable exposure. Inline `.dl` facts are seeded eagerly at `wirelog_session_create()` time, matching the wirelog_easy contract from #718. Internal `wl_session_*` and `wl_compute_backend_t` remain private.
 - **CI guard** (#717): `scripts/ci/check-advanced-header.sh` (suite `abi`) fails when `wirelog/wirelog-advanced.h` includes any internal header.
 
 ### Fixed
 
-- **wl_easy inline-fact materialization** (#718): `wl_easy_open` now seeds inline `.dl` facts into the columnar session at first lazy build, matching the CLI driver's order-of-operations. Previously the wl_easy facade dropped every static fact silently, so snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows.
+- **wirelog_easy inline-fact materialization** (#718): `wirelog_easy_open` now seeds inline `.dl` facts into the columnar session at first lazy build, matching the CLI driver's order-of-operations. Previously the wirelog_easy facade dropped every static fact silently, so snapshots and IDB derivations re-evaluated against an empty EDB and returned no rows.
 
 ### Added
 
@@ -73,7 +84,7 @@ All notable changes to wirelog are documented in this file.
 - **README.md** (#717): replace the now-misleading `wl_session_*` / `wirelog/session.h` advisory with `wirelog_session_*` / `wirelog/wirelog-advanced.h`. The internal session header is explicitly called out as private.
 - **`docs/SEMANTICS.md`** (#718): new document recording the engine's observable semantic-model decisions and the path toward 1.0 stabilization. First entry: inline `.dl` fact loading rules and the z-set host insert/remove model (status: Current).
 - **`docs/SEMANTICS.md`** (#717): promote the cross-facade parity section from Future to Current now that the advanced surface ships.
-- **`wirelog/wirelog.h`** (#717): expand the `wirelog_executor_t` docstring to clarify that it is the batch facade and to point at `wirelog_session_t` / `wl_easy_session_t` for incremental delta-callback workflows.
+- **`wirelog/wirelog.h`** (#717): expand the `wirelog_executor_t` docstring to clarify that it is the batch facade and to point at `wirelog_session_t` / `wirelog_easy_session_t` for incremental delta-callback workflows.
 
 ## [0.30.0] - 2026-05-07
 
@@ -81,7 +92,7 @@ All notable changes to wirelog are documented in this file.
 
 - **I/O Adapter Framework** (#446): User-defined I/O adapters via runtime registry (`wl_io_register_adapter`). Public header `wirelog/io/io_adapter.h` with opaque context, ABI versioning (`WL_IO_ABI_VERSION=1`), and thread-safe registration API
 - **Built-in CSV Adapter** (#455): CSV loading refactored into the adapter framework; backward-compatible `.input(filename=...)` dispatch
-- **wl_easy Facade** (#445): Simplified high-level API (`wl_easy.h`) for common session workflows
+- **wirelog_easy Facade** (#445): Simplified high-level API (`wirelog-easy.h`) for common session workflows
 - **String Operations** (#444): String-typed column functions (`strlen`, `cat`, `substr`, `contains`, `to_upper`, `to_lower`, `trim`, `str_replace`, `to_string`, `to_number`)
 - **Path A Example** (#462): Standalone pcap adapter skeleton with CI compile-check against installed headers
 - **C11 Threading Backend** (#494): Add C11 `<threads.h>` backend with auto-detection; POSIX/MSVC fallback preserved. `call_once` pattern for adapter registry initialization

--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ path(X, Y) :- edge(X, Y).
 path(X, Z) :- path(X, Y), edge(Y, Z).
 ```
 
-Run it from C using the `wl_easy` facade:
+Run it from C using the `wirelog_easy` facade:
 
 ```c
-#include <wirelog/wirelog.h>  /* umbrella: pulls in wl_easy and the rest */
+#include <wirelog/wirelog.h>  /* umbrella: pulls in wirelog_easy and the rest */
 
 int main(void) {
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(
             ".decl edge(a:symbol,b:symbol)\n"
             ".decl path(a:symbol,b:symbol)\n"
             "path(X,Y) :- edge(X,Y).\n"
             "path(X,Z) :- path(X,Y), edge(Y,Z).\n", &s) != WIRELOG_OK)
         return 1;
 
-    wl_easy_set_delta_cb(s, wl_easy_print_delta, s);
-    wl_easy_insert_sym(s, "edge", "a", "b", NULL);
-    wl_easy_insert_sym(s, "edge", "b", "c", NULL);
-    wl_easy_step(s);   /* prints: + path("a","b"), + path("b","c"), + path("a","c") */
-    wl_easy_close(s);
+    wirelog_easy_set_delta_cb(s, wirelog_easy_print_delta, s);
+    wirelog_easy_insert_sym(s, "edge", "a", "b", NULL);
+    wirelog_easy_insert_sym(s, "edge", "b", "c", NULL);
+    wirelog_easy_step(s);   /* prints: + path("a","b"), + path("b","c"), + path("a","c") */
+    wirelog_easy_close(s);
     return 0;
 }
 ```
@@ -140,7 +140,7 @@ done
 | `05-crc32-checksum` | CRC32 checksum validation |
 | `06-timestamp-lww` | Last-write-wins timestamp resolution |
 | `07-multi-source-analysis` | Set operations across data sources |
-| `08-delta-queries` | Delta callbacks with `wl_easy` |
+| `08-delta-queries` | Delta callbacks with `wirelog_easy` |
 | `09-retraction-basics` | Fact retraction with `-1` deltas |
 | `10-recursive-under-update` | Transitive closure under insert/remove |
 | `11-time-evolution` | Per-epoch delta isolation |
@@ -264,7 +264,7 @@ external-consumer audit.
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification
 - [CLA.md](CLA.md) -- Contributor License Agreement (required for dual licensing)
-- API: [`wirelog/wl_easy.h`](wirelog/wl_easy.h) (simple) | [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h) (advanced)
+- API: [`wirelog/wirelog-easy.h`](wirelog/wirelog-easy.h) (simple) | [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h) (advanced)
 
 ## License
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,52 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### wl_easy facade rename + file move (#756)
+
+The `wl_easy` convenience facade carried internal `wl_*`
+prefixes on a public installed header (`wirelog/wl_easy.h`).
+Per `AGENTS.md:17-20`, public symbols and headers must use
+the `wirelog_*` / `WIRELOG_*` prefix and (by convention) the
+`wirelog-` filename prefix.
+
+File moves:
+
+| Old path | New path |
+|---|---|
+| `wirelog/wl_easy.h` | `wirelog/wirelog-easy.h` |
+| `wirelog/wl_easy.c` | `wirelog/wirelog-easy.c` |
+| `tests/test_wl_easy.c` | `tests/test_wirelog_easy.c` |
+| `tests/test_wl_easy_inline_facts.c` | `tests/test_wirelog_easy_inline_facts.c` |
+
+Symbol renames (full surface):
+
+| Old | New |
+|---|---|
+| `wl_easy_session_t` | `wirelog_easy_session_t` |
+| `wl_easy_open_opts_t` | `wirelog_easy_open_opts_t` |
+| `WL_EASY_OPEN_OPTS_INIT` | `WIRELOG_EASY_OPEN_OPTS_INIT` |
+| `WL_EASY_MAX_COLS` | `WIRELOG_EASY_MAX_COLS` |
+| `wl_easy_open` / `wl_easy_close` | `wirelog_easy_open` / `wirelog_easy_close` |
+| `wl_easy_insert` / `wl_easy_remove` | `wirelog_easy_insert` / `wirelog_easy_remove` |
+| `wl_easy_insert_sym` / `wl_easy_remove_sym` | `wirelog_easy_insert_sym` / `wirelog_easy_remove_sym` |
+| `wl_easy_step` / `wl_easy_snapshot` | `wirelog_easy_step` / `wirelog_easy_snapshot` |
+| `wl_easy_set_delta_cb` | `wirelog_easy_set_delta_cb` |
+| `wl_easy_intern` | `wirelog_easy_intern` |
+| `wl_easy_print_delta` / `wl_easy_banner` | `wirelog_easy_print_delta` / `wirelog_easy_banner` |
+| `wl_easy_snapshot_filter_t` | `wirelog_easy_snapshot_filter_t` |
+
+`AGENTS.md:23` public-headers list updates the path.
+`meson.build` install_headers SSoT and source list reflect
+both the file move and the new symbol names.  Source-
+incompatible across the entire facade; migrate via:
+
+1. Update `#include` paths from `wirelog/wl_easy.h` to
+   `wirelog/wirelog-easy.h`.
+2. Textual-rename all `wl_easy_*` symbol references to
+   `wirelog_easy_*`.
+3. Textual-rename all `WL_EASY_*` macro references to
+   `WIRELOG_EASY_*`.
+
 ### Export-attribute macro rename: WL_PUBLIC -> WIRELOG_PUBLIC (#759)
 
 `wirelog/wirelog-export.h` previously defined `WL_PUBLIC` as
@@ -98,8 +144,8 @@ match `AGENTS.md:17-20`:
 
 Both typedefs live in `wirelog/wirelog-types.h` and are consumed by
 `wirelog/wirelog-advanced.h` (`wirelog_session_set_delta_cb`,
-`wirelog_session_snapshot`) and `wirelog/wl_easy.h`
-(`wl_easy_set_delta_cb`, `wl_easy_snapshot`).  Function-pointer
+`wirelog_session_snapshot`) and `wirelog/wirelog-easy.h`
+(`wirelog_easy_set_delta_cb`, `wirelog_easy_snapshot`).  Function-pointer
 parameter declarations rename to the new typedef names; the function
 signatures are otherwise unchanged.  Source-incompatible; existing
 callers update via a textual rename.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -27,7 +27,7 @@ host, with the host owning the I/O boundary. Specifically:
 
 - **Trusted**: the program text fed to `wirelog_parse` /
   `wirelog_parse_string`, the row data passed to
-  `wirelog_session_insert` and `wl_easy_insert`, the I/O adapter
+  `wirelog_session_insert` and `wirelog_easy_insert`, the I/O adapter
   callbacks the host registers via `wl_io_register_adapter`.
 - **Untrusted**: nothing in the default surface. wirelog does not
   open sockets, accept network connections, or fork helper processes.

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -26,28 +26,28 @@ the EDB. After parsing the program, the engine seeds these facts into
 the columnar session as base rows exactly once, on the first
 plan/session build:
 
-- via `wl_easy_open` / any `wl_easy_*` lazy entry point: at first
+- via `wirelog_easy_open` / any `wirelog_easy_*` lazy entry point: at first
   build, before any host delta callback can be installed.
 - via the CLI driver: at the same point in the
   `wl_session_create` → `wl_session_load_facts` →
   `wl_session_load_input_files` sequence.
 
-Snapshots returned by `wl_easy_snapshot()` and IDB rows derived by the
+Snapshots returned by `wirelog_easy_snapshot()` and IDB rows derived by the
 optimizer pipeline therefore observe inline facts on the first call,
 without any host action.
 
 ### Z-set semantics for host insert / remove
 
-`wl_easy_insert()` and `wl_easy_remove()` are differential operations
+`wirelog_easy_insert()` and `wirelog_easy_remove()` are differential operations
 on the session's z-set state:
 
-- `wl_easy_insert(R, row)` raises the multiplicity of `row` in `R`
+- `wirelog_easy_insert(R, row)` raises the multiplicity of `row` in `R`
   by `+1`.
-- `wl_easy_remove(R, row)` lowers it by `-1`.
+- `wirelog_easy_remove(R, row)` lowers it by `-1`.
 
 If a host inserts a row that is already present from the inline-fact
 seed, the row's multiplicity becomes `+2`. A subsequent
-`wl_easy_remove()` of the same row leaves multiplicity `+1`; the row
+`wirelog_easy_remove()` of the same row leaves multiplicity `+1`; the row
 remains observable in snapshots until both copies are retracted.
 
 This matches differential dataflow conventions and is consistent with
@@ -79,7 +79,7 @@ Two patterns are supported:
 ### Cross-facade parity (Status: Current)
 
 `wirelog/wirelog-advanced.h` ships the public `wirelog_session_*` surface
-as the advanced peer of `wl_easy`. Both facades share this exact
+as the advanced peer of `wirelog_easy`. Both facades share this exact
 semantic model: open-time inline-fact seeding, z-set host insert/remove,
 optional pre-check via `wirelog_program_get_facts`. This is the contract
 that prevents behavioral drift between the easy and advanced surfaces.
@@ -91,7 +91,7 @@ will appear as additive enum values in future minor releases.
 
 ### References
 
-- `wirelog/wl_easy.c` — `ensure_plan_built` performs the seed.
+- `wirelog/wirelog-easy.c` — `ensure_plan_built` performs the seed.
 - `wirelog/session_facts.c` — backend-agnostic loader.
 - `wirelog/cli/driver.c` — the canonical sequence the easy facade mirrors.
 - `wirelog/wirelog.h` — `wirelog_program_get_facts` for host pre-check.

--- a/examples/08-delta-queries/README.md
+++ b/examples/08-delta-queries/README.md
@@ -21,7 +21,7 @@ diff marker.
 ## Files
 
 - **access_control.dl**: Datalog program for the access control example (reference)
-- **delta_demo.c**: C program demonstrating `wl_easy_set_delta_cb()`
+- **delta_demo.c**: C program demonstrating `wirelog_easy_set_delta_cb()`
 - **example.csv**: Sample access control facts used as input
 - **meson.build**: Build configuration for `delta_demo`
 
@@ -42,7 +42,7 @@ Example 08: Delta Queries with Callback API
 
 Inserting access control facts...
 
-Delta output from wl_easy_step():
+Delta output from wirelog_easy_step():
 + granted("alice", "read")
 + granted("alice", "write")
 + granted("bob", "read")
@@ -57,11 +57,11 @@ Done.
 ### 1. Register the Callback
 
 ```c
-wl_easy_set_delta_cb(session, on_delta, user_data);
+wirelog_easy_set_delta_cb(session, on_delta, user_data);
 ```
 
 The callback fires for every output tuple that is newly derived (diff = +1)
-or retracted (diff = -1) when `wl_easy_step()` is called.
+or retracted (diff = -1) when `wirelog_easy_step()` is called.
 
 ### 2. Callback Signature
 
@@ -94,14 +94,14 @@ on_delta(const char *relation, const int64_t *row, uint32_t ncols,
 ```
 
 To insert facts with symbol columns from C code, intern your strings
-with `wl_easy_intern()` first:
+with `wirelog_easy_intern()` first:
 
 ```c
-int64_t id_alice = wl_easy_intern(s, "alice");
-int64_t id_read  = wl_easy_intern(s, "read");
+int64_t id_alice = wirelog_easy_intern(s, "alice");
+int64_t id_read  = wirelog_easy_intern(s, "read");
 
 int64_t row[] = { id_alice, id_read };
-wl_easy_insert(s, "can", row, 2);
+wirelog_easy_insert(s, "can", row, 2);
 ```
 
 ### 4. Datalog Program
@@ -136,8 +136,8 @@ not on every step if the fact was already known.
 
 | API | When to use |
 |-----|-------------|
-| `wl_easy_set_delta_cb` + `wl_easy_step` | Streaming, event-driven, incremental pipelines |
-| `wl_easy_snapshot` | One-shot batch queries |
+| `wirelog_easy_set_delta_cb` + `wirelog_easy_step` | Streaming, event-driven, incremental pipelines |
+| `wirelog_easy_snapshot` | One-shot batch queries |
 
 Delta mode is efficient for cases where facts trickle in over time and
 you want to react to each change without re-scanning the full result set.
@@ -152,7 +152,7 @@ snapshot. This is efficient even for large relation sizes.
 ## Next Steps
 
 - Add role-based rules: `granted(U, P) :- role(U, R), role_perm(R, P)`
-- Extend to retraction: use `wl_easy_remove_sym()` to revoke permissions
+- Extend to retraction: use `wirelog_easy_remove_sym()` to revoke permissions
   and observe diff=-1 callbacks
 - Combine with `07-multi-source-analysis` to integrate permissions from
   multiple identity providers

--- a/examples/08-delta-queries/delta_demo.c
+++ b/examples/08-delta-queries/delta_demo.c
@@ -5,9 +5,9 @@
  * Licensed under LGPL-3.0
  * For commercial licenses, contact: inquiry@cleverplant.com
  *
- * Demonstrates the wl_easy facade over wirelog's delta-callback pipeline.
+ * Demonstrates the wirelog_easy facade over wirelog's delta-callback pipeline.
  * As can(user, permission) tuples are inserted, delta callbacks fire for
- * each newly derived granted() fact via wl_easy_print_delta().
+ * each newly derived granted() fact via wirelog_easy_print_delta().
  *
  * Build: meson compile -C build delta_demo
  * Run:   ./build/examples/08-delta-queries/delta_demo
@@ -29,24 +29,25 @@ main(void)
     printf("Example 08: Delta Queries with Callback API\n");
     printf("============================================\n\n");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open failed\n");
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open failed\n");
         return 1;
     }
 
-    int64_t id_alice = wl_easy_intern(s, "alice");
-    int64_t id_bob = wl_easy_intern(s, "bob");
-    int64_t id_carol = wl_easy_intern(s, "carol");
-    int64_t id_read = wl_easy_intern(s, "read");
-    int64_t id_write = wl_easy_intern(s, "write");
-    int64_t id_admin = wl_easy_intern(s, "admin");
+    int64_t id_alice = wirelog_easy_intern(s, "alice");
+    int64_t id_bob = wirelog_easy_intern(s, "bob");
+    int64_t id_carol = wirelog_easy_intern(s, "carol");
+    int64_t id_read = wirelog_easy_intern(s, "read");
+    int64_t id_write = wirelog_easy_intern(s, "write");
+    int64_t id_admin = wirelog_easy_intern(s, "admin");
     (void)id_alice; (void)id_bob; (void)id_carol;
     (void)id_read;  (void)id_write; (void)id_admin;
 
-    if (wl_easy_set_delta_cb(s, wl_easy_print_delta, s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_set_delta_cb failed\n");
-        wl_easy_close(s);
+    if (wirelog_easy_set_delta_cb(s, wirelog_easy_print_delta,
+        s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_set_delta_cb failed\n");
+        wirelog_easy_close(s);
         return 1;
     }
 
@@ -57,20 +58,20 @@ main(void)
     int64_t r3[] = { id_bob,   id_read  };
     int64_t r4[] = { id_bob,   id_admin };
     int64_t r5[] = { id_carol, id_read  };
-    wl_easy_insert(s, "can", r1, 2);
-    wl_easy_insert(s, "can", r2, 2);
-    wl_easy_insert(s, "can", r3, 2);
-    wl_easy_insert(s, "can", r4, 2);
-    wl_easy_insert(s, "can", r5, 2);
+    wirelog_easy_insert(s, "can", r1, 2);
+    wirelog_easy_insert(s, "can", r2, 2);
+    wirelog_easy_insert(s, "can", r3, 2);
+    wirelog_easy_insert(s, "can", r4, 2);
+    wirelog_easy_insert(s, "can", r5, 2);
 
     printf("Delta output from wl_session_step():\n");
-    if (wl_easy_step(s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_step failed\n");
-        wl_easy_close(s);
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_step failed\n");
+        wirelog_easy_close(s);
         return 1;
     }
 
     printf("\nDone.\n");
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return 0;
 }

--- a/examples/08-delta-queries/meson.build
+++ b/examples/08-delta-queries/meson.build
@@ -1,5 +1,5 @@
 # examples/08-delta-queries/meson.build
-# Delta Queries demo using the wl_easy facade (#441)
+# Delta Queries demo using the wirelog_easy facade (#441)
 #
 # Include all wirelog sources directly (same pattern as wirelog_cli) to
 # ensure proper linking under LTO. Linking against wirelog_static_lib fails

--- a/examples/09-retraction-basics/README.md
+++ b/examples/09-retraction-basics/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This example demonstrates incremental retraction in wirelog using
-`wl_easy_remove_sym`.  When a base fact is retracted, the engine
+`wirelog_easy_remove_sym`.  When a base fact is retracted, the engine
 propagates `-1` deltas to any derived relations that depended on it.  The scope here is non-recursive: a single join rule
 derives `mutual(A, B)` from `friend(A, B), friend(B, A)`, and removing one
 side of the friendship pair produces exactly two `-1` deltas on `mutual`,
@@ -47,14 +47,14 @@ Done.
 
 ## What This Demonstrates
 
-- **Step 1**: `wl_easy_insert_sym` inserts `friend(alice,bob)` and
-  `friend(bob,alice)`.  After `wl_easy_step`, two `+1` deltas fire for
+- **Step 1**: `wirelog_easy_insert_sym` inserts `friend(alice,bob)` and
+  `friend(bob,alice)`.  After `wirelog_easy_step`, two `+1` deltas fire for
   `mutual(alice,bob)` and `mutual(bob,alice)`.
-- **Step 2**: `wl_easy_insert_sym` inserts `friend(alice,carol)`.  Since
+- **Step 2**: `wirelog_easy_insert_sym` inserts `friend(alice,carol)`.  Since
   `friend(carol,alice)` does not exist, the join produces no new `mutual`
   tuples and no deltas fire.
-- **Step 3**: `wl_easy_remove_sym` retracts `friend(bob,alice)`.  After
-  `wl_easy_step`, the engine emits exactly two `-1` deltas:
+- **Step 3**: `wirelog_easy_remove_sym` retracts `friend(bob,alice)`.  After
+  `wirelog_easy_step`, the engine emits exactly two `-1` deltas:
   `mutual(alice,bob)` and `mutual(bob,alice)`, reflecting that both
   derived tuples are no longer supported.
 - **In-driver assertion**: The driver counts the `-1` deltas on `mutual` in
@@ -72,6 +72,6 @@ Done.
 ## See Also
 
 - `examples/08-delta-queries/` -- the preceding example that introduces
-  delta callbacks with `wl_easy_print_delta`.
+  delta callbacks with `wirelog_easy_print_delta`.
 - `tests/test_delta_retraction.c` -- engine-level retraction tests (issue
-  #158) that exercise the same `wl_easy_remove_sym` contract used here.
+  #158) that exercise the same `wirelog_easy_remove_sym` contract used here.

--- a/examples/09-retraction-basics/meson.build
+++ b/examples/09-retraction-basics/meson.build
@@ -1,5 +1,5 @@
 # examples/09-retraction-basics/meson.build
-# Retraction Basics demo using the wl_easy facade (#442)
+# Retraction Basics demo using the wirelog_easy facade (#442)
 #
 # Include all wirelog sources directly (same pattern as example 08 and
 # wirelog_cli) to ensure proper linking under LTO.

--- a/examples/09-retraction-basics/retract_demo.c
+++ b/examples/09-retraction-basics/retract_demo.c
@@ -52,7 +52,7 @@ typedef struct {
 #define MAX_BUFFER 16
 
 typedef struct {
-    wl_easy_session_t *sess;
+    wirelog_easy_session_t *sess;
     buffered_delta_t buf[MAX_BUFFER];
     int n;
     int minus_mutual_count;
@@ -104,7 +104,7 @@ flush_sorted(demo_ctx_t *ctx)
     qsort(ctx->buf, (size_t)ctx->n, sizeof(ctx->buf[0]), delta_compare);
     for (int i = 0; i < ctx->n; i++) {
         buffered_delta_t *b = &ctx->buf[i];
-        wl_easy_print_delta(b->relation, b->row, 2, b->diff, ctx->sess);
+        wirelog_easy_print_delta(b->relation, b->row, 2, b->diff, ctx->sess);
     }
     ctx->n = 0;
 }
@@ -112,7 +112,7 @@ flush_sorted(demo_ctx_t *ctx)
 #define CHECK(expr, msg) do { \
             if ((expr) != WIRELOG_OK) { \
                 fprintf(stderr, "%s\n", msg); \
-                wl_easy_close(s); \
+                wirelog_easy_close(s); \
                 return 1; \
             } \
 } while (0)
@@ -123,42 +123,42 @@ main(void)
     printf("Example 09: Retraction Basics (-1 deltas)\n");
     printf("=========================================\n");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(FRIENDSHIP_SRC, &s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open failed\n");
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(FRIENDSHIP_SRC, &s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open failed\n");
         return 1;
     }
 
     demo_ctx_t ctx = { .sess = s, .n = 0, .minus_mutual_count = 0 };
-    CHECK(wl_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
-        "wl_easy_set_delta_cb failed");
+    CHECK(wirelog_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
+        "wirelog_easy_set_delta_cb failed");
 
-    (void)wl_easy_intern(s, "alice");
-    (void)wl_easy_intern(s, "bob");
-    (void)wl_easy_intern(s, "carol");
+    (void)wirelog_easy_intern(s, "alice");
+    (void)wirelog_easy_intern(s, "bob");
+    (void)wirelog_easy_intern(s, "carol");
 
     /* ---- Step 1 ---- */
-    wl_easy_banner("step 1: alice <-> bob");
-    CHECK(wl_easy_insert_sym(s, "friend", "alice", "bob", NULL),
+    wirelog_easy_banner("step 1: alice <-> bob");
+    CHECK(wirelog_easy_insert_sym(s, "friend", "alice", "bob", NULL),
         "insert friend(alice,bob) failed");
-    CHECK(wl_easy_insert_sym(s, "friend", "bob", "alice", NULL),
+    CHECK(wirelog_easy_insert_sym(s, "friend", "bob", "alice", NULL),
         "insert friend(bob,alice) failed");
-    CHECK(wl_easy_step(s), "step 1 failed");
+    CHECK(wirelog_easy_step(s), "step 1 failed");
     flush_sorted(&ctx);
 
     /* ---- Step 2 ---- */
-    wl_easy_banner("step 2: one-way alice -> carol");
-    CHECK(wl_easy_insert_sym(s, "friend", "alice", "carol", NULL),
+    wirelog_easy_banner("step 2: one-way alice -> carol");
+    CHECK(wirelog_easy_insert_sym(s, "friend", "alice", "carol", NULL),
         "insert friend(alice,carol) failed");
-    CHECK(wl_easy_step(s), "step 2 failed");
+    CHECK(wirelog_easy_step(s), "step 2 failed");
     flush_sorted(&ctx);
 
     /* ---- Step 3 ---- */
-    wl_easy_banner("step 3: bob unfriends alice");
+    wirelog_easy_banner("step 3: bob unfriends alice");
     int before = ctx.minus_mutual_count;
-    CHECK(wl_easy_remove_sym(s, "friend", "bob", "alice", NULL),
+    CHECK(wirelog_easy_remove_sym(s, "friend", "bob", "alice", NULL),
         "remove friend(bob,alice) failed");
-    CHECK(wl_easy_step(s), "step 3 failed");
+    CHECK(wirelog_easy_step(s), "step 3 failed");
     flush_sorted(&ctx);
     int step3_minus = ctx.minus_mutual_count - before;
 
@@ -168,10 +168,10 @@ main(void)
         fprintf(stderr,
             "ASSERTION FAILED: expected 2 '-1' deltas on mutual in step 3, got %d\n",
             step3_minus);
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 2;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return 0;
 }

--- a/examples/10-recursive-under-update/README.md
+++ b/examples/10-recursive-under-update/README.md
@@ -67,7 +67,7 @@ Done.
 - **Re-derivation on re-insert**: Re-inserting the same edge re-derives
   exactly the same four `reach` tuples, demonstrating that the engine's
   internal state is fully consistent after retraction.
-- **Per-step delta isolation**: Each `wl_easy_step` call produces only the
+- **Per-step delta isolation**: Each `wirelog_easy_step` call produces only the
   deltas for that step's input changes; no cross-step leakage occurs.
 
 ## What You Will NOT See Here
@@ -82,8 +82,8 @@ Done.
 ## See Also
 
 - `examples/08-delta-queries/` -- introduces delta callbacks with
-  `wl_easy_print_delta`.
+  `wirelog_easy_print_delta`.
 - `examples/09-retraction-basics/` -- non-recursive retraction basics with
   `-1` deltas on a single-join rule.
 - `tests/test_delta_retraction.c` -- engine-level retraction tests (issue
-  #158) that exercise the same `wl_easy_remove_sym` contract used here.
+  #158) that exercise the same `wirelog_easy_remove_sym` contract used here.

--- a/examples/10-recursive-under-update/meson.build
+++ b/examples/10-recursive-under-update/meson.build
@@ -1,5 +1,5 @@
 # examples/10-recursive-under-update/meson.build
-# Transitive Closure demo using the wl_easy facade (#443)
+# Transitive Closure demo using the wirelog_easy facade (#443)
 #
 # Include all wirelog sources directly (same pattern as example 08/09 and
 # wirelog_cli) to ensure proper linking under LTO.

--- a/examples/10-recursive-under-update/tc_demo.c
+++ b/examples/10-recursive-under-update/tc_demo.c
@@ -53,7 +53,7 @@ typedef struct {
 #define MAX_BUFFER 32
 
 typedef struct {
-    wl_easy_session_t *sess;
+    wirelog_easy_session_t *sess;
     buffered_delta_t buf[MAX_BUFFER];
     int n;
     int plus_reach;
@@ -110,7 +110,7 @@ flush_sorted(demo_ctx_t *ctx)
     qsort(ctx->buf, (size_t)ctx->n, sizeof(ctx->buf[0]), delta_compare);
     for (int i = 0; i < ctx->n; i++) {
         buffered_delta_t *b = &ctx->buf[i];
-        wl_easy_print_delta(b->relation, b->row, 2, b->diff, ctx->sess);
+        wirelog_easy_print_delta(b->relation, b->row, 2, b->diff, ctx->sess);
     }
     ctx->n = 0;
 }
@@ -118,7 +118,7 @@ flush_sorted(demo_ctx_t *ctx)
 #define CHECK(expr, msg) do { \
             if ((expr) != WIRELOG_OK) { \
                 fprintf(stderr, "%s\n", msg); \
-                wl_easy_close(s); \
+                wirelog_easy_close(s); \
                 return 1; \
             } \
 } while (0)
@@ -128,7 +128,7 @@ flush_sorted(demo_ctx_t *ctx)
                 fprintf(stderr, \
                     "ASSERTION FAILED: %s: expected %d, got %d\n", \
                     label, expected, actual); \
-                wl_easy_close(s); \
+                wirelog_easy_close(s); \
                 return 2; \
             } \
 } while (0)
@@ -139,56 +139,56 @@ main(void)
     printf("Example 10: Recursive Under Update (Transitive Closure)\n");
     printf("=======================================================\n");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(TC_SRC, &s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open failed\n");
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(TC_SRC, &s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open failed\n");
         return 1;
     }
 
     demo_ctx_t ctx = { .sess = s, .n = 0, .plus_reach = 0, .minus_reach = 0 };
-    CHECK(wl_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
-        "wl_easy_set_delta_cb failed");
+    CHECK(wirelog_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
+        "wirelog_easy_set_delta_cb failed");
 
     /* Pre-intern symbols for deterministic intern IDs. */
-    (void)wl_easy_intern(s, "a");
-    (void)wl_easy_intern(s, "b");
-    (void)wl_easy_intern(s, "c");
-    (void)wl_easy_intern(s, "d");
+    (void)wirelog_easy_intern(s, "a");
+    (void)wirelog_easy_intern(s, "b");
+    (void)wirelog_easy_intern(s, "c");
+    (void)wirelog_easy_intern(s, "d");
 
     /* ---- Step 1: Insert edges a->b->c->d ---- */
-    wl_easy_banner("step 1: insert edges a->b->c->d");
-    CHECK(wl_easy_insert_sym(s, "edge", "a", "b", NULL),
+    wirelog_easy_banner("step 1: insert edges a->b->c->d");
+    CHECK(wirelog_easy_insert_sym(s, "edge", "a", "b", NULL),
         "insert edge(a,b) failed");
-    CHECK(wl_easy_insert_sym(s, "edge", "b", "c", NULL),
+    CHECK(wirelog_easy_insert_sym(s, "edge", "b", "c", NULL),
         "insert edge(b,c) failed");
-    CHECK(wl_easy_insert_sym(s, "edge", "c", "d", NULL),
+    CHECK(wirelog_easy_insert_sym(s, "edge", "c", "d", NULL),
         "insert edge(c,d) failed");
-    CHECK(wl_easy_step(s), "step 1 failed");
+    CHECK(wirelog_easy_step(s), "step 1 failed");
     flush_sorted(&ctx);
     ASSERT_DELTAS("step 1 +reach", ctx.plus_reach, 6);
 
     /* ---- Step 2: Remove edge(b,c) ---- */
     ctx.plus_reach = 0;
     ctx.minus_reach = 0;
-    wl_easy_banner("step 2: remove edge(b,c)");
-    CHECK(wl_easy_remove_sym(s, "edge", "b", "c", NULL),
+    wirelog_easy_banner("step 2: remove edge(b,c)");
+    CHECK(wirelog_easy_remove_sym(s, "edge", "b", "c", NULL),
         "remove edge(b,c) failed");
-    CHECK(wl_easy_step(s), "step 2 failed");
+    CHECK(wirelog_easy_step(s), "step 2 failed");
     flush_sorted(&ctx);
     ASSERT_DELTAS("step 2 -reach", ctx.minus_reach, 4);
 
     /* ---- Step 3: Re-insert edge(b,c) ---- */
     ctx.plus_reach = 0;
     ctx.minus_reach = 0;
-    wl_easy_banner("step 3: re-insert edge(b,c)");
-    CHECK(wl_easy_insert_sym(s, "edge", "b", "c", NULL),
+    wirelog_easy_banner("step 3: re-insert edge(b,c)");
+    CHECK(wirelog_easy_insert_sym(s, "edge", "b", "c", NULL),
         "re-insert edge(b,c) failed");
-    CHECK(wl_easy_step(s), "step 3 failed");
+    CHECK(wirelog_easy_step(s), "step 3 failed");
     flush_sorted(&ctx);
     ASSERT_DELTAS("step 3 +reach", ctx.plus_reach, 4);
 
     printf("\nDone.\n");
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return 0;
 }

--- a/examples/11-time-evolution/README.md
+++ b/examples/11-time-evolution/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Each `wl_easy_step()` call is one tick of logical time.  Only deltas
+Each `wirelog_easy_step()` call is one tick of logical time.  Only deltas
 produced *during that step* are reported to the delta callback -- tuples
 derived in earlier steps are never re-emitted.
 
@@ -50,7 +50,7 @@ Done.
   not the epoch-1 alerts `alert("e1")` and `alert("e3")`.
 - **Insert-only monotone growth** -- no retraction is used; the fact set
   grows monotonically across steps.
-- **Discrete time model** -- each `wl_easy_step()` advances logical time
+- **Discrete time model** -- each `wirelog_easy_step()` advances logical time
   by one tick.  Facts inserted between steps are batched into the next
   step.
 
@@ -65,4 +65,4 @@ Done.
 - `examples/08-delta-queries/` -- single-step delta introduction
 - `examples/09-retraction-basics/` -- retraction deltas
 - `examples/10-recursive-under-update/` -- recursive transitive closure
-- `wirelog/wl_easy.h` -- convenience facade API
+- `wirelog/wirelog-easy.h` -- convenience facade API

--- a/examples/11-time-evolution/meson.build
+++ b/examples/11-time-evolution/meson.build
@@ -1,5 +1,5 @@
 # examples/11-time-evolution/meson.build
-# Time Evolution demo using the wl_easy facade (#444)
+# Time Evolution demo using the wirelog_easy facade (#444)
 #
 # Include all wirelog sources directly (same pattern as example 08 and
 # wirelog_cli) to ensure proper linking under LTO.

--- a/examples/11-time-evolution/time_evolution_demo.c
+++ b/examples/11-time-evolution/time_evolution_demo.c
@@ -20,7 +20,7 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  *
  * Demonstrates per-epoch delta isolation (Issue #444).  Each call to
- * wl_easy_step() is a discrete time epoch; the delta callback fires only
+ * wirelog_easy_step() is a discrete time epoch; the delta callback fires only
  * for tuples derived during that epoch, not since the beginning.
  *
  * Build: meson compile -C build time_evolution_demo
@@ -52,7 +52,7 @@ typedef struct {
 #define MAX_BUFFER 16
 
 typedef struct {
-    wl_easy_session_t *sess;
+    wirelog_easy_session_t *sess;
     buffered_delta_t buf[MAX_BUFFER];
     int n;
     int plus_alert_count;
@@ -105,7 +105,8 @@ flush_sorted(demo_ctx_t *ctx)
     qsort(ctx->buf, (size_t)ctx->n, sizeof(ctx->buf[0]), delta_compare);
     for (int i = 0; i < ctx->n; i++) {
         buffered_delta_t *b = &ctx->buf[i];
-        wl_easy_print_delta(b->relation, b->row, b->ncols, b->diff, ctx->sess);
+        wirelog_easy_print_delta(b->relation, b->row, b->ncols, b->diff,
+            ctx->sess);
     }
     ctx->n = 0;
 }
@@ -113,7 +114,7 @@ flush_sorted(demo_ctx_t *ctx)
 #define CHECK(expr, msg) do { \
             if ((expr) != WIRELOG_OK) { \
                 fprintf(stderr, "%s\n", msg); \
-                wl_easy_close(s); \
+                wirelog_easy_close(s); \
                 return 1; \
             } \
 } while (0)
@@ -124,79 +125,79 @@ main(void)
     printf("Example 11: Time Evolution (Per-Epoch Delta Isolation)\n");
     printf("=====================================================\n");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(EVENTS_SRC, &s) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open failed\n");
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(EVENTS_SRC, &s) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open failed\n");
         return 1;
     }
 
     demo_ctx_t ctx = { .sess = s, .n = 0, .plus_alert_count = 0 };
-    CHECK(wl_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
-        "wl_easy_set_delta_cb failed");
+    CHECK(wirelog_easy_set_delta_cb(s, on_delta_wrapper, &ctx),
+        "wirelog_easy_set_delta_cb failed");
 
     /* Pre-intern all symbols used in the demo. */
-    (void)wl_easy_intern(s, "e1");
-    (void)wl_easy_intern(s, "e2");
-    (void)wl_easy_intern(s, "e3");
-    (void)wl_easy_intern(s, "e4");
-    (void)wl_easy_intern(s, "e5");
-    (void)wl_easy_intern(s, "error");
-    (void)wl_easy_intern(s, "info");
+    (void)wirelog_easy_intern(s, "e1");
+    (void)wirelog_easy_intern(s, "e2");
+    (void)wirelog_easy_intern(s, "e3");
+    (void)wirelog_easy_intern(s, "e4");
+    (void)wirelog_easy_intern(s, "e5");
+    (void)wirelog_easy_intern(s, "error");
+    (void)wirelog_easy_intern(s, "info");
 
     /* ---- Epoch 1 ---- */
-    wl_easy_banner("epoch 1: insert e1(error), e2(info), e3(error)");
-    CHECK(wl_easy_insert_sym(s, "event", "e1", "error", NULL),
+    wirelog_easy_banner("epoch 1: insert e1(error), e2(info), e3(error)");
+    CHECK(wirelog_easy_insert_sym(s, "event", "e1", "error", NULL),
         "insert event(e1,error) failed");
-    CHECK(wl_easy_insert_sym(s, "event", "e2", "info", NULL),
+    CHECK(wirelog_easy_insert_sym(s, "event", "e2", "info", NULL),
         "insert event(e2,info) failed");
-    CHECK(wl_easy_insert_sym(s, "event", "e3", "error", NULL),
+    CHECK(wirelog_easy_insert_sym(s, "event", "e3", "error", NULL),
         "insert event(e3,error) failed");
     ctx.plus_alert_count = 0;
-    CHECK(wl_easy_step(s), "step 1 failed");
+    CHECK(wirelog_easy_step(s), "step 1 failed");
     flush_sorted(&ctx);
 
     if (ctx.plus_alert_count != 2) {
         fprintf(stderr,
             "ASSERTION FAILED: expected 2 '+' alert deltas in epoch 1, "
             "got %d\n", ctx.plus_alert_count);
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 2;
     }
 
     /* ---- Epoch 2 ---- */
-    wl_easy_banner("epoch 2: insert e4(info)");
-    CHECK(wl_easy_insert_sym(s, "event", "e4", "info", NULL),
+    wirelog_easy_banner("epoch 2: insert e4(info)");
+    CHECK(wirelog_easy_insert_sym(s, "event", "e4", "info", NULL),
         "insert event(e4,info) failed");
     ctx.plus_alert_count = 0;
-    CHECK(wl_easy_step(s), "step 2 failed");
+    CHECK(wirelog_easy_step(s), "step 2 failed");
     flush_sorted(&ctx);
 
     if (ctx.plus_alert_count != 0) {
         fprintf(stderr,
             "ASSERTION FAILED: expected 0 '+' alert deltas in epoch 2, "
             "got %d\n", ctx.plus_alert_count);
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 2;
     }
 
     /* ---- Epoch 3 ---- */
-    wl_easy_banner("epoch 3: insert e5(error)");
-    CHECK(wl_easy_insert_sym(s, "event", "e5", "error", NULL),
+    wirelog_easy_banner("epoch 3: insert e5(error)");
+    CHECK(wirelog_easy_insert_sym(s, "event", "e5", "error", NULL),
         "insert event(e5,error) failed");
     ctx.plus_alert_count = 0;
-    CHECK(wl_easy_step(s), "step 3 failed");
+    CHECK(wirelog_easy_step(s), "step 3 failed");
     flush_sorted(&ctx);
 
     if (ctx.plus_alert_count != 1) {
         fprintf(stderr,
             "ASSERTION FAILED: expected 1 '+' alert delta in epoch 3, "
             "got %d\n", ctx.plus_alert_count);
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 2;
     }
 
     printf("\nDone.\n");
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return 0;
 }

--- a/examples/12-snapshot-vs-delta/README.md
+++ b/examples/12-snapshot-vs-delta/README.md
@@ -3,8 +3,8 @@
 ## Overview
 
 Wirelog exposes two ways to read derived facts: **delta mode**
-(`wl_easy_set_delta_cb` + `wl_easy_step`) streams sign-tagged changes
-as they happen, while **snapshot mode** (`wl_easy_snapshot`) returns the
+(`wirelog_easy_set_delta_cb` + `wirelog_easy_step`) streams sign-tagged changes
+as they happen, while **snapshot mode** (`wirelog_easy_snapshot`) returns the
 full IDB in one shot.  Two APIs, same answer, different costs.
 
 This example runs the same access-control Datalog program through both
@@ -35,8 +35,8 @@ meson compile -C build snapshot_demo
 Example 12: Snapshot vs Delta
 =============================
 
-=== delta mode: wl_easy_step ===
-=== snapshot mode: wl_easy_snapshot ===
+=== delta mode: wirelog_easy_step ===
+=== snapshot mode: wirelog_easy_snapshot ===
 
 delta: granted("alice", "read")        snapshot: granted("alice", "read")        MATCH
 delta: granted("alice", "write")       snapshot: granted("alice", "write")       MATCH
@@ -51,8 +51,8 @@ PASS
 
 | API | Use when | Cost shape |
 |---|---|---|
-| `wl_easy_set_delta_cb` + `wl_easy_step` | Facts trickle in over time and you want to react to *changes* | Proportional to delta size |
-| `wl_easy_snapshot` | One-shot batch query where you want the full IDB | Proportional to total IDB size |
+| `wirelog_easy_set_delta_cb` + `wirelog_easy_step` | Facts trickle in over time and you want to react to *changes* | Proportional to delta size |
+| `wirelog_easy_snapshot` | One-shot batch query where you want the full IDB | Proportional to total IDB size |
 
 Delta mode is ideal for long-running sessions where only incremental
 updates matter (monitoring, streaming pipelines).  Snapshot mode is
@@ -62,9 +62,9 @@ simpler when you just need the current answer without tracking history.
 
 - **Semantic equivalence** -- the incremental delta path produces the
   same derived facts as full re-evaluation via snapshot.
-- **Two independent sessions** -- because `wl_easy_snapshot` is an
+- **Two independent sessions** -- because `wirelog_easy_snapshot` is an
   evaluating call, the driver uses separate sessions to avoid
-  double-counting.  See `wl_easy.h` for the full contract.
+  double-counting.  See `wirelog-easy.h` for the full contract.
 - **Deterministic comparison** -- both result sets are sorted before
   comparison so the test is stable regardless of backend evaluation
   order.
@@ -81,4 +81,4 @@ simpler when you just need the current answer without tracking history.
 - `examples/09-retraction-basics/` -- retraction deltas
 - `examples/10-recursive-under-update/` -- recursive transitive closure
 - `examples/11-time-evolution/` -- per-epoch delta isolation
-- `wirelog/wl_easy.h` -- convenience facade API
+- `wirelog/wirelog-easy.h` -- convenience facade API

--- a/examples/12-snapshot-vs-delta/expected.txt
+++ b/examples/12-snapshot-vs-delta/expected.txt
@@ -1,8 +1,8 @@
 Example 12: Snapshot vs Delta
 =============================
 
-=== delta mode: wl_easy_step ===
-=== snapshot mode: wl_easy_snapshot ===
+=== delta mode: wirelog_easy_step ===
+=== snapshot mode: wirelog_easy_snapshot ===
 
 delta: granted("alice", "read")        snapshot: granted("alice", "read")        MATCH
 delta: granted("alice", "write")       snapshot: granted("alice", "write")       MATCH

--- a/examples/12-snapshot-vs-delta/meson.build
+++ b/examples/12-snapshot-vs-delta/meson.build
@@ -1,5 +1,5 @@
 # examples/12-snapshot-vs-delta/meson.build
-# Snapshot vs Delta comparison demo using the wl_easy facade (#445)
+# Snapshot vs Delta comparison demo using the wirelog_easy facade (#445)
 #
 # Include all wirelog sources directly (same pattern as example 08 and
 # wirelog_cli) to ensure proper linking under LTO.

--- a/examples/12-snapshot-vs-delta/snapshot_demo.c
+++ b/examples/12-snapshot-vs-delta/snapshot_demo.c
@@ -20,11 +20,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  *
  * Runs the same access-control Datalog program through both
- * wl_easy_step (delta callback, streaming) and wl_easy_snapshot
+ * wirelog_easy_step (delta callback, streaming) and wirelog_easy_snapshot
  * (one-shot batch) and verifies that they produce identical results.
  *
- * IMPORTANT: wl_easy_snapshot() is an evaluating call -- calling
- * wl_easy_step() followed by wl_easy_snapshot() on the same insert
+ * IMPORTANT: wirelog_easy_snapshot() is an evaluating call -- calling
+ * wirelog_easy_step() followed by wirelog_easy_snapshot() on the same insert
  * batch would double-count derived tuples.  This driver therefore
  * uses two independent sessions: one for the delta path and one for
  * the snapshot path.
@@ -153,20 +153,20 @@ row_compare(const void *a, const void *b)
 #define CHECK(expr, msg, sess) do { \
             if ((expr) != WIRELOG_OK) { \
                 fprintf(stderr, "%s\n", msg); \
-                wl_easy_close(sess); \
+                wirelog_easy_close(sess); \
                 return 1; \
             } \
 } while (0)
 
 static void
-insert_facts(wl_easy_session_t *s, sym_table_t *syms)
+insert_facts(wirelog_easy_session_t *s, sym_table_t *syms)
 {
-    int64_t alice = wl_easy_intern(s, "alice");
-    int64_t bob = wl_easy_intern(s, "bob");
-    int64_t carol = wl_easy_intern(s, "carol");
-    int64_t rd = wl_easy_intern(s, "read");
-    int64_t wr = wl_easy_intern(s, "write");
-    int64_t adm = wl_easy_intern(s, "admin");
+    int64_t alice = wirelog_easy_intern(s, "alice");
+    int64_t bob = wirelog_easy_intern(s, "bob");
+    int64_t carol = wirelog_easy_intern(s, "carol");
+    int64_t rd = wirelog_easy_intern(s, "read");
+    int64_t wr = wirelog_easy_intern(s, "write");
+    int64_t adm = wirelog_easy_intern(s, "admin");
 
     sym_table_add(syms, alice, "alice");
     sym_table_add(syms, bob,   "bob");
@@ -180,11 +180,11 @@ insert_facts(wl_easy_session_t *s, sym_table_t *syms)
     int64_t r3[] = { bob,   rd  };
     int64_t r4[] = { bob,   adm };
     int64_t r5[] = { carol, rd  };
-    wl_easy_insert(s, "can", r1, 2);
-    wl_easy_insert(s, "can", r2, 2);
-    wl_easy_insert(s, "can", r3, 2);
-    wl_easy_insert(s, "can", r4, 2);
-    wl_easy_insert(s, "can", r5, 2);
+    wirelog_easy_insert(s, "can", r1, 2);
+    wirelog_easy_insert(s, "can", r2, 2);
+    wirelog_easy_insert(s, "can", r3, 2);
+    wirelog_easy_insert(s, "can", r4, 2);
+    wirelog_easy_insert(s, "can", r5, 2);
 }
 
 int
@@ -194,28 +194,28 @@ main(void)
     printf("=============================\n\n");
 
     /* ---- Path A: delta mode ---- */
-    wl_easy_session_t *sd = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &sd) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open (delta) failed\n");
+    wirelog_easy_session_t *sd = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &sd) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open (delta) failed\n");
         return 1;
     }
 
     sym_table_t delta_syms = { .n = 0 };
     result_set_t delta_rs = { .n = 0, .syms = &delta_syms };
 
-    CHECK(wl_easy_set_delta_cb(sd, on_delta, &delta_rs),
-        "wl_easy_set_delta_cb failed", sd);
+    CHECK(wirelog_easy_set_delta_cb(sd, on_delta, &delta_rs),
+        "wirelog_easy_set_delta_cb failed", sd);
 
     insert_facts(sd, &delta_syms);
 
-    printf("=== delta mode: wl_easy_step ===\n");
-    CHECK(wl_easy_step(sd), "wl_easy_step failed", sd);
-    wl_easy_close(sd);
+    printf("=== delta mode: wirelog_easy_step ===\n");
+    CHECK(wirelog_easy_step(sd), "wirelog_easy_step failed", sd);
+    wirelog_easy_close(sd);
 
     /* ---- Path B: snapshot mode ---- */
-    wl_easy_session_t *ss = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &ss) != WIRELOG_OK) {
-        fprintf(stderr, "wl_easy_open (snapshot) failed\n");
+    wirelog_easy_session_t *ss = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &ss) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open (snapshot) failed\n");
         return 1;
     }
 
@@ -224,10 +224,10 @@ main(void)
 
     insert_facts(ss, &snap_syms);
 
-    printf("=== snapshot mode: wl_easy_snapshot ===\n");
-    CHECK(wl_easy_snapshot(ss, "granted", on_snapshot, &snap_rs),
-        "wl_easy_snapshot failed", ss);
-    wl_easy_close(ss);
+    printf("=== snapshot mode: wirelog_easy_snapshot ===\n");
+    CHECK(wirelog_easy_snapshot(ss, "granted", on_snapshot, &snap_rs),
+        "wirelog_easy_snapshot failed", ss);
+    wirelog_easy_close(ss);
 
     /* ---- Sort both result sets ---- */
     qsort(delta_rs.rows, (size_t)delta_rs.n, RESULT_LEN, row_compare);

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -11,8 +11,8 @@ rotation lifecycle with a side compound declaration and the public
 This example shows the daemon pattern using only the installed public API:
 
 - keep a caller-owned copy of long-lived EDB facts
-- stream new facts through `wl_easy_insert`
-- consume changes through `wl_easy_set_delta_cb` and `wl_easy_step`
+- stream new facts through `wirelog_easy_insert`
+- consume changes through `wirelog_easy_set_delta_cb` and `wirelog_easy_step`
 - rotate by closing the old session, opening a new one, and replaying the EDB
 - log operator-visible lifecycle data to `stderr`
 
@@ -126,4 +126,4 @@ The exact RSS value depends on platform and allocator state.
 - `docs/COMPOUND_TERMS.md` -- compound term storage and arena lifecycle
 - `examples/08-delta-queries/` -- first delta-callback example
 - `examples/11-time-evolution/` -- per-epoch delta isolation
-- `wirelog/wl_easy.h` -- public convenience facade
+- `wirelog/wirelog-easy.h` -- public convenience facade

--- a/examples/13-daemon-style/daemon.c
+++ b/examples/13-daemon-style/daemon.c
@@ -1,7 +1,7 @@
 /*
  * daemon.c - Example 13: Daemon-style session rotation
  *
- * Demonstrates a long-running wl_easy caller that preserves persistent EDB
+ * Demonstrates a long-running wirelog_easy caller that preserves persistent EDB
  * facts across session rotations.  The example uses a public side compound
  * declaration for event metadata and rotates when the compound arena reports
  * saturation through the installed public API.
@@ -248,14 +248,14 @@ edb_free(edb_store_t *edb)
 }
 
 static int
-intern_symbols(wl_easy_session_t *s, symbol_ids_t *ids)
+intern_symbols(wirelog_easy_session_t *s, symbol_ids_t *ids)
 {
-    ids->tenant_a = wl_easy_intern(s, "tenant-a");
-    ids->tenant_b = wl_easy_intern(s, "tenant-b");
-    ids->info = wl_easy_intern(s, "info");
-    ids->warn = wl_easy_intern(s, "warn");
-    ids->host_a = wl_easy_intern(s, "edge-01");
-    ids->host_b = wl_easy_intern(s, "edge-02");
+    ids->tenant_a = wirelog_easy_intern(s, "tenant-a");
+    ids->tenant_b = wirelog_easy_intern(s, "tenant-b");
+    ids->info = wirelog_easy_intern(s, "info");
+    ids->warn = wirelog_easy_intern(s, "warn");
+    ids->host_a = wirelog_easy_intern(s, "edge-01");
+    ids->host_b = wirelog_easy_intern(s, "edge-02");
     return (ids->tenant_a < 0 || ids->tenant_b < 0 || ids->info < 0
            || ids->warn < 0 || ids->host_a < 0 || ids->host_b < 0)
         ? -1
@@ -263,24 +263,25 @@ intern_symbols(wl_easy_session_t *s, symbol_ids_t *ids)
 }
 
 static int
-enable_delta_cb(wl_easy_session_t *s, delta_stats_t *stats)
+enable_delta_cb(wirelog_easy_session_t *s, delta_stats_t *stats)
 {
-    return wl_easy_set_delta_cb(s, on_delta, stats) == WIRELOG_OK ? 0 : -1;
+    return wirelog_easy_set_delta_cb(s, on_delta, stats) == WIRELOG_OK ? 0 : -1;
 }
 
 static int
-open_session(wl_easy_session_t **out, symbol_ids_t *ids, delta_stats_t *stats,
+open_session(wirelog_easy_session_t **out, symbol_ids_t *ids,
+    delta_stats_t *stats,
     bool emit_live_deltas)
 {
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(DAEMON_SRC, &s) != WIRELOG_OK)
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(DAEMON_SRC, &s) != WIRELOG_OK)
         return -1;
     if (intern_symbols(s, ids) != 0) {
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return -1;
     }
     if (emit_live_deltas && enable_delta_cb(s, stats) != 0) {
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return -1;
     }
     *out = s;
@@ -288,7 +289,7 @@ open_session(wl_easy_session_t **out, symbol_ids_t *ids, delta_stats_t *stats,
 }
 
 static insert_status_t
-insert_event(wl_easy_session_t *s, const symbol_ids_t *ids,
+insert_event(wirelog_easy_session_t *s, const symbol_ids_t *ids,
     const event_record_t *record)
 {
     const int64_t level = record->hot ? ids->warn : ids->info;
@@ -314,12 +315,12 @@ insert_event(wl_easy_session_t *s, const symbol_ids_t *ids,
     row[1] = record->tenant_a ? ids->tenant_a : ids->tenant_b;
     row[2] = risk;
     row[3] = (int64_t)payload;
-    return wl_easy_insert(s, "event", row, 4) == WIRELOG_OK ? INSERT_OK
+    return wirelog_easy_insert(s, "event", row, 4) == WIRELOG_OK ? INSERT_OK
                                                             : INSERT_FAILED;
 }
 
 static int
-replay_edb(wl_easy_session_t *s, const symbol_ids_t *ids,
+replay_edb(wirelog_easy_session_t *s, const symbol_ids_t *ids,
     const edb_store_t *edb)
 {
     for (size_t i = 0; i < edb->count; i++) {
@@ -330,21 +331,21 @@ replay_edb(wl_easy_session_t *s, const symbol_ids_t *ids,
 }
 
 static int
-rotate_session(wl_easy_session_t **session_io, symbol_ids_t *ids,
+rotate_session(wirelog_easy_session_t **session_io, symbol_ids_t *ids,
     const edb_store_t *edb, delta_stats_t *stats, uint64_t *rotations)
 {
-    wl_easy_session_t *fresh = NULL;
+    wirelog_easy_session_t *fresh = NULL;
     if (open_session(&fresh, ids, stats, false) != 0)
         return -1;
     if (replay_edb(fresh, ids, edb) != 0) {
-        wl_easy_close(fresh);
+        wirelog_easy_close(fresh);
         return -1;
     }
     if (enable_delta_cb(fresh, stats) != 0) {
-        wl_easy_close(fresh);
+        wirelog_easy_close(fresh);
         return -1;
     }
-    wl_easy_close(*session_io);
+    wirelog_easy_close(*session_io);
     *session_io = fresh;
     (*rotations)++;
     return 0;
@@ -365,7 +366,7 @@ int
 main(int argc, char **argv)
 {
     daemon_opts_t opts;
-    wl_easy_session_t *session = NULL;
+    wirelog_easy_session_t *session = NULL;
     symbol_ids_t ids;
     delta_stats_t stats = { 0 };
     edb_store_t edb = { 0 };
@@ -404,7 +405,7 @@ main(int argc, char **argv)
             if (rotate_session(&session, &ids, &edb, &stats, &rotations)
                 != 0) {
                 fprintf(stderr, "[daemon] rotation failed\n");
-                wl_easy_close(session);
+                wirelog_easy_close(session);
                 edb_free(&edb);
                 return 1;
             }
@@ -413,20 +414,20 @@ main(int argc, char **argv)
         if (insert_rc != INSERT_OK) {
             fprintf(stderr, "[daemon] insert failed at event=%" PRIu64 "\n",
                 event_id);
-            wl_easy_close(session);
+            wirelog_easy_close(session);
             edb_free(&edb);
             return 1;
         }
-        if (wl_easy_step(session) != WIRELOG_OK) {
+        if (wirelog_easy_step(session) != WIRELOG_OK) {
             fprintf(stderr, "[daemon] step failed at event=%" PRIu64 "\n",
                 event_id);
-            wl_easy_close(session);
+            wirelog_easy_close(session);
             edb_free(&edb);
             return 1;
         }
         if (edb_push(&edb, &record) != 0) {
             fprintf(stderr, "[daemon] out of memory while recording EDB\n");
-            wl_easy_close(session);
+            wirelog_easy_close(session);
             edb_free(&edb);
             return 1;
         }
@@ -451,7 +452,7 @@ main(int argc, char **argv)
         event_id, edb.count, stats.hot_deltas, rotations, saturations,
         rss_kb());
 
-    wl_easy_close(session);
+    wirelog_easy_close(session);
     edb_free(&edb);
     return rotations > 0 ? 0 : 1;
 }

--- a/meson.build
+++ b/meson.build
@@ -255,7 +255,7 @@ wirelog_public_headers = [
   'wirelog/wirelog-ir.h',
   'wirelog/wirelog-optimizer.h',
   'wirelog/wirelog-export.h',
-  'wirelog/wl_easy.h',
+  'wirelog/wirelog-easy.h',
   'wirelog/wirelog-advanced.h',
 ]
 

--- a/scripts/check_log_header_not_public.sh
+++ b/scripts/check_log_header_not_public.sh
@@ -16,7 +16,7 @@ PUBLIC_HEADERS=(
     wirelog/wirelog-ir.h
     wirelog/wirelog-optimizer.h
     wirelog/wirelog-export.h
-    wirelog/wl_easy.h
+    wirelog/wirelog-easy.h
     wirelog/wirelog-advanced.h
     wirelog/io/io_adapter.h
 )

--- a/scripts/ci/check-advanced-header.sh
+++ b/scripts/ci/check-advanced-header.sh
@@ -19,14 +19,14 @@ die() {
 
 [ -f "$HEADER" ] || die "header not found: $HEADER"
 
-ALLOWED='#include[[:space:]]*"wirelog/(wirelog\.h|wirelog-types\.h|wirelog-parser\.h|wirelog-ir\.h|wirelog-optimizer\.h|wirelog-export\.h|wl_easy\.h|wirelog-advanced\.h|io/io_adapter\.h)"[[:space:]]*$'
+ALLOWED='#include[[:space:]]*"wirelog/(wirelog\.h|wirelog-types\.h|wirelog-parser\.h|wirelog-ir\.h|wirelog-optimizer\.h|wirelog-export\.h|wirelog_easy\.h|wirelog-advanced\.h|io/io_adapter\.h)"[[:space:]]*$'
 
 quoted_includes=$(grep -nE '^[[:space:]]*#include[[:space:]]*"' "$HEADER" || true)
 suspicious=$(printf '%s\n' "$quoted_includes" | grep -vE "$ALLOWED" || true)
 
 if [ -n "$suspicious" ]; then
     printf 'check-advanced-header: internal or unlisted header in public surface:\n%s\n' "$suspicious" >&2
-    printf '\nallowed quoted includes (allowlist):\n  wirelog/wirelog.h\n  wirelog/wirelog-types.h\n  wirelog/wirelog-parser.h\n  wirelog/wirelog-ir.h\n  wirelog/wirelog-optimizer.h\n  wirelog/wirelog-export.h\n  wirelog/wl_easy.h\n  wirelog/wirelog-advanced.h\n  wirelog/io/io_adapter.h\n' >&2
+    printf '\nallowed quoted includes (allowlist):\n  wirelog/wirelog.h\n  wirelog/wirelog-types.h\n  wirelog/wirelog-parser.h\n  wirelog/wirelog-ir.h\n  wirelog/wirelog-optimizer.h\n  wirelog/wirelog-export.h\n  wirelog/wirelog-easy.h\n  wirelog/wirelog-advanced.h\n  wirelog/io/io_adapter.h\n' >&2
     exit 1
 fi
 

--- a/scripts/ci/check-wl-easy-opts-symbol.sh
+++ b/scripts/ci/check-wl-easy-opts-symbol.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Issue #635: wl_easy_open and wl_easy_open_opts must be exported by libwirelog.
+# Issue #635: wirelog_easy_open and wirelog_easy_open_opts must be exported by libwirelog.
 set -euo pipefail
 
 BUILD_DIR="${1:-build}"
@@ -22,8 +22,8 @@ nm_dynamic_defined() {
 
 SYMS="$(nm_dynamic_defined "$LIB")"
 # Match either bare or underscore-prefixed symbols so the same probe
-# works for ELF (Linux: "wl_easy_open") and Mach-O (macOS: "_wl_easy_open").
-for sym in wl_easy_open wl_easy_open_opts; do
+# works for ELF (Linux: "wirelog_easy_open") and Mach-O (macOS: "_wl_easy_open").
+for sym in wirelog_easy_open wirelog_easy_open_opts; do
     if ! printf '%s\n' "$SYMS" | awk -v sym="$sym" \
         '$NF == sym || $NF == "_" sym {found = 1} END {exit !found}'; then
         echo "ERROR: missing exported symbol $sym in $LIB" >&2
@@ -31,4 +31,4 @@ for sym in wl_easy_open wl_easy_open_opts; do
     fi
 done
 
-echo "OK: wl_easy_open and wl_easy_open_opts exported by $LIB"
+echo "OK: wirelog_easy_open and wirelog_easy_open_opts exported by $LIB"

--- a/tests/fpga_backend.c
+++ b/tests/fpga_backend.c
@@ -16,7 +16,7 @@
  *    LFTJ, and EXCHANGE operators.  Non-columnar backends must skip these
  *    (ops >= WL_PLAN_OP__BACKEND_START).
  *
- * 2. wl_easy.h hardcodes the columnar backend via wl_backend_columnar().
+ * 2. wirelog-easy.h hardcodes the columnar backend via wl_backend_columnar().
  *    Alternative backends require manual wl_session_create() calls.
  *
  * 3. Expression opcode coverage: only arithmetic and comparison opcodes

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -375,7 +375,7 @@ if not is_windows
        find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
        args: [meson.project_build_root()],
        suite: 'abi')
-  test('wl_easy_abi_opts_symbol',
+  test('wirelog_easy_abi_opts_symbol',
        find_program(meson.project_source_root() / 'scripts/ci/check-wl-easy-opts-symbol.sh'),
        args: [meson.project_build_root()],
        suite: 'abi')
@@ -3600,9 +3600,9 @@ test_string_eval_exe = executable(
 
 test('string_eval', test_string_eval_exe)
 
-test_wl_easy_exe = executable(
-  'test_wl_easy',
-  files('test_wl_easy.c'),
+test_wirelog_easy_exe = executable(
+  'test_wirelog_easy',
+  files('test_wirelog_easy.c'),
   parser_src,
   ir_src,
   optimizer_src,
@@ -3611,17 +3611,17 @@ test_wl_easy_exe = executable(
   arena_src,
   thread_src,
   workqueue_src,
-  '../wirelog/wl_easy.c',
+  '../wirelog/wirelog-easy.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
-test('wl_easy', test_wl_easy_exe)
+test('wirelog_easy', test_wirelog_easy_exe)
 
 # Issue #718: inline .dl static-fact materialization regression.
-test_wl_easy_inline_facts_exe = executable(
-  'test_wl_easy_inline_facts',
-  files('test_wl_easy_inline_facts.c'),
+test_wirelog_easy_inline_facts_exe = executable(
+  'test_wirelog_easy_inline_facts',
+  files('test_wirelog_easy_inline_facts.c'),
   parser_src,
   ir_src,
   optimizer_src,
@@ -3630,12 +3630,12 @@ test_wl_easy_inline_facts_exe = executable(
   arena_src,
   thread_src,
   workqueue_src,
-  '../wirelog/wl_easy.c',
+  '../wirelog/wirelog-easy.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
-test('wl_easy_inline_facts', test_wl_easy_inline_facts_exe)
+test('wirelog_easy_inline_facts', test_wirelog_easy_inline_facts_exe)
 
 # Issue #717 / #703: behavioral-parity test for the advanced session API.
 test_wirelog_advanced_exe = executable(
@@ -3649,7 +3649,7 @@ test_wirelog_advanced_exe = executable(
   arena_src,
   thread_src,
   workqueue_src,
-  '../wirelog/wl_easy.c',
+  '../wirelog/wirelog-easy.c',
   '../wirelog/wirelog_advanced.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],

--- a/tests/test_diff_integration.c
+++ b/tests/test_diff_integration.c
@@ -1075,7 +1075,7 @@ test_bulk_insert_no_epoch_increment(void)
  * outer_epoch counter advances exactly as it would for
  * col_session_insert_incremental.  Without the symmetric routing in
  * col_session_insert, this assertion fails (epoch stays at epoch_before),
- * which is the engine-level signature of the wl_easy_step EXEC report in
+ * which is the engine-level signature of the wirelog_easy_step EXEC report in
  * issue #662. */
 static void
 test_bulk_insert_with_delta_cb_takes_incremental_path(void)

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -5,7 +5,7 @@
  * Licensed under LGPL-3.0
  *
  * Behavioral parity tests for the advanced session API.  Each test
- * exercises one observable wl_easy-equivalent invariant so the two
+ * exercises one observable wirelog_easy-equivalent invariant so the two
  * facades cannot drift apart silently.
  */
 
@@ -141,7 +141,7 @@ test_create_invalid_backend(void)
 }
 
 /* T4: inline `.dl` facts must materialize into snapshot derivations on
- *     the advanced facade just like wl_easy (#718 contract carries over). */
+ *     the advanced facade just like wirelog_easy (#718 contract carries over). */
 static int
 test_inline_facts_seeded(void)
 {

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -1,5 +1,5 @@
 /*
- * test_wl_easy.c - Unit tests for the wl_easy convenience facade (Issue #441)
+ * test_wirelog-easy.c - Unit tests for the wirelog_easy convenience facade (Issue #441)
  *
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
@@ -8,7 +8,7 @@
 
 #define _POSIX_C_SOURCE 200809L
 
-#include "../wirelog/wl_easy.h"
+#include "../wirelog/wirelog-easy.h"
 #include "../wirelog/util/log.h"
 
 #include <fcntl.h>
@@ -136,22 +136,22 @@ collect_tuple(const char *relation, const int64_t *row, uint32_t ncols,
 }
 
 static bool
-drive_access_control_trace(wl_easy_session_t *s)
+drive_access_control_trace(wirelog_easy_session_t *s)
 {
-    int64_t alice = wl_easy_intern(s, "alice");
-    int64_t read = wl_easy_intern(s, "read");
+    int64_t alice = wirelog_easy_intern(s, "alice");
+    int64_t read = wirelog_easy_intern(s, "read");
     if (alice < 0 || read < 0)
         return false;
 
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    if (wl_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK)
+    if (wirelog_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK)
         return false;
 
     int64_t row[2] = { alice, read };
-    if (wl_easy_insert(s, "can", row, 2) != WIRELOG_OK)
+    if (wirelog_easy_insert(s, "can", row, 2) != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
 
     bool found_delta = false;
@@ -168,7 +168,7 @@ drive_access_control_trace(wl_easy_session_t *s)
 
     tuple_collector_t granted_t;
     memset(&granted_t, 0, sizeof(granted_t));
-    if (wl_easy_snapshot(s, "granted", collect_tuple, &granted_t)
+    if (wirelog_easy_snapshot(s, "granted", collect_tuple, &granted_t)
         != WIRELOG_OK)
         return false;
 
@@ -197,7 +197,7 @@ file_contains_substring(const char *path, const char *needle)
 
 #ifndef _WIN32
 static bool
-capture_num_workers_log(const wl_easy_open_opts_t *opts, uint32_t expected)
+capture_num_workers_log(const wirelog_easy_open_opts_t *opts, uint32_t expected)
 {
     char path[128];
     snprintf(path, sizeof(path), "/tmp/wl-easy-num-test-%ld-%u.log",
@@ -230,11 +230,11 @@ capture_num_workers_log(const wl_easy_open_opts_t *opts, uint32_t expected)
     }
     close(log_fd);
 
-    wl_easy_session_t *s = NULL;
-    wirelog_error_t open_rc = wl_easy_open_opts(ACCESS_CONTROL_SRC, opts, &s);
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t open_rc = wirelog_easy_open_opts(ACCESS_CONTROL_SRC, opts, &s);
     wirelog_error_t build_rc = WIRELOG_ERR_EXEC;
     if (open_rc == WIRELOG_OK && s)
-        build_rc = wl_easy_set_delta_cb(s, NULL, NULL);
+        build_rc = wirelog_easy_set_delta_cb(s, NULL, NULL);
 
     fflush(stderr);
     bool restored = dup2(saved_stderr, STDERR_FILENO) >= 0;
@@ -244,7 +244,7 @@ capture_num_workers_log(const wl_easy_open_opts_t *opts, uint32_t expected)
     unsetenv("WL_LOG");
     wl_log_init();
     if (s)
-        wl_easy_close(s);
+        wirelog_easy_close(s);
     unlink(path);
 
     return restored && open_rc == WIRELOG_OK && build_rc == WIRELOG_OK
@@ -261,17 +261,17 @@ test_open_close_null_safe(void)
 {
     TEST("open NULL src + NULL out + close(NULL) safe");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(NULL, &s) == WIRELOG_OK) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(NULL, &s) == WIRELOG_OK) {
         FAIL("expected non-OK on NULL src");
         return;
     }
-    if (wl_easy_open(ACCESS_CONTROL_SRC, NULL) == WIRELOG_OK) {
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, NULL) == WIRELOG_OK) {
         FAIL("expected non-OK on NULL out");
         return;
     }
     /* Must not crash */
-    wl_easy_close(NULL);
+    wirelog_easy_close(NULL);
     PASS();
 }
 
@@ -280,8 +280,8 @@ test_open_parse_error(void)
 {
     TEST("open invalid Datalog returns error");
 
-    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
-    wirelog_error_t rc = wl_easy_open("this is not datalog ::: !!!", &s);
+    wirelog_easy_session_t *s = (wirelog_easy_session_t *)0xdeadbeef;
+    wirelog_error_t rc = wirelog_easy_open("this is not datalog ::: !!!", &s);
     if (rc == WIRELOG_OK) {
         FAIL("parse should have failed");
         return;
@@ -298,17 +298,17 @@ test_open_opts_null_equiv_to_open(void)
 {
     TEST("open_opts NULL opts equivalent to open");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open_opts(ACCESS_CONTROL_SRC, NULL, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, NULL, &s) != WIRELOG_OK || !s) {
         FAIL("open_opts failed");
         return;
     }
     if (!drive_access_control_trace(s)) {
         FAIL("access-control trace failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     PASS();
 }
 
@@ -317,9 +317,9 @@ test_open_opts_zero_size_rejected(void)
 {
     TEST("open_opts rejects zero size");
 
-    wl_easy_open_opts_t opts = { 0 };
-    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
-    wirelog_error_t rc = wl_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s);
+    wirelog_easy_open_opts_t opts = { 0 };
+    wirelog_easy_session_t *s = (wirelog_easy_session_t *)0xdeadbeef;
+    wirelog_error_t rc = wirelog_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s);
     if (rc != WIRELOG_ERR_EXEC) {
         FAIL("expected WIRELOG_ERR_EXEC");
         return;
@@ -336,11 +336,11 @@ test_open_opts_reserved_rejected(void)
 {
     TEST("open_opts rejects reserved field before parsing");
 
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts._reserved = (const void *)0x1;
-    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
+    wirelog_easy_session_t *s = (wirelog_easy_session_t *)0xdeadbeef;
     wirelog_error_t rc
-        = wl_easy_open_opts("this is not datalog", &opts, &s);
+        = wirelog_easy_open_opts("this is not datalog", &opts, &s);
     if (rc != WIRELOG_ERR_EXEC) {
         FAIL("expected WIRELOG_ERR_EXEC");
         return;
@@ -357,8 +357,8 @@ test_open_opts_init_macro(void)
 {
     TEST("open_opts init macro sets defaults");
 
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
-    if (opts.size != sizeof(wl_easy_open_opts_t)) {
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    if (opts.size != sizeof(wirelog_easy_open_opts_t)) {
         FAIL("unexpected size");
         return;
     }
@@ -382,19 +382,19 @@ test_open_opts_eager_build_ok(void)
 {
     TEST("open_opts eager_build opens usable session");
 
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts.eager_build = true;
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s) != WIRELOG_OK || !s) {
         FAIL("open_opts eager_build failed");
         return;
     }
     if (!drive_access_control_trace(s)) {
         FAIL("access-control trace failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     PASS();
 }
 
@@ -409,11 +409,11 @@ test_open_opts_eager_build_propagates_parse_error(void)
 {
     TEST("open_opts eager_build propagates parse error");
 
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts.eager_build = true;
-    wl_easy_session_t *s = (wl_easy_session_t *)0xdeadbeef;
+    wirelog_easy_session_t *s = (wirelog_easy_session_t *)0xdeadbeef;
     wirelog_error_t rc
-        = wl_easy_open_opts("definitely not datalog", &opts, &s);
+        = wirelog_easy_open_opts("definitely not datalog", &opts, &s);
     if (rc != WIRELOG_ERR_PARSE) {
         FAIL("expected WIRELOG_ERR_PARSE");
         return;
@@ -451,7 +451,7 @@ test_num_workers_explicit_four(void)
     SKIP("POSIX fd redirection not available on Windows");
     return;
 #else
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts.num_workers = 4;
     if (!capture_num_workers_log(&opts, 4)) {
         FAIL("expected num_workers=4 log");
@@ -466,19 +466,19 @@ test_intern_returns_same_id(void)
 {
     TEST("intern same string returns same id");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
-    int64_t a = wl_easy_intern(s, "alice");
-    int64_t b = wl_easy_intern(s, "alice");
+    int64_t a = wirelog_easy_intern(s, "alice");
+    int64_t b = wirelog_easy_intern(s, "alice");
     if (a < 0 || b < 0 || a != b) {
         FAIL("intern returned inconsistent ids");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     PASS();
 }
 
@@ -487,32 +487,32 @@ test_insert_step_delta(void)
 {
     TEST("insert + step fires delta callback");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
-    int64_t alice = wl_easy_intern(s, "alice");
-    int64_t read = wl_easy_intern(s, "read");
+    int64_t alice = wirelog_easy_intern(s, "alice");
+    int64_t read = wirelog_easy_intern(s, "read");
     if (alice < 0 || read < 0) {
         FAIL("intern failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    wl_easy_set_delta_cb(s, collect_delta, &deltas);
+    wirelog_easy_set_delta_cb(s, collect_delta, &deltas);
 
     int64_t row[2] = { alice, read };
-    if (wl_easy_insert(s, "can", row, 2) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "can", row, 2) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
@@ -525,7 +525,7 @@ test_insert_step_delta(void)
             break;
         }
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!found) {
         FAIL("expected +granted(alice,read) delta not seen");
         return;
@@ -543,30 +543,30 @@ test_inline_compound_body_binding(void)
         ".decl hot(id: int64)\n"
         "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
     int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
-    if (wl_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
-        || wl_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t hot;
     memset(&hot, 0, sizeof(hot));
-    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
         FAIL("snapshot failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (hot.count != 1 || strcmp(hot.relations[0], "hot") != 0
         || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
@@ -588,8 +588,8 @@ test_inline_compound_body_join_binding(void)
         "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)), "
         "threshold(Risk).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
@@ -597,23 +597,23 @@ test_inline_compound_body_join_binding(void)
     int64_t matched_row[5] = { 7, 1, 2, 3, 90 };
     int64_t unmatched_row[5] = { 8, 1, 2, 3, 40 };
     int64_t threshold_row[1] = { 90 };
-    if (wl_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
-        || wl_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK
-        || wl_easy_insert(s, "threshold", threshold_row, 1) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK
+        || wirelog_easy_insert(s, "threshold", threshold_row, 1) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t hot;
     memset(&hot, 0, sizeof(hot));
-    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
         FAIL("snapshot failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (hot.count != 1 || strcmp(hot.relations[0], "hot") != 0
         || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
@@ -633,28 +633,28 @@ test_inline_compound_functor_mismatch_is_empty(void)
         ".decl bad(id: int64)\n"
         "bad(ID) :- event(ID, other(Level, Ts, Host, Risk)).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     int64_t row[5] = { 7, 1, 2, 3, 90 };
-    if (wl_easy_insert(s, "event", row, 5) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "event", row, 5) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t bad;
     memset(&bad, 0, sizeof(bad));
-    if (wl_easy_snapshot(s, "bad", collect_tuple, &bad) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "bad", collect_tuple, &bad) != WIRELOG_OK) {
         FAIL("snapshot failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (bad.count != 0) {
         FAIL("mismatched functor should derive no rows");
@@ -673,30 +673,30 @@ test_inline_compound_constant_child_filters(void)
         ".decl hot(id: int64)\n"
         "hot(ID) :- event(ID, metadata(_, _, _, 90)).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
     int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
-    if (wl_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
-        || wl_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "event", hot_row, 5) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", cold_row, 5) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t hot;
     memset(&hot, 0, sizeof(hot));
-    if (wl_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
         FAIL("snapshot failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (hot.count != 1 || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
         FAIL("expected only row with constant child value 90");
@@ -715,30 +715,30 @@ test_inline_compound_duplicate_child_variables_filter(void)
         ".decl same(id: int64)\n"
         "same(ID) :- event(ID, metadata(X, X, _, _)).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     int64_t matched_row[5] = { 7, 4, 4, 3, 90 };
     int64_t unmatched_row[5] = { 8, 1, 2, 3, 90 };
-    if (wl_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
-        || wl_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t same;
     memset(&same, 0, sizeof(same));
-    if (wl_easy_snapshot(s, "same", collect_tuple, &same) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "same", collect_tuple, &same) != WIRELOG_OK) {
         FAIL("snapshot failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (same.count != 1 || same.ncols[0] != 1 || same.rows[0][0] != 7) {
         FAIL("expected only row with equal duplicate child variables");
@@ -766,8 +766,8 @@ test_side_compound_public_allocation_saturates(void)
         "tc(X, Y) :- edge(X, Y).\n"
         "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(src, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
         unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
         FAIL("open failed");
         return;
@@ -783,7 +783,7 @@ test_side_compound_public_allocation_saturates(void)
     wirelog_error_t rc = wirelog_easy_make_compound(s, "metadata", 4, args,
             &handle);
     if (rc != WIRELOG_OK || handle == 0) {
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
         FAIL("first compound allocation failed");
         return;
@@ -792,12 +792,12 @@ test_side_compound_public_allocation_saturates(void)
     int64_t edge_12[2] = { 1, 2 };
     int64_t edge_23[2] = { 2, 3 };
     int64_t edge_34[2] = { 3, 4 };
-    if (wl_easy_insert(s, "event", row, 2) != WIRELOG_OK
-        || wl_easy_insert(s, "edge", edge_12, 2) != WIRELOG_OK
-        || wl_easy_insert(s, "edge", edge_23, 2) != WIRELOG_OK
-        || wl_easy_insert(s, "edge", edge_34, 2) != WIRELOG_OK
-        || wl_easy_step(s) != WIRELOG_OK) {
-        wl_easy_close(s);
+    if (wirelog_easy_insert(s, "event", row, 2) != WIRELOG_OK
+        || wirelog_easy_insert(s, "edge", edge_12, 2) != WIRELOG_OK
+        || wirelog_easy_insert(s, "edge", edge_23, 2) != WIRELOG_OK
+        || wirelog_easy_insert(s, "edge", edge_34, 2) != WIRELOG_OK
+        || wirelog_easy_step(s) != WIRELOG_OK) {
+        wirelog_easy_close(s);
         unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
         FAIL("first insert/step failed");
         return;
@@ -805,7 +805,7 @@ test_side_compound_public_allocation_saturates(void)
 
     handle = 123;
     rc = wirelog_easy_make_compound(s, "metadata", 4, args, &handle);
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
     if (rc != WIRELOG_ERR_COMPOUND_SATURATED || handle != 0) {
         FAIL("expected WIRELOG_ERR_COMPOUND_SATURATED with cleared handle");
@@ -819,25 +819,25 @@ test_insert_sym_variadic(void)
 {
     TEST("insert_sym variadic helper");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    wl_easy_set_delta_cb(s, collect_delta, &deltas);
+    wirelog_easy_set_delta_cb(s, collect_delta, &deltas);
 
-    if (wl_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
         != WIRELOG_OK) {
         FAIL("insert_sym failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
     bool found = false;
@@ -848,7 +848,7 @@ test_insert_sym_variadic(void)
             break;
         }
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!found) {
         FAIL("no granted delta after insert_sym");
         return;
@@ -861,38 +861,38 @@ test_remove_sym(void)
 {
     TEST("remove_sym fires negative delta");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    wl_easy_set_delta_cb(s, collect_delta, &deltas);
+    wirelog_easy_set_delta_cb(s, collect_delta, &deltas);
 
-    if (wl_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
         != WIRELOG_OK) {
         FAIL("insert_sym failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step 1 failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
     int after_step1 = deltas.count;
 
-    if (wl_easy_remove_sym(s, "can", "alice", "read", (const char *)NULL)
+    if (wirelog_easy_remove_sym(s, "can", "alice", "read", (const char *)NULL)
         != WIRELOG_OK) {
         FAIL("remove_sym failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step 2 failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
@@ -904,7 +904,7 @@ test_remove_sym(void)
             break;
         }
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!found_neg) {
         FAIL("no -granted delta after remove_sym + step");
         return;
@@ -917,44 +917,44 @@ test_snapshot_filter(void)
 {
     TEST("snapshot filters by relation name");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
-    if (wl_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
         != WIRELOG_OK
-        || wl_easy_insert_sym(s, "can", "bob", "write", (const char *)NULL)
+        || wirelog_easy_insert_sym(s, "can", "bob", "write", (const char *)NULL)
         != WIRELOG_OK) {
         FAIL("insert_sym failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    /* NOTE: Do NOT call wl_easy_step() before wl_easy_snapshot().  The
+    /* NOTE: Do NOT call wirelog_easy_step() before wirelog_easy_snapshot().  The
      * columnar backend's snapshot path re-evaluates all strata and appends
      * to the IDB relation rows; a prior step() already derived the IDB
      * tuples, so combining the two would double-count.  See the doc
-     * comment on wl_easy_snapshot() in wl_easy.h. */
+     * comment on wirelog_easy_snapshot() in wirelog-easy.h. */
 
     tuple_collector_t granted_t;
     memset(&granted_t, 0, sizeof(granted_t));
-    if (wl_easy_snapshot(s, "granted", collect_tuple, &granted_t)
+    if (wirelog_easy_snapshot(s, "granted", collect_tuple, &granted_t)
         != WIRELOG_OK) {
         FAIL("snapshot granted failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     tuple_collector_t can_t;
     memset(&can_t, 0, sizeof(can_t));
-    if (wl_easy_snapshot(s, "can", collect_tuple, &can_t) != WIRELOG_OK) {
+    if (wirelog_easy_snapshot(s, "can", collect_tuple, &can_t) != WIRELOG_OK) {
         FAIL("snapshot can failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
-    wl_easy_close(s);
+    wirelog_easy_close(s);
 
     if (granted_t.count != 2) {
         FAIL("expected 2 granted tuples in snapshot");
@@ -984,24 +984,24 @@ test_print_delta_integer_column(void)
     static const char *SRC = ".decl a(x: int32)\n"
         ".decl r(x: int32)\n"
         "r(x) :- a(x).\n";
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
-    wl_easy_set_delta_cb(s, wl_easy_print_delta, s);
+    wirelog_easy_set_delta_cb(s, wirelog_easy_print_delta, s);
     int64_t row[1] = { 42 };
-    if (wl_easy_insert(s, "a", row, 1) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "a", row, 1) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     PASS();
 }
 
@@ -1030,12 +1030,12 @@ test_print_delta_unknown_relation_integer_fallback(void)
         fclose(stdout);
         fclose(stderr);
 
-        wl_easy_session_t *s = NULL;
-        if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s)
+        wirelog_easy_session_t *s = NULL;
+        if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s)
             _exit(2);
         int64_t row[2] = { 123456789, 987654321 };
-        wl_easy_print_delta("no_such_relation", row, 2, 1, s);
-        wl_easy_close(s);
+        wirelog_easy_print_delta("no_such_relation", row, 2, 1, s);
+        wirelog_easy_close(s);
         _exit(0);
     }
     int status = 0;
@@ -1071,15 +1071,15 @@ test_print_delta_abort_on_missed_symbol(void)
         fclose(stdout);
         fclose(stderr);
 
-        wl_easy_session_t *s = NULL;
-        if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s)
+        wirelog_easy_session_t *s = NULL;
+        if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s)
             _exit(2);
-        wl_easy_set_delta_cb(s, wl_easy_print_delta, s);
+        wirelog_easy_set_delta_cb(s, wirelog_easy_print_delta, s);
         /* Bogus, never-interned ids — printer must abort. */
         int64_t row[2] = { 999999, 888888 };
-        wl_easy_insert(s, "can", row, 2);
-        wl_easy_step(s);
-        wl_easy_close(s);
+        wirelog_easy_insert(s, "can", row, 2);
+        wirelog_easy_step(s);
+        wirelog_easy_close(s);
         _exit(0);
     }
     int status = 0;
@@ -1101,23 +1101,23 @@ test_cleanup_order_no_use_after_free(void)
     TEST("open/use/close repeated has no leaks");
 
     for (int iter = 0; iter < 2; iter++) {
-        wl_easy_session_t *s = NULL;
-        if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+        wirelog_easy_session_t *s = NULL;
+        if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
             FAIL("open failed");
             return;
         }
-        if (wl_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
+        if (wirelog_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
             != WIRELOG_OK) {
             FAIL("insert_sym failed");
-            wl_easy_close(s);
+            wirelog_easy_close(s);
             return;
         }
-        if (wl_easy_step(s) != WIRELOG_OK) {
+        if (wirelog_easy_step(s) != WIRELOG_OK) {
             FAIL("step failed");
-            wl_easy_close(s);
+            wirelog_easy_close(s);
             return;
         }
-        wl_easy_close(s);
+        wirelog_easy_close(s);
     }
     PASS();
 }
@@ -1127,40 +1127,40 @@ test_intern_after_step_succeeds(void)
 {
     TEST("intern after first step still succeeds (Option B contract)");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ACCESS_CONTROL_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
-    int64_t alice = wl_easy_intern(s, "alice");
-    int64_t read = wl_easy_intern(s, "read");
+    int64_t alice = wirelog_easy_intern(s, "alice");
+    int64_t read = wirelog_easy_intern(s, "read");
     if (alice < 0 || read < 0) {
         FAIL("intern failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
     int64_t row[2] = { alice, read };
-    if (wl_easy_insert(s, "can", row, 2) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "can", row, 2) != WIRELOG_OK) {
         FAIL("insert failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("step failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
     /* After the plan has been built and stepped, interning a brand new
      * symbol must still succeed and return a fresh id, because the intern
      * table is aliased through the whole session lifetime. */
-    int64_t late = wl_easy_intern(s, "late_symbol");
+    int64_t late = wirelog_easy_intern(s, "late_symbol");
     /* And a new insert using that id must also succeed, proving the id is
      * actually visible to the running backend. */
     int64_t late_row[2] = { late, read };
     wirelog_error_t ins_rc
-        = wl_easy_insert(s, "can", late_row, 2);
-    wirelog_error_t step_rc = wl_easy_step(s);
-    wl_easy_close(s);
+        = wirelog_easy_insert(s, "can", late_row, 2);
+    wirelog_error_t step_rc = wirelog_easy_step(s);
+    wirelog_easy_close(s);
     if (late < 0) {
         FAIL("late intern should have returned a non-negative id");
         return;
@@ -1177,9 +1177,9 @@ test_delta_cb_multi_round_recursive_insert(void)
 {
     TEST("delta_cb + recursive insert/step rounds produce expected deltas");
 
-    /* Issue #662: when wl_easy_set_delta_cb has installed a callback, a
-     * subsequent wl_easy_insert must take the same incremental path that
-     * wl_easy_remove already takes, so that arrangement caches are
+    /* Issue #662: when wirelog_easy_set_delta_cb has installed a callback, a
+     * subsequent wirelog_easy_insert must take the same incremental path that
+     * wirelog_easy_remove already takes, so that arrangement caches are
      * invalidated and the outer-epoch counter advances.  Without that
      * symmetry, a second insert+step round on a recursive stratum either
      * skips the new iteration (no delta surfaces) or trips the join over
@@ -1190,47 +1190,47 @@ test_delta_cb_multi_round_recursive_insert(void)
         "reach(A, B) :- edge(A, B).\n"
         "reach(A, C) :- reach(A, B), edge(B, C).\n";
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(RECURSIVE_REACH_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(RECURSIVE_REACH_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
 
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    if (wl_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK) {
+    if (wirelog_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK) {
         FAIL("set_delta_cb failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     int64_t e12[2] = { 1, 2 };
-    if (wl_easy_insert(s, "edge", e12, 2) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "edge", e12, 2) != WIRELOG_OK) {
         FAIL("insert edge(1,2) failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("first step returned non-OK");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
     int round1_count = deltas.count;
     if (round1_count == 0) {
         FAIL("first step produced no deltas");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
     int64_t e23[2] = { 2, 3 };
-    if (wl_easy_insert(s, "edge", e23, 2) != WIRELOG_OK) {
+    if (wirelog_easy_insert(s, "edge", e23, 2) != WIRELOG_OK) {
         FAIL("insert edge(2,3) failed");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
-    if (wl_easy_step(s) != WIRELOG_OK) {
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
         FAIL("second step returned non-OK (issue #662 reproduction)");
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return;
     }
 
@@ -1247,7 +1247,7 @@ test_delta_cb_multi_round_recursive_insert(void)
             break;
         }
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!saw_reach_1_3) {
         FAIL("expected +reach(1,3) delta in round 2 not seen");
         return;
@@ -1256,7 +1256,7 @@ test_delta_cb_multi_round_recursive_insert(void)
 }
 
 /* Issue #665: a 5-relation conjunctive rule was reported to surface
-* WIRELOG_ERR_EXEC from wl_easy_step when the EDB prerequisites were
+* WIRELOG_ERR_EXEC from wirelog_easy_step when the EDB prerequisites were
 * inserted across separate epochs and only some were present at step time.
 * PR #663 (Closes #662) made col_session_insert reroute to the incremental
 * path under an installed delta callback; that reroute also covers the
@@ -1290,30 +1290,30 @@ count_allow_bool_added(const delta_collector_t *deltas, int from)
 }
 
 static bool
-drive_issue_665_partial_conjunction(wl_easy_session_t *s)
+drive_issue_665_partial_conjunction(wirelog_easy_session_t *s)
 {
     delta_collector_t deltas;
     memset(&deltas, 0, sizeof(deltas));
-    if (wl_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK)
+    if (wirelog_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK)
         return false;
 
     /* Step 1: only grant present. allow_bool requires four more EDB legs;
      * the partial-prereq step must succeed and emit no allow_bool delta. */
-    if (wl_easy_insert_sym(s, "grant", "u", "p", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "grant", "u", "p", (const char *)NULL)
         != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
     if (count_allow_bool_added(&deltas, 0) != 0)
         return false;
     int after_grant = deltas.count;
 
     /* Step 2: add principal_state with the literal "authenticated". */
-    if (wl_easy_insert_sym(s, "principal_state", "u", "authenticated",
+    if (wirelog_easy_insert_sym(s, "principal_state", "u", "authenticated",
         (const char *)NULL)
         != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
     if (count_allow_bool_added(&deltas, after_grant) != 0)
         return false;
@@ -1321,20 +1321,20 @@ drive_issue_665_partial_conjunction(wl_easy_session_t *s)
 
     /* Step 3: session_state(S, ST) — still missing session_active and
      * perm_state, so the join body is unsatisfied. */
-    if (wl_easy_insert_sym(s, "session_state", "s", "st", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "session_state", "s", "st", (const char *)NULL)
         != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
     if (count_allow_bool_added(&deltas, after_principal) != 0)
         return false;
     int after_session = deltas.count;
 
     /* Step 4: session_active(ST) — perm_state still missing. */
-    if (wl_easy_insert_sym(s, "session_active", "st", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "session_active", "st", (const char *)NULL)
         != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
     if (count_allow_bool_added(&deltas, after_session) != 0)
         return false;
@@ -1342,20 +1342,20 @@ drive_issue_665_partial_conjunction(wl_easy_session_t *s)
 
     /* Step 5: perm_state(U, P, S, "armed") completes the conjunction.
      * Exactly one +allow_bool("u","p","s") must surface. */
-    if (wl_easy_insert_sym(s, "perm_state", "u", "p", "s", "armed",
+    if (wirelog_easy_insert_sym(s, "perm_state", "u", "p", "s", "armed",
         (const char *)NULL)
         != WIRELOG_OK)
         return false;
-    if (wl_easy_step(s) != WIRELOG_OK)
+    if (wirelog_easy_step(s) != WIRELOG_OK)
         return false;
     if (count_allow_bool_added(&deltas, after_active) != 1)
         return false;
 
     /* Verify the bound row matches the inputs we interned through the
      * insert_sym helper: allow_bool(u, p, s). */
-    int64_t u = wl_easy_intern(s, "u");
-    int64_t p = wl_easy_intern(s, "p");
-    int64_t scope = wl_easy_intern(s, "s");
+    int64_t u = wirelog_easy_intern(s, "u");
+    int64_t p = wirelog_easy_intern(s, "p");
+    int64_t scope = wirelog_easy_intern(s, "s");
     if (u < 0 || p < 0 || scope < 0)
         return false;
     bool matched = false;
@@ -1377,13 +1377,13 @@ test_issue_665_partial_conjunction_default_workers(void)
 {
     TEST("issue 665: partial conjunctive EDB updates step OK across epochs");
 
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open(ISSUE_665_PROGRAM_SRC, &s) != WIRELOG_OK || !s) {
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(ISSUE_665_PROGRAM_SRC, &s) != WIRELOG_OK || !s) {
         FAIL("open failed");
         return;
     }
     bool ok = drive_issue_665_partial_conjunction(s);
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!ok) {
         FAIL("partial-prereq step regressed");
         return;
@@ -1403,16 +1403,16 @@ test_issue_665_partial_conjunction_multi_worker(void)
      * delta contract that the default-workers test pins. */
     TEST("issue 665: partial conjunctive shape stable on num_workers=4");
 
-    wl_easy_open_opts_t opts = WL_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts.num_workers = 4;
-    wl_easy_session_t *s = NULL;
-    if (wl_easy_open_opts(ISSUE_665_PROGRAM_SRC, &opts, &s) != WIRELOG_OK
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open_opts(ISSUE_665_PROGRAM_SRC, &opts, &s) != WIRELOG_OK
         || !s) {
         FAIL("open_opts failed");
         return;
     }
     bool ok = drive_issue_665_partial_conjunction(s);
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     if (!ok) {
         FAIL("partial-prereq step regressed under multi-worker");
         return;
@@ -1427,7 +1427,7 @@ test_issue_665_partial_conjunction_multi_worker(void)
 int
 main(void)
 {
-    printf("wl_easy Tests (Issue #441)\n");
+    printf("wirelog_easy Tests (Issue #441)\n");
     printf("==========================\n\n");
 
     test_open_close_null_safe();

--- a/tests/test_wirelog_easy_inline_facts.c
+++ b/tests/test_wirelog_easy_inline_facts.c
@@ -5,14 +5,14 @@
  * Licensed under LGPL-3.0
  *
  * Static facts declared in a `.dl` program must materialize into snapshots
- * and IDB derivations when the host opens the program through wl_easy.
- * Pre-fix, wl_easy never invoked wl_session_load_facts, so static rows
+ * and IDB derivations when the host opens the program through wirelog_easy.
+ * Pre-fix, wirelog_easy never invoked wl_session_load_facts, so static rows
  * never reached col_rel_t and every downstream observation (snapshot,
  * derived IDB, host-mirrored insert) silently disagreed with the .dl
  * program.
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog-easy.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -48,13 +48,13 @@ count_rows(const char *relation, const int64_t *row, uint32_t ncols,
 static int
 test_static_fact_drives_idb_snapshot(void)
 {
-    wl_easy_session_t *s = NULL;
-    wirelog_error_t err = wl_easy_open(PROG_SRC, &s);
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(PROG_SRC, &s);
     if (err != WIRELOG_OK || !s)
         return 1;
 
     struct count_state st = { 0 };
-    err = wl_easy_snapshot(s, "effective_permission", count_rows, &st);
+    err = wirelog_easy_snapshot(s, "effective_permission", count_rows, &st);
     int rc = 0;
     if (err != WIRELOG_OK) {
         fprintf(stderr, "T1 snapshot err=%d\n", err);
@@ -64,7 +64,7 @@ test_static_fact_drives_idb_snapshot(void)
             "T1: expected 1 effective_permission row, got %u\n", st.rows);
         rc = 1;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return rc;
 }
 
@@ -73,28 +73,28 @@ test_static_fact_drives_idb_snapshot(void)
 static int
 test_static_fact_joins_with_host_insert(void)
 {
-    wl_easy_session_t *s = NULL;
-    wirelog_error_t err = wl_easy_open(PROG_SRC, &s);
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(PROG_SRC, &s);
     if (err != WIRELOG_OK || !s)
         return 1;
 
-    int64_t alice = wl_easy_intern(s, "alice");
-    int64_t admin = wl_easy_intern(s, "wr.system_admin");
-    int64_t global = wl_easy_intern(s, "global");
+    int64_t alice = wirelog_easy_intern(s, "alice");
+    int64_t admin = wirelog_easy_intern(s, "wr.system_admin");
+    int64_t global = wirelog_easy_intern(s, "global");
     if (alice < 0 || admin < 0 || global < 0) {
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 1;
     }
     int64_t row[3] = { alice, admin, global };
-    err = wl_easy_insert(s, "member_of", row, 3);
+    err = wirelog_easy_insert(s, "member_of", row, 3);
     if (err != WIRELOG_OK) {
         fprintf(stderr, "T2 insert err=%d\n", err);
-        wl_easy_close(s);
+        wirelog_easy_close(s);
         return 1;
     }
 
     struct count_state st = { 0 };
-    err = wl_easy_snapshot(s, "has_permission", count_rows, &st);
+    err = wirelog_easy_snapshot(s, "has_permission", count_rows, &st);
     int rc = 0;
     if (err != WIRELOG_OK) {
         fprintf(stderr, "T2 snapshot err=%d\n", err);
@@ -104,7 +104,7 @@ test_static_fact_joins_with_host_insert(void)
             "T2: expected 1 has_permission row, got %u\n", st.rows);
         rc = 1;
     }
-    wl_easy_close(s);
+    wirelog_easy_close(s);
     return rc;
 }
 

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -121,10 +121,10 @@ wirelog_io_src = files('io/csv_reader.c', 'io/io_adapter.c', 'io/io_ctx.c', 'io/
 wirelog_string_ops_src = files('string_ops.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
-#wl_easy Module(Issue #441)
+#wirelog_easy Module(Issue #441)
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_wl_easy_src = files('wl_easy.c', )
+wirelog_wl_easy_src = files('wirelog-easy.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Advanced session API (Issue #717 / #703)

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -44,9 +44,9 @@ struct wl_session {
 /*
  * NOTE: This header is INTERNAL — it is not part of the installed
  * public surface (see install_headers in the top-level meson.build).
- * Public users must use <wirelog/wl_easy.h> (or, equivalently, the
+ * Public users must use <wirelog/wirelog-easy.h> (or, equivalently, the
  * umbrella <wirelog/wirelog.h>).  The wl_session_* primitives below
- * back the wl_easy_* facade and are exercised by in-tree tests; they
+ * back the wirelog_easy_* facade and are exercised by in-tree tests; they
  * are not promised to external consumers and may change without notice.
  */
 

--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -25,10 +25,10 @@
  * @file wirelog-advanced.h
  *
  * Fine-grained session API.  This header is the public counterpart to the
- * convenience facade in <wirelog/wl_easy.h>: it lets a host pick the
+ * convenience facade in <wirelog/wirelog-easy.h>: it lets a host pick the
  * compute backend, the worker count, and drive the session through the
  * same insert / remove / step / snapshot / set_delta_cb / make_compound
- * surface that wl_easy wraps.
+ * surface that wirelog_easy wraps.
  *
  * Status: Current.  The signatures and semantics here are stable for the
  * 0.x series and are intended to freeze at 1.0; see docs/SEMANTICS.md and
@@ -36,7 +36,7 @@
  *
  * The internal wl_session_* primitives in wirelog/session.h are not part
  * of the installed public surface and may change without notice between
- * minor releases.  External users must use this header (or wl_easy.h).
+ * minor releases.  External users must use this header (or wirelog-easy.h).
  */
 
 #ifndef WIRELOG_ADVANCED_H
@@ -102,7 +102,7 @@ typedef enum {
  *
  * Build the execution plan, instantiate the chosen backend, and seed
  * any inline `.dl` facts declared in @program into the session as base
- * rows (the same contract documented for wl_easy_open in #718 — see
+ * rows (the same contract documented for wirelog_easy_open in #718 — see
  * docs/SEMANTICS.md "Inline `.dl` facts").  All work happens before
  * this call returns; there is no lazy-build path on the advanced API.
  *
@@ -204,7 +204,7 @@ wirelog_session_set_delta_cb(wirelog_session_t *session,
  * @user_data: Opaque user data passed to @callback.
  *
  * Evaluate the current state and forward every IDB tuple to @callback.
- * Like wl_easy_snapshot(), this is an *evaluating* call; do NOT mix
+ * Like wirelog_easy_snapshot(), this is an *evaluating* call; do NOT mix
  * with wirelog_session_step() on the same insert batch (step() and
  * snapshot() each derive IDB rows independently and combining them
  * produces duplicates).

--- a/wirelog/wirelog-easy.c
+++ b/wirelog/wirelog-easy.c
@@ -1,5 +1,5 @@
 /*
- * wl_easy.c - wirelog convenience facade (Issue #441)
+ * wirelog-easy.c - wirelog convenience facade (Issue #441)
  *
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
@@ -20,7 +20,7 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog-easy.h"
 
 #include "wirelog/backend.h"
 #include "wirelog/exec_plan.h"
@@ -42,9 +42,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define WL_EASY_MAX_COLS 16
+#define WIRELOG_EASY_MAX_COLS 16
 
-struct wl_easy_session {
+struct wirelog_easy_session {
     wirelog_program_t *prog; /* owns */
     wl_plan_t *plan;         /* owns, lazy-built */
     wl_session_t *session;   /* owns, lazy-built */
@@ -54,7 +54,7 @@ struct wl_easy_session {
      * intern's lifetime so the cast is safe. */
     wl_intern_t *intern_mut;
     uint32_t num_workers;
-    bool plan_built; /* true once first wl_easy_step-class call ran */
+    bool plan_built; /* true once first wirelog_easy_step-class call ran */
 };
 
 /* ======================================================================== */
@@ -62,7 +62,7 @@ struct wl_easy_session {
 /* ======================================================================== */
 
 static wirelog_error_t
-ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
+ensure_plan_built(wirelog_easy_session_t *s, uint32_t num_workers)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
@@ -89,7 +89,7 @@ ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
      * so snapshots and IDB derivations observe them.  This mirrors the
      * fact-load step of the CLI driver's session-build sequence
      * (cli/driver.c:397); the wider optimizer pipeline alignment
-     * between wl_easy (fusion + jpp + sip) and the CLI (which also
+     * between wirelog_easy (fusion + jpp + sip) and the CLI (which also
      * runs subsumption + magic_sets) is tracked separately and is not
      * in scope here.  The load runs exactly once on the lazy
      * plan/session boundary, before any host delta callback can be
@@ -114,14 +114,14 @@ ensure_plan_built(wl_easy_session_t *s, uint32_t num_workers)
 /* ======================================================================== */
 
 wirelog_error_t
-wl_easy_open_opts(const char *dl_src, const wl_easy_open_opts_t *opts,
-    wl_easy_session_t **out)
+wirelog_easy_open_opts(const char *dl_src, const wirelog_easy_open_opts_t *opts,
+    wirelog_easy_session_t **out)
 {
     if (!dl_src || !out)
         return WIRELOG_ERR_EXEC;
     *out = NULL;
 
-    if (opts && opts->size < sizeof(wl_easy_open_opts_t))
+    if (opts && opts->size < sizeof(wirelog_easy_open_opts_t))
         return WIRELOG_ERR_EXEC;
     if (opts && opts->_reserved)
         return WIRELOG_ERR_EXEC;
@@ -139,27 +139,27 @@ wl_easy_open_opts(const char *dl_src, const wl_easy_open_opts_t *opts,
     int pass_rc = wl_fusion_apply(prog, NULL);
     if (pass_rc != 0) {
         fprintf(stderr,
-            "wl_easy_open: wl_fusion_apply failed (rc=%d)\n", pass_rc);
+            "wirelog_easy_open: wl_fusion_apply failed (rc=%d)\n", pass_rc);
         wirelog_program_free(prog);
         return WIRELOG_ERR_EXEC;
     }
     pass_rc = wl_jpp_apply(prog, NULL);
     if (pass_rc != 0) {
         fprintf(stderr,
-            "wl_easy_open: wl_jpp_apply failed (rc=%d)\n", pass_rc);
+            "wirelog_easy_open: wl_jpp_apply failed (rc=%d)\n", pass_rc);
         wirelog_program_free(prog);
         return WIRELOG_ERR_EXEC;
     }
     pass_rc = wl_sip_apply(prog, NULL);
     if (pass_rc != 0) {
         fprintf(stderr,
-            "wl_easy_open: wl_sip_apply failed (rc=%d)\n", pass_rc);
+            "wirelog_easy_open: wl_sip_apply failed (rc=%d)\n", pass_rc);
         wirelog_program_free(prog);
         return WIRELOG_ERR_EXEC;
     }
 
-    wl_easy_session_t *s
-        = (wl_easy_session_t *)calloc(1, sizeof(wl_easy_session_t));
+    wirelog_easy_session_t *s
+        = (wirelog_easy_session_t *)calloc(1, sizeof(wirelog_easy_session_t));
     if (!s) {
         wirelog_program_free(prog);
         return WIRELOG_ERR_MEMORY;
@@ -189,13 +189,13 @@ wl_easy_open_opts(const char *dl_src, const wl_easy_open_opts_t *opts,
 }
 
 wirelog_error_t
-wl_easy_open(const char *dl_src, wl_easy_session_t **out)
+wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out)
 {
-    return wl_easy_open_opts(dl_src, NULL, out);
+    return wirelog_easy_open_opts(dl_src, NULL, out);
 }
 
 void
-wl_easy_close(wl_easy_session_t *s)
+wirelog_easy_close(wirelog_easy_session_t *s)
 {
     if (!s)
         return;
@@ -213,7 +213,7 @@ wl_easy_close(wl_easy_session_t *s)
 /* ======================================================================== */
 
 int64_t
-wl_easy_intern(wl_easy_session_t *s, const char *sym)
+wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym)
 {
     if (!s || !sym || !s->intern_mut)
         return -1;
@@ -227,7 +227,7 @@ wl_easy_intern(wl_easy_session_t *s, const char *sym)
 }
 
 wirelog_error_t
-wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
+wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out)
 {
     if (handle_out)
@@ -259,7 +259,7 @@ wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
 /* ======================================================================== */
 
 wirelog_error_t
-wl_easy_insert(wl_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
     uint32_t ncols)
 {
     if (!s || !relation || !row)
@@ -272,7 +272,7 @@ wl_easy_insert(wl_easy_session_t *s, const char *relation, const int64_t *row,
 }
 
 wirelog_error_t
-wl_easy_remove(wl_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
     uint32_t ncols)
 {
     if (!s || !relation || !row)
@@ -289,16 +289,16 @@ wl_easy_remove(wl_easy_session_t *s, const char *relation, const int64_t *row,
 /* ======================================================================== */
 
 static wirelog_error_t
-collect_sym_row(wl_easy_session_t *s, va_list ap, int64_t *row, uint32_t *ncols)
+collect_sym_row(wirelog_easy_session_t *s, va_list ap, int64_t *row, uint32_t *ncols)
 {
     uint32_t n = 0;
-    while (n < WL_EASY_MAX_COLS) {
+    while (n < WIRELOG_EASY_MAX_COLS) {
         const char *sym = va_arg(ap, const char *);
         if (sym == NULL)
             break;
         /* Interning a never-seen symbol after plan build is rejected by
-         * wl_easy_intern, but if the caller pre-interned the symbol via
-         * wl_easy_intern() before the first step, wl_intern_put() simply
+         * wirelog_easy_intern, but if the caller pre-interned the symbol via
+         * wirelog_easy_intern() before the first step, wl_intern_put() simply
          * returns the existing id. */
         int64_t id = wl_intern_put(s->intern_mut, sym);
         if (id < 0)
@@ -310,11 +310,11 @@ collect_sym_row(wl_easy_session_t *s, va_list ap, int64_t *row, uint32_t *ncols)
 }
 
 wirelog_error_t
-wl_easy_insert_sym(wl_easy_session_t *s, const char *relation, ...)
+wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...)
 {
     if (!s || !relation)
         return WIRELOG_ERR_EXEC;
-    int64_t row[WL_EASY_MAX_COLS];
+    int64_t row[WIRELOG_EASY_MAX_COLS];
     uint32_t ncols = 0;
     va_list ap;
     va_start(ap, relation);
@@ -322,15 +322,15 @@ wl_easy_insert_sym(wl_easy_session_t *s, const char *relation, ...)
     va_end(ap);
     if (err != WIRELOG_OK)
         return err;
-    return wl_easy_insert(s, relation, row, ncols);
+    return wirelog_easy_insert(s, relation, row, ncols);
 }
 
 wirelog_error_t
-wl_easy_remove_sym(wl_easy_session_t *s, const char *relation, ...)
+wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...)
 {
     if (!s || !relation)
         return WIRELOG_ERR_EXEC;
-    int64_t row[WL_EASY_MAX_COLS];
+    int64_t row[WIRELOG_EASY_MAX_COLS];
     uint32_t ncols = 0;
     va_list ap;
     va_start(ap, relation);
@@ -338,7 +338,7 @@ wl_easy_remove_sym(wl_easy_session_t *s, const char *relation, ...)
     va_end(ap);
     if (err != WIRELOG_OK)
         return err;
-    return wl_easy_remove(s, relation, row, ncols);
+    return wirelog_easy_remove(s, relation, row, ncols);
 }
 
 /* ======================================================================== */
@@ -346,7 +346,7 @@ wl_easy_remove_sym(wl_easy_session_t *s, const char *relation, ...)
 /* ======================================================================== */
 
 wirelog_error_t
-wl_easy_step(wl_easy_session_t *s)
+wirelog_easy_step(wirelog_easy_session_t *s)
 {
     if (!s)
         return WIRELOG_ERR_EXEC;
@@ -358,7 +358,7 @@ wl_easy_step(wl_easy_session_t *s)
 }
 
 wirelog_error_t
-wl_easy_set_delta_cb(wl_easy_session_t *s, wirelog_on_delta_fn cb,
+wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
     void *user_data)
 {
     if (!s)
@@ -381,12 +381,12 @@ column_is_string(wirelog_column_type_t t)
 }
 
 void
-wl_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
+wirelog_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
     int32_t diff, void *user_data)
 {
-    wl_easy_session_t *s = (wl_easy_session_t *)user_data;
+    wirelog_easy_session_t *s = (wirelog_easy_session_t *)user_data;
     if (!s || !relation || !row) {
-        fprintf(stderr, "wl_easy_print_delta: NULL argument\n");
+        fprintf(stderr, "wirelog_easy_print_delta: NULL argument\n");
         abort();
     }
 
@@ -413,7 +413,7 @@ wl_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
             const char *str = wl_intern_reverse(s->intern_mut, row[i]);
             if (!str) {
                 fprintf(stderr,
-                    "wl_easy_print_delta: missed reverse-intern for "
+                    "wirelog_easy_print_delta: missed reverse-intern for "
                     "relation '%s' column %u id %" PRId64 "\n",
                     relation, i, row[i]);
                 abort();
@@ -434,7 +434,7 @@ wl_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
 /* ======================================================================== */
 
 void
-wl_easy_banner(const char *label)
+wirelog_easy_banner(const char *label)
 {
     printf("\n=== %s ===\n", label ? label : "");
 }
@@ -447,13 +447,13 @@ typedef struct {
     const char *wanted;
     wirelog_on_tuple_fn user_cb;
     void *user_data;
-} wl_easy_snapshot_filter_t;
+} wirelog_easy_snapshot_filter_t;
 
 static void
 snapshot_trampoline(const char *relation, const int64_t *row, uint32_t ncols,
     void *user_data)
 {
-    wl_easy_snapshot_filter_t *f = (wl_easy_snapshot_filter_t *)user_data;
+    wirelog_easy_snapshot_filter_t *f = (wirelog_easy_snapshot_filter_t *)user_data;
     if (!relation || !f || !f->wanted)
         return;
     if (strcmp(relation, f->wanted) != 0)
@@ -463,7 +463,7 @@ snapshot_trampoline(const char *relation, const int64_t *row, uint32_t ncols,
 }
 
 wirelog_error_t
-wl_easy_snapshot(wl_easy_session_t *s, const char *relation,
+wirelog_easy_snapshot(wirelog_easy_session_t *s, const char *relation,
     wirelog_on_tuple_fn cb,
     void *user_data)
 {
@@ -472,7 +472,7 @@ wl_easy_snapshot(wl_easy_session_t *s, const char *relation,
     wirelog_error_t err = ensure_plan_built(s, s->num_workers);
     if (err != WIRELOG_OK)
         return err;
-    wl_easy_snapshot_filter_t filter
+    wirelog_easy_snapshot_filter_t filter
         = { .wanted = relation, .user_cb = cb, .user_data = user_data };
     int rc = wl_session_snapshot(s->session, snapshot_trampoline, &filter);
     return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;

--- a/wirelog/wirelog-easy.h
+++ b/wirelog/wirelog-easy.h
@@ -1,5 +1,5 @@
 /*
- * wl_easy.h - wirelog convenience facade (Issue #441)
+ * wirelog-easy.h - wirelog convenience facade (Issue #441)
  *
  * Copyright (C) CleverPlant
  * SPDX-License-Identifier: LGPL-3.0-or-later
@@ -35,53 +35,53 @@ extern "C" {
 #include <stdint.h>
 
 /**
- * wl_easy_session_t:
+ * wirelog_easy_session_t:
  *
  * Opaque convenience handle that bundles parse, optimize, plan and session
- * lifecycle in a single object.  Use wl_easy_open() / wl_easy_close() to
+ * lifecycle in a single object.  Use wirelog_easy_open() / wirelog_easy_close() to
  * manage instances.
  *
  * Thread safety:
- *   A wl_easy_session_t is NOT thread-safe.  Any two concurrent calls on the
- *   same session pointer — including read-only helpers like wl_easy_intern()
- *   or wl_easy_snapshot() — race on the underlying program, plan and
+ *   A wirelog_easy_session_t is NOT thread-safe.  Any two concurrent calls on the
+ *   same session pointer — including read-only helpers like wirelog_easy_intern()
+ *   or wirelog_easy_snapshot() — race on the underlying program, plan and
  *   session state.  Callers MUST serialize access (e.g. with an external
  *   mutex) if they share a session across threads.
  *
- *   Independent sessions created by separate wl_easy_open() calls may be
+ *   Independent sessions created by separate wirelog_easy_open() calls may be
  *   used on different threads provided the caller does not share any
  *   derived state (rows, callback user_data, intern ids) between them.
  */
-typedef struct wl_easy_session wl_easy_session_t;
+typedef struct wirelog_easy_session wirelog_easy_session_t;
 
 /**
- * wl_easy_open_opts_t:
+ * wirelog_easy_open_opts_t:
  *
- * Optional configuration for wl_easy_open_opts().  All fields are
- * optional; pass NULL for all defaults (equivalent to wl_easy_open).
+ * Optional configuration for wirelog_easy_open_opts().  All fields are
+ * optional; pass NULL for all defaults (equivalent to wirelog_easy_open).
  *
  * The struct is ABI-versioned via @size.  Callers MUST initialize it
- * with the WL_EASY_OPEN_OPTS_INIT macro (or assign
- * `.size = sizeof(wl_easy_open_opts_t)` explicitly) so future field
+ * with the WIRELOG_EASY_OPEN_OPTS_INIT macro (or assign
+ * `.size = sizeof(wirelog_easy_open_opts_t)` explicitly) so future field
  * additions remain ABI-safe.  Library validates `size` on entry and
  * returns WIRELOG_ERR_EXEC if it is smaller than the runtime
- * sizeof(wl_easy_open_opts_t) compiled into libwirelog.
+ * sizeof(wirelog_easy_open_opts_t) compiled into libwirelog.
  *
- * @size:         sizeof(wl_easy_open_opts_t) at the caller's compile
- *                time.  REQUIRED.  Use WL_EASY_OPEN_OPTS_INIT.
+ * @size:         sizeof(wirelog_easy_open_opts_t) at the caller's compile
+ *                time.  REQUIRED.  Use WIRELOG_EASY_OPEN_OPTS_INIT.
  * @num_workers:  Number of worker threads for the underlying session.
  *                0 (the default) is permanently mapped to 1; do not
  *                rely on a different default in future releases.
  * @eager_build:  If true, force plan + session build before
- *                wl_easy_open_opts() returns, so parse/plan/session
+ *                wirelog_easy_open_opts() returns, so parse/plan/session
  *                errors surface synchronously.  If false (default),
  *                the build is deferred until the first
  *                insert/remove/step/set_delta_cb/snapshot call
- *                (legacy wl_easy_open behavior).
+ *                (legacy wirelog_easy_open behavior).
  * @_reserved:    Reserved for future use; must be NULL.  Non-NULL
  *                returns WIRELOG_ERR_EXEC.
  *
- * Lifetime: opts is read once during wl_easy_open_opts() and may be
+ * Lifetime: opts is read once during wirelog_easy_open_opts() and may be
  * freed by the caller immediately after the call returns.
  */
 typedef struct {
@@ -89,27 +89,27 @@ typedef struct {
     uint32_t num_workers;
     bool eager_build;
     const void *_reserved;
-} wl_easy_open_opts_t;
+} wirelog_easy_open_opts_t;
 
-#define WL_EASY_OPEN_OPTS_INIT \
-        { .size = sizeof(wl_easy_open_opts_t), \
+#define WIRELOG_EASY_OPEN_OPTS_INIT \
+        { .size = sizeof(wirelog_easy_open_opts_t), \
           .num_workers = 0, \
           .eager_build = false, \
           ._reserved = NULL }
 
 /**
- * wl_easy_open_opts:
+ * wirelog_easy_open_opts:
  * @dl_src: Datalog source text (must not be NULL).
  * @opts:   Optional configuration (may be NULL → defaults).  If
  *          non-NULL, must have @size set to
- *          sizeof(wl_easy_open_opts_t) (use WL_EASY_OPEN_OPTS_INIT).
+ *          sizeof(wirelog_easy_open_opts_t) (use WIRELOG_EASY_OPEN_OPTS_INIT).
  * @out:    (out) Receives the new session handle on success.
  *
- * Same contract as wl_easy_open() but with optional configuration.
- * wl_easy_open(dl, out) is equivalent to
- * wl_easy_open_opts(dl, NULL, out).
+ * Same contract as wirelog_easy_open() but with optional configuration.
+ * wirelog_easy_open(dl, out) is equivalent to
+ * wirelog_easy_open_opts(dl, NULL, out).
  *
- * Error codes (in addition to wl_easy_open's):
+ * Error codes (in addition to wirelog_easy_open's):
  *   WIRELOG_ERR_EXEC      - opts->size too small / opts->_reserved non-NULL
  *   WIRELOG_ERR_INVALID_IR - eager_build set and plan generation failed
  *   WIRELOG_ERR_MEMORY    - eager_build set and session allocation failed
@@ -117,19 +117,19 @@ typedef struct {
  * Returns: WIRELOG_OK on success; *out set to NULL on any error.
  */
 wirelog_error_t
-wl_easy_open_opts(const char *dl_src,
-    const wl_easy_open_opts_t *opts,
-    wl_easy_session_t **out);
+wirelog_easy_open_opts(const char *dl_src,
+    const wirelog_easy_open_opts_t *opts,
+    wirelog_easy_session_t **out);
 
 /**
- * wl_easy_open:
+ * wirelog_easy_open:
  * @dl_src: Datalog source text (must not be NULL).
  * @out:    (out) Receives the new session handle on success.
  *
  * Parse @dl_src, run the standard optimizer passes (fusion, jpp, sip), and
  * return a session handle.  The execution plan and underlying session are
- * built lazily on the first call to wl_easy_insert/remove/step/set_delta_cb.
- * Symbol interning via wl_easy_intern() may happen before or after that
+ * built lazily on the first call to wirelog_easy_insert/remove/step/set_delta_cb.
+ * Symbol interning via wirelog_easy_intern() may happen before or after that
  * first step-class call; the intern table is shared through the whole
  * session lifetime.
  *
@@ -137,7 +137,7 @@ wl_easy_open_opts(const char *dl_src,
  * as base rows at first lazy build, before any host delta callback can be
  * installed.  Snapshots and IDB derivations therefore observe them.  Host
  * inserts of the same row add a second multiplicity (z-set semantics): a
- * subsequent wl_easy_remove() decrements one multiplicity, so a host that
+ * subsequent wirelog_easy_remove() decrements one multiplicity, so a host that
  * mirrors a static fact and later retracts must mirror the retract too.
  * Hosts that need to know which rows are already present from the source
  * can read them via wirelog_program_get_facts().
@@ -147,19 +147,19 @@ wl_easy_open_opts(const char *dl_src,
  * other failure modes.  *out is set to NULL on error.
  */
 wirelog_error_t
-wl_easy_open(const char *dl_src, wl_easy_session_t **out);
+wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out);
 
 /**
- * wl_easy_close:
+ * wirelog_easy_close:
  * @s: Session to free (NULL-safe).
  *
  * Release the session, plan, program, and intern table in the correct order.
  */
 void
-wl_easy_close(wl_easy_session_t *s);
+wirelog_easy_close(wirelog_easy_session_t *s);
 
 /**
- * wl_easy_intern:
+ * wirelog_easy_intern:
  * @s:   Open session (must not be NULL).
  * @sym: Symbol to intern (must not be NULL).
  *
@@ -174,11 +174,11 @@ wl_easy_close(wl_easy_session_t *s);
  * Returns: non-negative ID on success, -1 on NULL args or internal error.
  */
 int64_t
-wl_easy_intern(wl_easy_session_t *s, const char *sym);
+wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym);
 
 /**
  * wirelog_easy_make_compound:
- * @s:          Open wl_easy session.
+ * @s:          Open wirelog_easy session.
  * @functor:    Compound functor name, e.g. "metadata".
  * @arity:      Number of compound arguments.
  * @args:       Row values for arg0..arg{arity-1}.
@@ -188,7 +188,7 @@ wl_easy_intern(wl_easy_session_t *s, const char *sym);
  * arena and insert its side-relation row (`__compound_<functor>_<arity>`).
  * The returned handle is valid only for this session.  Callers that rotate
  * sessions must persist source-level argument values and rebuild handles in
- * the fresh session; do not persist handles across `wl_easy_open()` calls.
+ * the fresh session; do not persist handles across `wirelog_easy_open()` calls.
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_COMPOUND_SATURATED when the arena
  * refuses allocation after epoch saturation, WIRELOG_ERR_COMPOUND_BUSY when it
@@ -197,11 +197,11 @@ wl_easy_intern(wl_easy_session_t *s, const char *sym);
  * side-relation registration failure, or insertion failure.
  */
 wirelog_error_t
-wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
+wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
 
 /**
- * wl_easy_insert:
+ * wirelog_easy_insert:
  * @s:        Open session.
  * @relation: Relation name (must not be NULL).
  * @row:      Row of @ncols int64_t values.
@@ -213,11 +213,11 @@ wirelog_easy_make_compound(wl_easy_session_t *s, const char *functor,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_insert(wl_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
     uint32_t ncols);
 
 /**
- * wl_easy_remove:
+ * wirelog_easy_remove:
  * @s:        Open session.
  * @relation: Relation name (must not be NULL).
  * @row:      Row of @ncols int64_t values.
@@ -228,11 +228,11 @@ wl_easy_insert(wl_easy_session_t *s, const char *relation, const int64_t *row,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_remove(wl_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
     uint32_t ncols);
 
 /**
- * wl_easy_insert_sym:
+ * wirelog_easy_insert_sym:
  * @s:        Open session.
  * @relation: Relation name.
  * @...:      NULL-terminated list of (const char *) symbols, max 16.
@@ -242,20 +242,20 @@ wl_easy_remove(wl_easy_session_t *s, const char *relation, const int64_t *row,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_insert_sym(wl_easy_session_t *s, const char *relation, ...);
+wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
- * wl_easy_remove_sym:
+ * wirelog_easy_remove_sym:
  *
- * Variadic counterpart of wl_easy_insert_sym for retraction.
+ * Variadic counterpart of wirelog_easy_insert_sym for retraction.
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_remove_sym(wl_easy_session_t *s, const char *relation, ...);
+wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
- * wl_easy_step:
+ * wirelog_easy_step:
  * @s: Open session.
  *
  * Advance the session by one step, lazily building the plan if needed.
@@ -263,33 +263,33 @@ wl_easy_remove_sym(wl_easy_session_t *s, const char *relation, ...);
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_step(wl_easy_session_t *s);
+wirelog_easy_step(wirelog_easy_session_t *s);
 
 /**
- * wl_easy_set_delta_cb:
+ * wirelog_easy_set_delta_cb:
  * @s:         Open session.
  * @cb:        Delta callback (may be NULL to clear).
  * @user_data: Opaque user data passed back to @cb.
  *
  * Register a delta callback.  This eagerly builds the plan and underlying
  * session (lazy-init path), which may fail; the return value propagates
- * that error to the caller.  Symbol interning via wl_easy_intern() may
+ * that error to the caller.  Symbol interning via wirelog_easy_intern() may
  * happen before OR after this call.
  *
  * Returns: WIRELOG_OK on success, or a wirelog_error_t describing the
  * plan/session build failure.  A NULL @s returns WIRELOG_ERR_EXEC.
  */
 wirelog_error_t
-wl_easy_set_delta_cb(wl_easy_session_t *s, wirelog_on_delta_fn cb,
+wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
     void *user_data);
 
 /**
- * wl_easy_print_delta:
+ * wirelog_easy_print_delta:
  * @relation:  Relation name from a delta event.
  * @row:       Row of @ncols int64_t values.
  * @ncols:     Number of columns.
  * @diff:      +1 (insertion) or -1 (removal).
- * @user_data: MUST be a wl_easy_session_t* (not the program intern).
+ * @user_data: MUST be a wirelog_easy_session_t* (not the program intern).
  *
  * Convenience delta callback that prints "+" / "-" followed by the relation
  * and the columns formatted according to the parsed schema.  STRING columns
@@ -298,20 +298,20 @@ wl_easy_set_delta_cb(wl_easy_session_t *s, wirelog_on_delta_fn cb,
  * prevent silent corruption (NDEBUG-safe — assert() would compile out).
  */
 void
-wl_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
+wirelog_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
     int32_t diff, void *user_data);
 
 /**
- * wl_easy_banner:
+ * wirelog_easy_banner:
  * @label: Section label.
  *
  * Print a small "=== @label ===" banner used by examples.
  */
 void
-wl_easy_banner(const char *label);
+wirelog_easy_banner(const char *label);
 
 /**
- * wl_easy_snapshot:
+ * wirelog_easy_snapshot:
  * @s:         Open session.
  * @relation:  Relation to filter on (must not be NULL).
  * @cb:        Callback invoked once per matching tuple.
@@ -320,19 +320,19 @@ wl_easy_banner(const char *label);
  * Take a snapshot of the current state and forward only tuples whose
  * relation name matches @relation to @cb.
  *
- * IMPORTANT: wl_easy_snapshot() is an *evaluating* call — the underlying
+ * IMPORTANT: wirelog_easy_snapshot() is an *evaluating* call — the underlying
  * columnar backend re-evaluates every stratum and emits the resulting IDB
- * rows.  Do NOT call wl_easy_step() followed by wl_easy_snapshot() on the
+ * rows.  Do NOT call wirelog_easy_step() followed by wirelog_easy_snapshot() on the
  * same insert batch: step() already derives and appends the IDB rows, and
  * a subsequent snapshot() will re-derive and append again, producing
  * duplicated tuples.  Choose one mode per batch:
- *   - Incremental / delta mode: wl_easy_set_delta_cb() + wl_easy_step()
- *   - Query mode:               wl_easy_snapshot() (no prior step)
+ *   - Incremental / delta mode: wirelog_easy_set_delta_cb() + wirelog_easy_step()
+ *   - Query mode:               wirelog_easy_snapshot() (no prior step)
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
 wirelog_error_t
-wl_easy_snapshot(wl_easy_session_t *s, const char *relation,
+wirelog_easy_snapshot(wirelog_easy_session_t *s, const char *relation,
     wirelog_on_tuple_fn cb,
     void *user_data);
 

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -31,7 +31,7 @@
  *     #include <wirelog/wirelog.h>
  *
  * Individual sub-headers (wirelog-types.h, wirelog-parser.h,
- * wirelog-ir.h, wirelog-optimizer.h, wirelog-export.h, wl_easy.h,
+ * wirelog-ir.h, wirelog-optimizer.h, wirelog-export.h, wirelog-easy.h,
  * wirelog-advanced.h, io/io_adapter.h) are still installed for
  * backwards compatibility but should not be included directly in
  * new code.
@@ -79,7 +79,7 @@ typedef struct wirelog_result wirelog_result_t;
  * collect IDB results in one shot via wirelog_evaluate().  For
  * incremental sessions with delta callbacks and z-set semantics, use
  * wirelog_session_t (in wirelog/wirelog-advanced.h) or
- * wl_easy_session_t (in wirelog/wl_easy.h) instead.  These three
+ * wirelog_easy_session_t (in wirelog/wirelog-easy.h) instead.  These three
  * facades are independent surfaces; do not mix handles across them.
  */
 typedef struct wirelog_executor wirelog_executor_t;
@@ -302,7 +302,7 @@ wirelog_config_threads(void);
 #include "wirelog/wirelog-parser.h"
 #include "wirelog/wirelog-ir.h"
 #include "wirelog/wirelog-optimizer.h"
-#include "wirelog/wl_easy.h"
+#include "wirelog/wirelog-easy.h"
 #include "wirelog/wirelog-advanced.h"
 #include "wirelog/io/io_adapter.h"
 


### PR DESCRIPTION
## Summary

Renames the entire `wl_easy` convenience facade from `wl_easy_*` /
`WL_EASY_*` to `wirelog_easy_*` / `WIRELOG_EASY_*` per
`AGENTS.md:17-20`, and moves the header / source / test files to
the `wirelog-` filename convention.

## Files moved

- `wirelog/wl_easy.{h,c}` -> `wirelog/wirelog-easy.{h,c}`
- `tests/test_wl_easy.c` -> `tests/test_wirelog_easy.c`
- `tests/test_wl_easy_inline_facts.c` -> `tests/test_wirelog_easy_inline_facts.c`

## Test plan

- [x] `grep -rE '\bwl_easy|\bWL_EASY_'` returns zero matches
      across the entire repo
- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] `examples/12-snapshot-vs-delta/expected.txt` golden updated
- [x] `AGENTS.md:23` public-headers list updates path
- [x] `meson.build` install_headers SSoT updates
- [x] CHANGELOG `[Unreleased]` records the rename
- [x] `docs/MIGRATION.md` 0.30 -> 1.0 section gains the entry
- [ ] CI: full default + abi + sanitizer matrix

Closes #756.  Part of public-API prefix audit epic #755.