### PR TITLE
rename: I/O adapter framework wl_io_* -> wirelog_io_*, ABI 1u -> 2u (#762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **I/O adapter framework renamed and ABI bumped to 2u for v1.0
+  prefix conformance** (#762): the entire `wirelog/io/io_adapter.h`
+  surface (20 identifiers including `wl_io_*` symbols, `WL_IO_*`
+  macros, the `"wl_io_plugin_entry"` dlsym key, and the
+  `WL_IO_ABI_VERSION` macro) is renamed to `wirelog_io_*` /
+  `WIRELOG_IO_*`, and `WIRELOG_IO_ABI_VERSION` is bumped from
+  `1u` to `2u`.  The registration-time
+  `adapter->abi_version != WIRELOG_IO_ABI_VERSION` check rejects
+  v0.30.0 plugins loud (abi_version == 1u) with a clear
+  `wirelog_io_last_error()` diagnostic.  Path-B plugins must
+  rebuild and rename the exported entry symbol from
+  `wl_io_plugin_entry` to `wirelog_io_plugin_entry`; otherwise
+  the loader's `dlsym` lookup returns NULL.  Source- and binary-
+  incompatible across the entire I/O adapter surface; pre-1.0
+  ABI break per the v0.40 API audit decision.  Part of public-
+  API prefix audit epic #755.
 - **wl_easy facade renamed and moved for v1.0 prefix conformance**
   (#756): the `wl_easy` convenience facade is renamed across its
   entire surface from `wl_easy_*` / `WL_EASY_*` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
-- **I/O Adapter Framework** (#446): User-defined I/O adapters via runtime registry (`wl_io_register_adapter`). Public header `wirelog/io/io_adapter.h` with opaque context, ABI versioning (`WL_IO_ABI_VERSION=1`), and thread-safe registration API
+- **I/O Adapter Framework** (#446): User-defined I/O adapters via runtime registry (`wirelog_io_register_adapter`). Public header `wirelog/io/io_adapter.h` with opaque context, ABI versioning (`WIRELOG_IO_ABI_VERSION=1`), and thread-safe registration API
 - **Built-in CSV Adapter** (#455): CSV loading refactored into the adapter framework; backward-compatible `.input(filename=...)` dispatch
 - **wirelog_easy Facade** (#445): Simplified high-level API (`wirelog-easy.h`) for common session workflows
 - **String Operations** (#444): String-typed column functions (`strlen`, `cat`, `substr`, `contains`, `to_upper`, `to_lower`, `trim`, `str_replace`, `to_string`, `to_number`)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,58 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### I/O adapter framework rename + ABI v2 bump (#762)
+
+The `wirelog/io/io_adapter.h` public-installed header carried
+internal-style `wl_io_*` / `WL_IO_*` prefixes across its entire
+20-symbol surface, contradicting `AGENTS.md:17-20`.  All
+identifiers are renamed and the I/O-adapter ABI version is
+bumped from `1u` to `2u` so plugins compiled against v0.30.0
+fail loud at registration time.
+
+Symbol renames (full surface):
+
+| Old | New |
+|---|---|
+| `wl_io_ctx_t` | `wirelog_io_ctx_t` |
+| `wl_io_adapter_t` | `wirelog_io_adapter_t` |
+| `wl_io_register_adapter` | `wirelog_io_register_adapter` |
+| `wl_io_unregister_adapter` | `wirelog_io_unregister_adapter` |
+| `wl_io_find_adapter` | `wirelog_io_find_adapter` |
+| `wl_io_last_error` | `wirelog_io_last_error` |
+| `wl_io_ctx_relation_name` | `wirelog_io_ctx_relation_name` |
+| `wl_io_ctx_num_cols` | `wirelog_io_ctx_num_cols` |
+| `wl_io_ctx_col_type` | `wirelog_io_ctx_col_type` |
+| `wl_io_ctx_param` | `wirelog_io_ctx_param` |
+| `wl_io_ctx_intern_string` | `wirelog_io_ctx_intern_string` |
+| `wl_io_ctx_platform` | `wirelog_io_ctx_platform` |
+| `wl_io_ctx_set_platform` | `wirelog_io_ctx_set_platform` |
+| `wl_io_plugin_entry_fn` | `wirelog_io_plugin_entry_fn` |
+| `wl_io_plugin_entry` (dlsym key) | `wirelog_io_plugin_entry` |
+| `WL_IO_ABI_VERSION` (1u) | `WIRELOG_IO_ABI_VERSION` (2u) |
+| `WL_IO_MAX_ADAPTERS` | `WIRELOG_IO_MAX_ADAPTERS` |
+| `WL_IO_PLUGIN_ENTRY_SYMBOL` | `WIRELOG_IO_PLUGIN_ENTRY_SYMBOL` |
+| `WL_IO_PLUGIN_EXPORT` | `WIRELOG_IO_PLUGIN_EXPORT` |
+| `WL_IO_USED` | `WIRELOG_IO_USED` |
+
+ABI bump 1u -> 2u: the registration-time check
+(`adapter->abi_version != WIRELOG_IO_ABI_VERSION`) rejects
+v0.30.0 plugins (abi_version == 1u) with a clear diagnostic
+retrievable via `wirelog_io_last_error()`.  Combined with the
+dlsym-symbol rename, v0.30.0 Path-B plugins fail loudly on
+load: `dlsym(handle, "wirelog_io_plugin_entry")` returns NULL
+because the plugin still exports `wl_io_plugin_entry`.
+
+Migration for downstream consumers:
+
+1. Rebuild Path-A consumers (link-time adapter registration)
+   against `WIRELOG_IO_ABI_VERSION = 2u` headers.
+2. Rebuild Path-B plugins (dynamic `dlopen` load) and rename
+   the exported entry symbol from `wl_io_plugin_entry` to
+   `wirelog_io_plugin_entry`.
+3. Textual-rename all source-level `wl_io_*` / `WL_IO_*`
+   references to `wirelog_io_*` / `WIRELOG_IO_*`.
+
 ### wl_easy facade rename + file move (#756)
 
 The `wl_easy` convenience facade carried internal `wl_*`

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -28,7 +28,7 @@ host, with the host owning the I/O boundary. Specifically:
 - **Trusted**: the program text fed to `wirelog_parse` /
   `wirelog_parse_string`, the row data passed to
   `wirelog_session_insert` and `wirelog_easy_insert`, the I/O adapter
-  callbacks the host registers via `wl_io_register_adapter`.
+  callbacks the host registers via `wirelog_io_register_adapter`.
 - **Untrusted**: nothing in the default surface. wirelog does not
   open sockets, accept network connections, or fork helper processes.
 - **Optional crypto**: when built with `-DmbedTLS=enabled` (default

--- a/docs/io-adapters.md
+++ b/docs/io-adapters.md
@@ -21,28 +21,28 @@ Both paths use the same adapter interface defined in
 ```c
 #include <wirelog/io/io_adapter.h>
 
-typedef struct wl_io_adapter {
-    uint32_t    abi_version;   /* must equal WL_IO_ABI_VERSION (currently 1) */
+typedef struct wirelog_io_adapter {
+    uint32_t    abi_version;   /* must equal WIRELOG_IO_ABI_VERSION (currently 1) */
     const char *scheme;        /* e.g. "csv", "pcap"                        */
     const char *description;   /* human-readable, for diagnostics           */
 
-    int (*read)(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
+    int (*read)(wirelog_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
                 void *user_data);
 
-    int (*validate)(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
+    int (*validate)(wirelog_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
                     void *user_data);       /* optional, may be NULL */
 
     void *user_data;           /* passed verbatim to read()/validate()      */
-} wl_io_adapter_t;
+} wirelog_io_adapter_t;
 ```
 
 ### Key fields
 
-- **`abi_version`** -- must equal `WL_IO_ABI_VERSION`. The registry rejects
+- **`abi_version`** -- must equal `WIRELOG_IO_ABI_VERSION`. The registry rejects
   mismatches at registration time, giving a clean error instead of a silent
   ABI break.
 - **`read`** (required) -- produces a `malloc`-allocated, row-major `int64_t`
-  buffer of size `*out_nrows * wl_io_ctx_num_cols(ctx)`. Ownership transfers
+  buffer of size `*out_nrows * wirelog_io_ctx_num_cols(ctx)`. Ownership transfers
   to the caller; wirelog will `free()` it with the same libc `free()`.
 - **`validate`** (optional) -- pre-flight parameter validation. Called before
   `read`. Writes at most `errbuf_len - 1` bytes into `errbuf` on error.
@@ -53,18 +53,18 @@ typedef struct wl_io_adapter {
 
 ### Context accessors
 
-The opaque `wl_io_ctx_t` provides safe, ABI-stable access to session
+The opaque `wirelog_io_ctx_t` provides safe, ABI-stable access to session
 internals:
 
 | Accessor | Description |
 |----------|-------------|
-| `wl_io_ctx_relation_name(ctx)` | Name of the target relation |
-| `wl_io_ctx_num_cols(ctx)` | Column count |
-| `wl_io_ctx_col_type(ctx, i)` | Column type (`WIRELOG_TYPE_INT64`, `WIRELOG_TYPE_STRING`, ...) |
-| `wl_io_ctx_param(ctx, key)` | `.input` parameter lookup (e.g. `"filename"`, `"delimiter"`) |
-| `wl_io_ctx_intern_string(ctx, utf8)` | Intern a string, returns `int64_t` id for `WIRELOG_TYPE_STRING` columns |
-| `wl_io_ctx_platform(ctx)` | Platform context pointer (e.g. `JavaVM *` on Android) |
-| `wl_io_ctx_set_platform(ctx, ptr)` | Set platform context pointer; returns 0 on success |
+| `wirelog_io_ctx_relation_name(ctx)` | Name of the target relation |
+| `wirelog_io_ctx_num_cols(ctx)` | Column count |
+| `wirelog_io_ctx_col_type(ctx, i)` | Column type (`WIRELOG_TYPE_INT64`, `WIRELOG_TYPE_STRING`, ...) |
+| `wirelog_io_ctx_param(ctx, key)` | `.input` parameter lookup (e.g. `"filename"`, `"delimiter"`) |
+| `wirelog_io_ctx_intern_string(ctx, utf8)` | Intern a string, returns `int64_t` id for `WIRELOG_TYPE_STRING` columns |
+| `wirelog_io_ctx_platform(ctx)` | Platform context pointer (e.g. `JavaVM *` on Android) |
+| `wirelog_io_ctx_set_platform(ctx, ptr)` | Set platform context pointer; returns 0 on success |
 
 Adapters never see `wl_intern_t`, `wl_ir_relation_info_t`, or any other
 internal type. This is the ABI firewall -- the context struct is opaque and
@@ -75,20 +75,20 @@ its layout is private.
 ## 2. Registration API
 
 ```c
-int  wl_io_register_adapter(const wl_io_adapter_t *adapter);
-int  wl_io_unregister_adapter(const char *scheme);
-const wl_io_adapter_t *wl_io_find_adapter(const char *scheme);
-const char *wl_io_last_error(void);
+int  wirelog_io_register_adapter(const wirelog_io_adapter_t *adapter);
+int  wirelog_io_unregister_adapter(const char *scheme);
+const wirelog_io_adapter_t *wirelog_io_find_adapter(const char *scheme);
+const char *wirelog_io_last_error(void);
 ```
 
 - All three mutation/query functions are **thread-safe** (process-global mutex).
-- The adapter pointer must remain valid until `wl_io_unregister_adapter()` or
+- The adapter pointer must remain valid until `wirelog_io_unregister_adapter()` or
   process exit. Typical usage: pass `&static_const_struct`.
 - The `scheme` string is copied into a fixed-size internal buffer at
   registration time; the caller's pointer may be freed afterwards.
 - On failure, functions return `-1` and record a human-readable reason
-  retrievable via `wl_io_last_error()` (thread-local).
-- The registry holds up to `WL_IO_MAX_ADAPTERS` (32) entries.
+  retrievable via `wirelog_io_last_error()` (thread-local).
+- The registry holds up to `WIRELOG_IO_MAX_ADAPTERS` (32) entries.
 
 ---
 
@@ -133,12 +133,12 @@ The following is the Path A pcap skeleton from
 /* ---------- adapter callbacks ---------- */
 
 static int
-pcap_validate(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
+pcap_validate(wirelog_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
     void *user_data)
 {
     (void)user_data;
 
-    const char *filename = wl_io_ctx_param(ctx, "filename");
+    const char *filename = wirelog_io_ctx_param(ctx, "filename");
     if (!filename) {
         snprintf(errbuf, errbuf_len, "missing required param 'filename'");
         return -1;
@@ -147,7 +147,7 @@ pcap_validate(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
 }
 
 static int
-pcap_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
+pcap_read(wirelog_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
     void *user_data)
 {
     (void)ctx;
@@ -165,8 +165,8 @@ pcap_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
 
 /* ---------- adapter definition ---------- */
 
-static const wl_io_adapter_t pcap_adapter = {
-    .abi_version = WL_IO_ABI_VERSION,
+static const wirelog_io_adapter_t pcap_adapter = {
+    .abi_version = WIRELOG_IO_ABI_VERSION,
     .scheme = "pcap",
     .description = "libpcap file reader (skeleton)",
     .read = pcap_read,
@@ -179,12 +179,12 @@ static const wl_io_adapter_t pcap_adapter = {
 int
 main(void)
 {
-    if (wl_io_register_adapter(&pcap_adapter) != 0) {
-        fprintf(stderr, "register failed: %s\n", wl_io_last_error());
+    if (wirelog_io_register_adapter(&pcap_adapter) != 0) {
+        fprintf(stderr, "register failed: %s\n", wirelog_io_last_error());
         return 1;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("pcap");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("pcap");
     if (!found) {
         fprintf(stderr, "adapter lookup failed\n");
         return 1;
@@ -193,7 +193,7 @@ main(void)
     printf("registered adapter: scheme=%s desc=\"%s\"\n",
         found->scheme, found->description);
 
-    wl_io_unregister_adapter("pcap");
+    wirelog_io_unregister_adapter("pcap");
     return 0;
 }
 ```
@@ -239,19 +239,19 @@ iOS builds.
 A user shared library must export exactly one symbol:
 
 ```c
-WL_IO_PLUGIN_EXPORT
-const wl_io_adapter_t *const *wl_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver);
+WIRELOG_IO_PLUGIN_EXPORT
+const wirelog_io_adapter_t *const *wirelog_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver);
 ```
 
-- `abi_ver` is the host's `WL_IO_ABI_VERSION`. The plugin should check it
+- `abi_ver` is the host's `WIRELOG_IO_ABI_VERSION`. The plugin should check it
   against its own compiled version and return `NULL` on mismatch.
 - `*n_out` receives the number of adapters returned.
 - The returned array of pointers must remain valid for the process lifetime.
 
-The CLI calls `dlopen` + `dlsym("wl_io_plugin_entry")`, validates the ABI
+The CLI calls `dlopen` + `dlsym("wirelog_io_plugin_entry")`, validates the ABI
 version, and bulk-registers all returned adapters.
 
-> **Note**: The symbols above (`WL_IO_PLUGIN_EXPORT`, `wl_io_plugin_entry`)
+> **Note**: The symbols above (`WIRELOG_IO_PLUGIN_EXPORT`, `wirelog_io_plugin_entry`)
 > are the proposed contract and are not yet defined in the header. They will
 > be introduced in #461.
 
@@ -263,25 +263,25 @@ The ownership contract is simple:
 
 | Resource | Owner | Rule |
 |----------|-------|------|
-| `wl_io_adapter_t` struct | User | Must outlive registration (use `static const`) |
-| `scheme` string | Copied | Caller may free after `wl_io_register_adapter()` returns |
+| `wirelog_io_adapter_t` struct | User | Must outlive registration (use `static const`) |
+| `scheme` string | Copied | Caller may free after `wirelog_io_register_adapter()` returns |
 | `int64_t *out_data` buffer | Transfers | Adapter `malloc`s, wirelog `free`s (same libc) |
-| `wl_io_ctx_t` | wirelog | Valid only during `read()`/`validate()` call |
+| `wirelog_io_ctx_t` | wirelog | Valid only during `read()`/`validate()` call |
 | Borrowed pointers from accessors | wirelog | Valid only during the enclosing callback |
 
 ---
 
 ## 6. ABI versioning policy
 
-- `WL_IO_ABI_VERSION` starts at `1`.
+- `WIRELOG_IO_ABI_VERSION` starts at `1`.
 - The registry rejects adapters with a mismatched version at registration time.
 - A version bump is required when:
-  - A field is added to or removed from `wl_io_adapter_t`.
+  - A field is added to or removed from `wirelog_io_adapter_t`.
   - The signature of `read()` or `validate()` changes.
   - The semantics of an accessor function change incompatibly.
 - A version bump is **not** required for:
-  - Adding new accessor functions to `wl_io_ctx_t`.
-  - Adding new fields to the *end* of `wl_io_ctx_t` internals (opaque).
+  - Adding new accessor functions to `wirelog_io_ctx_t`.
+  - Adding new fields to the *end* of `wirelog_io_ctx_t` internals (opaque).
 
 Since `libwirelog.so` is the only side that dereferences the adapter struct,
 a version bump provides a clean break point for migration.
@@ -290,16 +290,16 @@ a version bump provides a clean break point for migration.
 
 ## 7. Thread safety
 
-- **Registration**: `wl_io_register_adapter()`, `wl_io_unregister_adapter()`,
-  and `wl_io_find_adapter()` all acquire a process-global mutex.
+- **Registration**: `wirelog_io_register_adapter()`, `wirelog_io_unregister_adapter()`,
+  and `wirelog_io_find_adapter()` all acquire a process-global mutex.
 - **Built-in bootstrap**: The built-in `csv` adapter is auto-registered on the
-  first call to `wl_io_find_adapter()` via a one-shot flag (`pthread_once`
+  first call to `wirelog_io_find_adapter()` via a one-shot flag (`pthread_once`
   equivalent). User registration calls `ensure_builtins()` first, preventing
   races.
 - **Adapter callbacks**: `read()` and `validate()` are called from the
   evaluation thread. The adapter itself is responsible for any internal
   synchronization (e.g., if it accesses shared state).
-- **Error reporting**: `wl_io_last_error()` uses thread-local storage
+- **Error reporting**: `wirelog_io_last_error()` uses thread-local storage
   (`__thread` / `__declspec(thread)`), so error messages do not race across
   threads.
 

--- a/examples/path_a_pcap_skeleton/main.c
+++ b/examples/path_a_pcap_skeleton/main.c
@@ -22,12 +22,12 @@
 /* ---------- adapter callbacks ---------- */
 
 static int
-pcap_validate(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
+pcap_validate(wirelog_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
     void *user_data)
 {
     (void)user_data;
 
-    const char *filename = wl_io_ctx_param(ctx, "filename");
+    const char *filename = wirelog_io_ctx_param(ctx, "filename");
     if (!filename) {
         snprintf(errbuf, errbuf_len, "missing required param 'filename'");
         return -1;
@@ -36,7 +36,7 @@ pcap_validate(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
 }
 
 static int
-pcap_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
+pcap_read(wirelog_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
     void *user_data)
 {
     (void)ctx;
@@ -54,8 +54,8 @@ pcap_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
 
 /* ---------- adapter definition ---------- */
 
-static const wl_io_adapter_t pcap_adapter = {
-    .abi_version = WL_IO_ABI_VERSION,
+static const wirelog_io_adapter_t pcap_adapter = {
+    .abi_version = WIRELOG_IO_ABI_VERSION,
     .scheme = "pcap",
     .description = "libpcap file reader (skeleton)",
     .read = pcap_read,
@@ -68,12 +68,12 @@ static const wl_io_adapter_t pcap_adapter = {
 int
 main(void)
 {
-    if (wl_io_register_adapter(&pcap_adapter) != 0) {
-        fprintf(stderr, "register failed: %s\n", wl_io_last_error());
+    if (wirelog_io_register_adapter(&pcap_adapter) != 0) {
+        fprintf(stderr, "register failed: %s\n", wirelog_io_last_error());
         return 1;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("pcap");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("pcap");
     if (!found) {
         fprintf(stderr, "adapter lookup failed\n");
         return 1;
@@ -82,6 +82,6 @@ main(void)
     printf("registered adapter: scheme=%s desc=\"%s\"\n",
         found->scheme, found->description);
 
-    wl_io_unregister_adapter("pcap");
+    wirelog_io_unregister_adapter("pcap");
     return 0;
 }

--- a/tests/mock_plugin_adapter.c
+++ b/tests/mock_plugin_adapter.c
@@ -2,7 +2,7 @@
  * mock_plugin_adapter.c - Mock adapter plugin for test_plugin_loader
  *
  * Built as a shared library (libmock_plugin_adapter.so) that exports
- * the wl_io_plugin_entry symbol.  Used by test_plugin_loader.c to
+ * the wirelog_io_plugin_entry symbol.  Used by test_plugin_loader.c to
  * exercise the plugin load + register + dispatch path.
  */
 
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 
 static int
-mock_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
+mock_read(wirelog_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
     void *user_data)
 {
     (void)ctx;
@@ -22,8 +22,8 @@ mock_read(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
     return 0;
 }
 
-static const wl_io_adapter_t mock_adapter = {
-    .abi_version = WL_IO_ABI_VERSION,
+static const wirelog_io_adapter_t mock_adapter = {
+    .abi_version = WIRELOG_IO_ABI_VERSION,
     .scheme = "mock_plugin",
     .description = "mock plugin adapter for testing",
     .read = mock_read,
@@ -31,13 +31,13 @@ static const wl_io_adapter_t mock_adapter = {
     .user_data = NULL,
 };
 
-static const wl_io_adapter_t *const adapter_list[] = {&mock_adapter};
+static const wirelog_io_adapter_t *const adapter_list[] = {&mock_adapter};
 
-WL_IO_PLUGIN_EXPORT
-const wl_io_adapter_t *const *
-wl_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver)
+WIRELOG_IO_PLUGIN_EXPORT
+const wirelog_io_adapter_t *const *
+wirelog_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver)
 {
-    if (abi_ver != WL_IO_ABI_VERSION) {
+    if (abi_ver != WIRELOG_IO_ABI_VERSION) {
         *n_out = 0;
         return NULL;
     }

--- a/tests/mock_plugin_adapter_bad_abi.c
+++ b/tests/mock_plugin_adapter_bad_abi.c
@@ -8,9 +8,9 @@
 
 #include <stddef.h>
 
-WL_IO_PLUGIN_EXPORT
-const wl_io_adapter_t *const *
-wl_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver)
+WIRELOG_IO_PLUGIN_EXPORT
+const wirelog_io_adapter_t *const *
+wirelog_io_plugin_entry(uint32_t *n_out, uint32_t abi_ver)
 {
     (void)abi_ver;
     *n_out = 0;

--- a/tests/test_io_adapter.c
+++ b/tests/test_io_adapter.c
@@ -42,17 +42,17 @@ test_register_and_find(void)
 {
     TEST("register_and_find");
 #ifdef TEST_REGISTRY_PRESENT
-    wl_io_adapter_t adapter;
+    wirelog_io_adapter_t adapter;
     memset(&adapter, 0, sizeof(adapter));
     adapter.scheme = "mock";
-    adapter.abi_version = WL_IO_ABI_VERSION;
+    adapter.abi_version = WIRELOG_IO_ABI_VERSION;
 
-    int rc = wl_io_register_adapter(&adapter);
+    int rc = wirelog_io_register_adapter(&adapter);
     if (rc != 0) {
         FAIL("register returned non-zero"); return;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("mock");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("mock");
     if (found == &adapter) PASS();
     else FAIL("found pointer does not match registered adapter");
 #else
@@ -65,7 +65,7 @@ test_find_unknown_scheme(void)
 {
     TEST("find_unknown_scheme");
 #ifdef TEST_REGISTRY_PRESENT
-    const wl_io_adapter_t *found = wl_io_find_adapter("nonexistent");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("nonexistent");
     if (found == NULL) PASS();
     else FAIL("expected NULL for unknown scheme");
 #else
@@ -78,17 +78,17 @@ test_duplicate_register_error(void)
 {
     TEST("duplicate_register_error");
 #ifdef TEST_REGISTRY_PRESENT
-    wl_io_adapter_t adapter;
+    wirelog_io_adapter_t adapter;
     memset(&adapter, 0, sizeof(adapter));
     adapter.scheme = "mock_dup";
-    adapter.abi_version = WL_IO_ABI_VERSION;
+    adapter.abi_version = WIRELOG_IO_ABI_VERSION;
 
-    int rc1 = wl_io_register_adapter(&adapter);
+    int rc1 = wirelog_io_register_adapter(&adapter);
     if (rc1 != 0) {
         FAIL("first register failed"); return;
     }
 
-    int rc2 = wl_io_register_adapter(&adapter);
+    int rc2 = wirelog_io_register_adapter(&adapter);
     if (rc2 == -1) PASS();
     else FAIL("expected -1 for duplicate registration");
 #else
@@ -101,7 +101,7 @@ test_builtin_csv_autoload(void)
 {
     TEST("builtin_csv_autoload");
 #ifdef TEST_REGISTRY_PRESENT
-    const wl_io_adapter_t *found = wl_io_find_adapter("csv");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("csv");
     if (found != NULL) PASS();
     else FAIL("expected non-NULL for built-in csv adapter");
 #else
@@ -114,27 +114,27 @@ test_unregister_then_find(void)
 {
     TEST("unregister_then_find");
 #ifdef TEST_REGISTRY_PRESENT
-    wl_io_adapter_t adapter;
+    wirelog_io_adapter_t adapter;
     memset(&adapter, 0, sizeof(adapter));
     adapter.scheme = "mock_unreg";
-    adapter.abi_version = WL_IO_ABI_VERSION;
+    adapter.abi_version = WIRELOG_IO_ABI_VERSION;
 
-    int rc = wl_io_register_adapter(&adapter);
+    int rc = wirelog_io_register_adapter(&adapter);
     if (rc != 0) {
         FAIL("register failed"); return;
     }
 
-    rc = wl_io_unregister_adapter("mock_unreg");
+    rc = wirelog_io_unregister_adapter("mock_unreg");
     if (rc != 0) {
         FAIL("unregister failed"); return;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("mock_unreg");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("mock_unreg");
     if (found != NULL) {
         FAIL("expected NULL after unregister"); return;
     }
 
-    rc = wl_io_register_adapter(&adapter);
+    rc = wirelog_io_register_adapter(&adapter);
     if (rc == 0) PASS();
     else FAIL("re-register after unregister failed");
 #else
@@ -147,12 +147,12 @@ test_abi_version_mismatch(void)
 {
     TEST("abi_version_mismatch");
 #ifdef TEST_REGISTRY_PRESENT
-    wl_io_adapter_t adapter;
+    wirelog_io_adapter_t adapter;
     memset(&adapter, 0, sizeof(adapter));
     adapter.scheme = "mock_bad_abi";
     adapter.abi_version = 999;
 
-    int rc = wl_io_register_adapter(&adapter);
+    int rc = wirelog_io_register_adapter(&adapter);
     if (rc == -1) PASS();
     else FAIL("expected -1 for ABI version mismatch");
 #else

--- a/tests/test_io_adapter_asan.c
+++ b/tests/test_io_adapter_asan.c
@@ -10,7 +10,7 @@
  *   - Scheme at SCHEME_MAX_LEN-1 boundary (max safe length)
  *   - Scheme one byte over SCHEME_MAX_LEN (must be truncated safely)
  *   - Fill registry to capacity then verify "registry full" error
- *   - wl_io_last_error() valid after each error path
+ *   - wirelog_io_last_error() valid after each error path
  *
  * Part of #459 (ASan + TSan CI gates).
  */
@@ -60,11 +60,11 @@ static void
 test_null_adapter(void)
 {
     TEST("register NULL adapter returns -1");
-    int rc = wl_io_register_adapter(NULL);
+    int rc = wirelog_io_register_adapter(NULL);
     if (rc != -1) {
         FAIL("expected -1"); return;
     }
-    const char *err = wl_io_last_error();
+    const char *err = wirelog_io_last_error();
     if (err && err[0] != '\0') PASS();
     else FAIL("expected non-empty error string after NULL adapter");
 }
@@ -73,15 +73,15 @@ static void
 test_null_scheme_register(void)
 {
     TEST("register adapter with NULL scheme returns -1");
-    wl_io_adapter_t a;
+    wirelog_io_adapter_t a;
     memset(&a, 0, sizeof(a));
     a.scheme = NULL;
-    a.abi_version = WL_IO_ABI_VERSION;
-    int rc = wl_io_register_adapter(&a);
+    a.abi_version = WIRELOG_IO_ABI_VERSION;
+    int rc = wirelog_io_register_adapter(&a);
     if (rc != -1) {
         FAIL("expected -1"); return;
     }
-    const char *err = wl_io_last_error();
+    const char *err = wirelog_io_last_error();
     if (err && err[0] != '\0') PASS();
     else FAIL("expected non-empty error string");
 }
@@ -90,7 +90,7 @@ static void
 test_null_find(void)
 {
     TEST("find NULL scheme returns NULL");
-    const wl_io_adapter_t *found = wl_io_find_adapter(NULL);
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter(NULL);
     if (found == NULL) PASS();
     else FAIL("expected NULL for NULL scheme");
 }
@@ -99,11 +99,11 @@ static void
 test_null_unregister(void)
 {
     TEST("unregister NULL scheme returns -1");
-    int rc = wl_io_unregister_adapter(NULL);
+    int rc = wirelog_io_unregister_adapter(NULL);
     if (rc != -1) {
         FAIL("expected -1"); return;
     }
-    const char *err = wl_io_last_error();
+    const char *err = wirelog_io_last_error();
     if (err && err[0] != '\0') PASS();
     else FAIL("expected non-empty error string");
 }
@@ -112,11 +112,11 @@ static void
 test_abi_mismatch(void)
 {
     TEST("register adapter with wrong ABI version returns -1");
-    wl_io_adapter_t a;
+    wirelog_io_adapter_t a;
     memset(&a, 0, sizeof(a));
     a.scheme = "mock_bad_abi2";
-    a.abi_version = WL_IO_ABI_VERSION + 99u;
-    int rc = wl_io_register_adapter(&a);
+    a.abi_version = WIRELOG_IO_ABI_VERSION + 99u;
+    int rc = wirelog_io_register_adapter(&a);
     if (rc == -1) PASS();
     else FAIL("expected -1 for ABI mismatch");
 }
@@ -125,22 +125,22 @@ static void
 test_boundary_scheme_length(void)
 {
     TEST("register/find/unregister scheme at max length boundary");
-    wl_io_adapter_t a;
+    wirelog_io_adapter_t a;
     memset(&a, 0, sizeof(a));
     a.scheme = s_long_scheme;        /* 63 chars */
-    a.abi_version = WL_IO_ABI_VERSION;
+    a.abi_version = WIRELOG_IO_ABI_VERSION;
 
-    int rc = wl_io_register_adapter(&a);
+    int rc = wirelog_io_register_adapter(&a);
     if (rc != 0) {
         FAIL("register failed for max-length scheme"); return;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter(s_long_scheme);
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter(s_long_scheme);
     if (found == NULL) {
         FAIL("find failed for max-length scheme"); return;
     }
 
-    rc = wl_io_unregister_adapter(s_long_scheme);
+    rc = wirelog_io_unregister_adapter(s_long_scheme);
     if (rc == 0) PASS();
     else FAIL("unregister failed for max-length scheme");
 }
@@ -153,20 +153,20 @@ test_overlong_scheme_safe(void)
      * strncpy(dst, src, SCHEME_MAX_LEN-1) so it will be truncated to 63 'b'
      * chars.  We just verify the call does not crash (ASan would detect any
      * out-of-bounds write). */
-    wl_io_adapter_t a;
+    wirelog_io_adapter_t a;
     memset(&a, 0, sizeof(a));
     a.scheme = s_overlong_scheme;
-    a.abi_version = WL_IO_ABI_VERSION;
+    a.abi_version = WIRELOG_IO_ABI_VERSION;
 
     /* May succeed or fail (truncated scheme might collide or not), but must
      * not crash or write out of bounds. */
-    int rc = wl_io_register_adapter(&a);
+    int rc = wirelog_io_register_adapter(&a);
     if (rc == 0) {
         /* Clean up: look up by first SCHEME_MAX_LEN-1 chars */
         char truncated[SCHEME_MAX_LEN];
         memset(truncated, 'b', SCHEME_MAX_LEN - 1);
         truncated[SCHEME_MAX_LEN - 1] = '\0';
-        wl_io_unregister_adapter(truncated);
+        wirelog_io_unregister_adapter(truncated);
     }
     /* If rc == -1, that's also fine (duplicate or other error). */
     PASS();
@@ -175,37 +175,37 @@ test_overlong_scheme_safe(void)
 static void
 test_registry_full(void)
 {
-    TEST("register past WL_IO_MAX_ADAPTERS returns -1 with error");
+    TEST("register past WIRELOG_IO_MAX_ADAPTERS returns -1 with error");
 
     /* csv is already registered (slot 0).  Register adapters to fill the
      * remaining 31 slots, then attempt one more. */
-    wl_io_adapter_t adapters[WL_IO_MAX_ADAPTERS];
-    char schemes[WL_IO_MAX_ADAPTERS][16];
+    wirelog_io_adapter_t adapters[WIRELOG_IO_MAX_ADAPTERS];
+    char schemes[WIRELOG_IO_MAX_ADAPTERS][16];
     int registered = 0;
 
-    for (int i = 0; i < WL_IO_MAX_ADAPTERS - 1; i++) {
+    for (int i = 0; i < WIRELOG_IO_MAX_ADAPTERS - 1; i++) {
         snprintf(schemes[i], sizeof(schemes[i]), "fill_%d", i);
         memset(&adapters[i], 0, sizeof(adapters[i]));
         adapters[i].scheme = schemes[i];
-        adapters[i].abi_version = WL_IO_ABI_VERSION;
-        if (wl_io_register_adapter(&adapters[i]) == 0)
+        adapters[i].abi_version = WIRELOG_IO_ABI_VERSION;
+        if (wirelog_io_register_adapter(&adapters[i]) == 0)
             registered++;
     }
 
     /* Try to register one more beyond capacity */
-    wl_io_adapter_t overflow;
+    wirelog_io_adapter_t overflow;
     memset(&overflow, 0, sizeof(overflow));
     overflow.scheme = "overflow_scheme";
-    overflow.abi_version = WL_IO_ABI_VERSION;
-    int rc = wl_io_register_adapter(&overflow);
+    overflow.abi_version = WIRELOG_IO_ABI_VERSION;
+    int rc = wirelog_io_register_adapter(&overflow);
 
     /* Cleanup: unregister all fill_ adapters we registered */
-    for (int i = 0; i < WL_IO_MAX_ADAPTERS - 1; i++) {
+    for (int i = 0; i < WIRELOG_IO_MAX_ADAPTERS - 1; i++) {
         if (adapters[i].scheme)
-            wl_io_unregister_adapter(schemes[i]);
+            wirelog_io_unregister_adapter(schemes[i]);
     }
 
-    if (rc == -1 && registered == WL_IO_MAX_ADAPTERS - 1) PASS();
+    if (rc == -1 && registered == WIRELOG_IO_MAX_ADAPTERS - 1) PASS();
     else if (rc == -1) {
         /* Registry may have been partially filled by prior test state */
         PASS();
@@ -218,7 +218,7 @@ static void
 test_unregister_nonexistent(void)
 {
     TEST("unregister non-existent scheme returns -1");
-    int rc = wl_io_unregister_adapter("scheme_that_was_never_registered");
+    int rc = wirelog_io_unregister_adapter("scheme_that_was_never_registered");
     if (rc == -1) PASS();
     else FAIL("expected -1 for unknown scheme");
 }
@@ -226,21 +226,21 @@ test_unregister_nonexistent(void)
 static void
 test_error_string_after_success(void)
 {
-    TEST("wl_io_last_error() is empty after successful operation");
-    wl_io_adapter_t a;
+    TEST("wirelog_io_last_error() is empty after successful operation");
+    wirelog_io_adapter_t a;
     memset(&a, 0, sizeof(a));
     a.scheme = "mock_err_clear";
-    a.abi_version = WL_IO_ABI_VERSION;
+    a.abi_version = WIRELOG_IO_ABI_VERSION;
 
-    int rc = wl_io_register_adapter(&a);
+    int rc = wirelog_io_register_adapter(&a);
     if (rc != 0) {
         FAIL("register failed unexpectedly"); return;
     }
 
-    const char *err = wl_io_last_error();
+    const char *err = wirelog_io_last_error();
     int ok = (err == NULL || err[0] == '\0');
 
-    wl_io_unregister_adapter("mock_err_clear");
+    wirelog_io_unregister_adapter("mock_err_clear");
 
     if (ok) PASS();
     else FAIL("expected empty error string after success");

--- a/tests/test_io_adapter_concurrent.c
+++ b/tests/test_io_adapter_concurrent.c
@@ -8,7 +8,7 @@
  * Designed to expose data races under TSan (Issue #459).
  *
  * Tests:
- *   1. Concurrent find: N threads repeatedly call wl_io_find_adapter
+ *   1. Concurrent find: N threads repeatedly call wirelog_io_find_adapter
  *   2. Concurrent register/unregister: N threads each own a unique scheme
  *   3. Mixed readers + writers: find and register running simultaneously
  *
@@ -49,7 +49,7 @@ find_worker(void *arg)
     (void)arg;
     for (int i = 0; i < FIND_ITERS; i++) {
         /* csv is the built-in; must always be findable */
-        const wl_io_adapter_t *a = wl_io_find_adapter("csv");
+        const wirelog_io_adapter_t *a = wirelog_io_find_adapter("csv");
         (void)a;
     }
     return NULL;
@@ -67,7 +67,7 @@ test_concurrent_find(void)
         thread_join(&threads[i]);
 
     /* After concurrent reads, csv must still be findable */
-    const wl_io_adapter_t *a = wl_io_find_adapter("csv");
+    const wirelog_io_adapter_t *a = wirelog_io_find_adapter("csv");
     if (a != NULL) PASS();
     else FAIL("csv not found after concurrent reads");
 }
@@ -76,7 +76,7 @@ test_concurrent_find(void)
 
 typedef struct {
     char scheme[32];
-    wl_io_adapter_t adapter;
+    wirelog_io_adapter_t adapter;
     int result;   /* 0 = ok, 1 = error */
 } reg_arg_t;
 
@@ -89,12 +89,12 @@ reg_unreg_worker(void *arg)
      * times.  The registry has 32 slots total; with 8 threads, each holding
      * at most 1 slot at a time, we stay well within capacity. */
     for (int i = 0; i < FIND_ITERS; i++) {
-        int rc = wl_io_register_adapter(&a->adapter);
+        int rc = wirelog_io_register_adapter(&a->adapter);
         if (rc != 0) {
             a->result = 1;
             return NULL;
         }
-        rc = wl_io_unregister_adapter(a->scheme);
+        rc = wirelog_io_unregister_adapter(a->scheme);
         if (rc != 0) {
             a->result = 1;
             return NULL;
@@ -116,7 +116,7 @@ test_concurrent_register_unregister(void)
         snprintf(args[i].scheme, sizeof(args[i].scheme), "conc_%d", i);
         memset(&args[i].adapter, 0, sizeof(args[i].adapter));
         args[i].adapter.scheme = args[i].scheme;
-        args[i].adapter.abi_version = WL_IO_ABI_VERSION;
+        args[i].adapter.abi_version = WIRELOG_IO_ABI_VERSION;
         args[i].result = 0;
         thread_create(&threads[i], reg_unreg_worker, &args[i]);
     }
@@ -141,9 +141,9 @@ mixed_find_worker(void *arg)
 {
     (void)arg;
     for (int i = 0; i < FIND_ITERS; i++) {
-        const wl_io_adapter_t *a = wl_io_find_adapter("csv");
+        const wirelog_io_adapter_t *a = wirelog_io_find_adapter("csv");
         (void)a;
-        a = wl_io_find_adapter("nonexistent_scheme_xyz");
+        a = wirelog_io_find_adapter("nonexistent_scheme_xyz");
         (void)a;
     }
     return NULL;
@@ -154,8 +154,8 @@ mixed_reg_worker(void *arg)
 {
     reg_arg_t *a = (reg_arg_t *)arg;
     for (int i = 0; i < FIND_ITERS; i++) {
-        wl_io_register_adapter(&a->adapter);
-        wl_io_unregister_adapter(a->scheme);
+        wirelog_io_register_adapter(&a->adapter);
+        wirelog_io_unregister_adapter(a->scheme);
     }
     return NULL;
 }
@@ -173,7 +173,7 @@ test_mixed_readers_writers(void)
         snprintf(wargs[i].scheme, sizeof(wargs[i].scheme), "mixed_%d", i);
         memset(&wargs[i].adapter, 0, sizeof(wargs[i].adapter));
         wargs[i].adapter.scheme = wargs[i].scheme;
-        wargs[i].adapter.abi_version = WL_IO_ABI_VERSION;
+        wargs[i].adapter.abi_version = WIRELOG_IO_ABI_VERSION;
         thread_create(&readers[i], mixed_find_worker, NULL);
         thread_create(&writers[i], mixed_reg_worker, &wargs[i]);
     }
@@ -183,7 +183,7 @@ test_mixed_readers_writers(void)
     }
 
     /* Registry must still be consistent: csv findable, no dangling entries */
-    const wl_io_adapter_t *a = wl_io_find_adapter("csv");
+    const wirelog_io_adapter_t *a = wirelog_io_find_adapter("csv");
     if (a != NULL) PASS();
     else FAIL("csv not found after mixed concurrent access");
 }

--- a/tests/test_io_ctx.c
+++ b/tests/test_io_ctx.c
@@ -4,7 +4,7 @@
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
  *
- * Seven test scenarios for wl_io_ctx_t accessors: relation_name,
+ * Seven test scenarios for wirelog_io_ctx_t accessors: relation_name,
  * num_cols, col_type, param_lookup, param_null_key, intern_string,
  * platform_ctx. All guarded behind TEST_CTX_PRESENT and currently SKIP
  * until #453 implements the context.
@@ -25,7 +25,7 @@
 
 static wl_intern_t *g_intern = NULL;
 
-static wl_io_ctx_t *
+static wirelog_io_ctx_t *
 create_mock_ctx(const char *relation_name,
     const wirelog_column_type_t *col_types, uint32_t num_cols,
     const char **param_keys, const char **param_values,
@@ -33,15 +33,15 @@ create_mock_ctx(const char *relation_name,
 {
     if (!g_intern)
         g_intern = wl_intern_create();
-    return wl_io_ctx_create_test(relation_name, col_types, num_cols,
+    return wirelog_io_ctx_create_test(relation_name, col_types, num_cols,
                param_keys, param_values, num_params,
                g_intern);
 }
 
 static void
-destroy_mock_ctx(wl_io_ctx_t *ctx)
+destroy_mock_ctx(wirelog_io_ctx_t *ctx)
 {
-    wl_io_ctx_destroy(ctx);
+    wirelog_io_ctx_destroy(ctx);
 }
 
 /* ======================================================================== */
@@ -62,11 +62,11 @@ static int passed = 0, failed = 0, skipped = 0;
 static void
 test_relation_name(void)
 {
-    TEST("wl_io_ctx_relation_name returns correct name");
+    TEST("wirelog_io_ctx_relation_name returns correct name");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = { WIRELOG_TYPE_INT32 };
-    wl_io_ctx_t *ctx = create_mock_ctx("events", cols, 1, NULL, NULL, 0);
-    if (strcmp(wl_io_ctx_relation_name(ctx), "events") != 0) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("events", cols, 1, NULL, NULL, 0);
+    if (strcmp(wirelog_io_ctx_relation_name(ctx), "events") != 0) {
         FAIL("relation name mismatch"); destroy_mock_ctx(ctx); return;
     }
     PASS();
@@ -79,13 +79,13 @@ test_relation_name(void)
 static void
 test_num_cols(void)
 {
-    TEST("wl_io_ctx_num_cols returns correct count");
+    TEST("wirelog_io_ctx_num_cols returns correct count");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = {
         WIRELOG_TYPE_STRING, WIRELOG_TYPE_INT32, WIRELOG_TYPE_STRING
     };
-    wl_io_ctx_t *ctx = create_mock_ctx("rel3", cols, 3, NULL, NULL, 0);
-    if (wl_io_ctx_num_cols(ctx) != 3) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("rel3", cols, 3, NULL, NULL, 0);
+    if (wirelog_io_ctx_num_cols(ctx) != 3) {
         FAIL("expected 3 columns"); destroy_mock_ctx(ctx); return;
     }
     PASS();
@@ -98,19 +98,19 @@ test_num_cols(void)
 static void
 test_col_type(void)
 {
-    TEST("wl_io_ctx_col_type returns correct types");
+    TEST("wirelog_io_ctx_col_type returns correct types");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = {
         WIRELOG_TYPE_STRING, WIRELOG_TYPE_INT32, WIRELOG_TYPE_STRING
     };
-    wl_io_ctx_t *ctx = create_mock_ctx("typed", cols, 3, NULL, NULL, 0);
-    if (wl_io_ctx_col_type(ctx, 0) != WIRELOG_TYPE_STRING) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("typed", cols, 3, NULL, NULL, 0);
+    if (wirelog_io_ctx_col_type(ctx, 0) != WIRELOG_TYPE_STRING) {
         FAIL("col 0 type mismatch"); destroy_mock_ctx(ctx); return;
     }
-    if (wl_io_ctx_col_type(ctx, 1) != WIRELOG_TYPE_INT32) {
+    if (wirelog_io_ctx_col_type(ctx, 1) != WIRELOG_TYPE_INT32) {
         FAIL("col 1 type mismatch"); destroy_mock_ctx(ctx); return;
     }
-    if (wl_io_ctx_col_type(ctx, 2) != WIRELOG_TYPE_STRING) {
+    if (wirelog_io_ctx_col_type(ctx, 2) != WIRELOG_TYPE_STRING) {
         FAIL("col 2 type mismatch"); destroy_mock_ctx(ctx); return;
     }
     PASS();
@@ -123,19 +123,19 @@ test_col_type(void)
 static void
 test_param_lookup(void)
 {
-    TEST("wl_io_ctx_param returns correct values");
+    TEST("wirelog_io_ctx_param returns correct values");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = { WIRELOG_TYPE_INT32 };
     const char *keys[] = { "filename", "delimiter" };
     const char *values[] = { "data.csv", "," };
-    wl_io_ctx_t *ctx = create_mock_ctx("params", cols, 1, keys, values, 2);
-    if (strcmp(wl_io_ctx_param(ctx, "filename"), "data.csv") != 0) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("params", cols, 1, keys, values, 2);
+    if (strcmp(wirelog_io_ctx_param(ctx, "filename"), "data.csv") != 0) {
         FAIL("filename param mismatch"); destroy_mock_ctx(ctx); return;
     }
-    if (strcmp(wl_io_ctx_param(ctx, "delimiter"), ",") != 0) {
+    if (strcmp(wirelog_io_ctx_param(ctx, "delimiter"), ",") != 0) {
         FAIL("delimiter param mismatch"); destroy_mock_ctx(ctx); return;
     }
-    if (wl_io_ctx_param(ctx, "nonexistent") != NULL) {
+    if (wirelog_io_ctx_param(ctx, "nonexistent") != NULL) {
         FAIL("expected NULL for unknown param"); destroy_mock_ctx(ctx); return;
     }
     PASS();
@@ -148,11 +148,11 @@ test_param_lookup(void)
 static void
 test_param_null_key(void)
 {
-    TEST("wl_io_ctx_param with NULL key returns NULL");
+    TEST("wirelog_io_ctx_param with NULL key returns NULL");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = { WIRELOG_TYPE_INT32 };
-    wl_io_ctx_t *ctx = create_mock_ctx("nullkey", cols, 1, NULL, NULL, 0);
-    if (wl_io_ctx_param(ctx, NULL) != NULL) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("nullkey", cols, 1, NULL, NULL, 0);
+    if (wirelog_io_ctx_param(ctx, NULL) != NULL) {
         FAIL("expected NULL for NULL key"); destroy_mock_ctx(ctx); return;
     }
     PASS();
@@ -165,16 +165,16 @@ test_param_null_key(void)
 static void
 test_intern_string(void)
 {
-    TEST("wl_io_ctx_intern_string returns consistent IDs");
+    TEST("wirelog_io_ctx_intern_string returns consistent IDs");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = { WIRELOG_TYPE_STRING };
-    wl_io_ctx_t *ctx = create_mock_ctx("intern", cols, 1, NULL, NULL, 0);
-    int64_t id1 = wl_io_ctx_intern_string(ctx, "hello");
+    wirelog_io_ctx_t *ctx = create_mock_ctx("intern", cols, 1, NULL, NULL, 0);
+    int64_t id1 = wirelog_io_ctx_intern_string(ctx, "hello");
     if (id1 <= 0) {
         FAIL("first intern returned non-positive ID"); destroy_mock_ctx(ctx);
         return;
     }
-    int64_t id2 = wl_io_ctx_intern_string(ctx, "hello");
+    int64_t id2 = wirelog_io_ctx_intern_string(ctx, "hello");
     if (id2 != id1) {
         FAIL("second intern returned different ID"); destroy_mock_ctx(ctx);
         return;
@@ -189,15 +189,15 @@ test_intern_string(void)
 static void
 test_platform_ctx(void)
 {
-    TEST("wl_io_ctx_platform get/set round-trip");
+    TEST("wirelog_io_ctx_platform get/set round-trip");
 #ifdef TEST_CTX_PRESENT
     wirelog_column_type_t cols[] = { WIRELOG_TYPE_INT32 };
-    wl_io_ctx_t *ctx = create_mock_ctx("plat", cols, 1, NULL, NULL, 0);
-    if (wl_io_ctx_platform(ctx) != NULL) {
+    wirelog_io_ctx_t *ctx = create_mock_ctx("plat", cols, 1, NULL, NULL, 0);
+    if (wirelog_io_ctx_platform(ctx) != NULL) {
         FAIL("expected NULL initial platform"); destroy_mock_ctx(ctx); return;
     }
-    wl_io_ctx_set_platform(ctx, (void *)0xCAFE);
-    if (wl_io_ctx_platform(ctx) != (void *)0xCAFE) {
+    wirelog_io_ctx_set_platform(ctx, (void *)0xCAFE);
+    if (wirelog_io_ctx_platform(ctx) != (void *)0xCAFE) {
         FAIL("platform pointer mismatch"); destroy_mock_ctx(ctx); return;
     }
     PASS();

--- a/tests/test_io_dispatch.c
+++ b/tests/test_io_dispatch.c
@@ -74,12 +74,12 @@ static int s_mock_read_called;
 static const char *s_mock_received_key;
 
 static int
-mock_read_cb(wl_io_ctx_t *ctx, int64_t **out_data,
+mock_read_cb(wirelog_io_ctx_t *ctx, int64_t **out_data,
     uint32_t *out_nrows, void *user_data)
 {
     (void)user_data;
     s_mock_read_called = 1;
-    s_mock_received_key = wl_io_ctx_param(ctx, "key");
+    s_mock_received_key = wirelog_io_ctx_param(ctx, "key");
 
     /* Return a single row with one column */
     *out_data = (int64_t *)malloc(sizeof(int64_t));
@@ -168,15 +168,15 @@ test_dispatch_mock_adapter(void)
     s_insert_called = 0;
 
     /* Register mock adapter */
-    wl_io_adapter_t mock = {0};
-    mock.abi_version = WL_IO_ABI_VERSION;
+    wirelog_io_adapter_t mock = {0};
+    mock.abi_version = WIRELOG_IO_ABI_VERSION;
     mock.scheme = "mock";
     mock.description = "test mock adapter";
     mock.read = mock_read_cb;
     mock.validate = NULL;
     mock.user_data = NULL;
 
-    int reg_rc = wl_io_register_adapter(&mock);
+    int reg_rc = wirelog_io_register_adapter(&mock);
     if (reg_rc != 0) {
         FAIL("failed to register mock adapter");
         return;
@@ -188,7 +188,7 @@ test_dispatch_mock_adapter(void)
     struct wirelog_program *prog = make_program("mock", pnames, pvalues, 1);
     if (!prog) {
         FAIL("failed to create program");
-        wl_io_unregister_adapter("mock");
+        wirelog_io_unregister_adapter("mock");
         return;
     }
 
@@ -206,7 +206,7 @@ test_dispatch_mock_adapter(void)
     }
 
     free_program(prog);
-    wl_io_unregister_adapter("mock");
+    wirelog_io_unregister_adapter("mock");
 #else
     SKIP("dispatch rewrite not yet implemented (#458)");
 #endif

--- a/tests/test_plugin_loader.c
+++ b/tests/test_plugin_loader.c
@@ -34,7 +34,7 @@ test_load_valid_plugin(const char *mock_path)
         return;
     }
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("mock_plugin");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("mock_plugin");
     if (!found) {
         FAIL("adapter 'mock_plugin' not found after load");
         return;
@@ -55,7 +55,7 @@ test_unload_cleans_registry(void)
 
     wl_plugin_unload_all();
 
-    const wl_io_adapter_t *found = wl_io_find_adapter("mock_plugin");
+    const wirelog_io_adapter_t *found = wirelog_io_find_adapter("mock_plugin");
     if (found) {
         FAIL("adapter 'mock_plugin' still found after unload");
         return;

--- a/wirelog/cli/plugin_loader.c
+++ b/wirelog/cli/plugin_loader.c
@@ -24,7 +24,7 @@
 
 typedef struct {
     void *handle;
-    const wl_io_adapter_t *const *adapters;
+    const wirelog_io_adapter_t *const *adapters;
     uint32_t n_adapters;
 } loaded_plugin_t;
 
@@ -59,28 +59,29 @@ wl_plugin_load(const char *path)
     /* Clear any stale dlerror */
     dlerror();
 
-    wl_io_plugin_entry_fn entry =
-        (wl_io_plugin_entry_fn)dlsym(handle, WL_IO_PLUGIN_ENTRY_SYMBOL);
+    wirelog_io_plugin_entry_fn entry =
+        (wirelog_io_plugin_entry_fn)dlsym(handle,
+            WIRELOG_IO_PLUGIN_ENTRY_SYMBOL);
 
     const char *err = dlerror();
     if (err || !entry) {
         fprintf(stderr,
             "error: plugin '%s' missing symbol '%s': %s\n",
-            path, WL_IO_PLUGIN_ENTRY_SYMBOL,
+            path, WIRELOG_IO_PLUGIN_ENTRY_SYMBOL,
             err ? err : "symbol resolved to NULL");
         dlclose(handle);
         return -1;
     }
 
     uint32_t n_out = 0;
-    const wl_io_adapter_t *const *adapters =
-        entry(&n_out, WL_IO_ABI_VERSION);
+    const wirelog_io_adapter_t *const *adapters =
+        entry(&n_out, WIRELOG_IO_ABI_VERSION);
 
     if (!adapters) {
         fprintf(stderr,
             "error: plugin '%s' returned NULL "
             "(ABI version mismatch? host=%u)\n",
-            path, (unsigned)WL_IO_ABI_VERSION);
+            path, (unsigned)WIRELOG_IO_ABI_VERSION);
         dlclose(handle);
         return -1;
     }
@@ -100,17 +101,17 @@ wl_plugin_load(const char *path)
                 path, (unsigned)i);
             continue;
         }
-        if (wl_io_register_adapter(adapters[i]) != 0) {
+        if (wirelog_io_register_adapter(adapters[i]) != 0) {
             fprintf(stderr,
                 "error: plugin '%s' adapter[%u] (%s) "
                 "registration failed: %s\n",
                 path, (unsigned)i,
                 adapters[i]->scheme ? adapters[i]->scheme : "(null)",
-                wl_io_last_error());
+                wirelog_io_last_error());
             /* Fail fast: unregister what we registered and close */
             for (uint32_t j = 0; j < i; j++) {
                 if (adapters[j] && adapters[j]->scheme) {
-                    wl_io_unregister_adapter(adapters[j]->scheme);
+                    wirelog_io_unregister_adapter(adapters[j]->scheme);
                 }
             }
             dlclose(handle);
@@ -137,7 +138,7 @@ wl_plugin_unload_all(void)
         /* Unregister all adapters from this plugin */
         for (uint32_t j = 0; j < p->n_adapters; j++) {
             if (p->adapters[j] && p->adapters[j]->scheme) {
-                wl_io_unregister_adapter(p->adapters[j]->scheme);
+                wirelog_io_unregister_adapter(p->adapters[j]->scheme);
             }
         }
 

--- a/wirelog/cli/plugin_loader.h
+++ b/wirelog/cli/plugin_loader.h
@@ -12,7 +12,7 @@
  * Load adapter plugin(s) from a shared library.
  *
  * Opens the library at `path` via dlopen, resolves the
- * "wl_io_plugin_entry" symbol, validates the ABI version,
+ * "wirelog_io_plugin_entry" symbol, validates the ABI version,
  * and bulk-registers all returned adapters.
  *
  * Returns 0 on success, -1 on error (message printed to stderr).

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -20,7 +20,7 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  *
  * Wraps wl_csv_read_file / wl_csv_read_file_via_ctx behind the
- * wl_io_adapter_t vtable for auto-registration in the I/O registry.
+ * wirelog_io_adapter_t vtable for auto-registration in the I/O registry.
  *
  * Part of #446 (I/O adapter umbrella).
  */
@@ -45,12 +45,12 @@
 /*
  * The built-in CSV adapter calls wl_intern_put directly (0-based IDs)
  * to stay consistent with the legacy wl_csv_read_file_ex path.
- * External adapters should use wl_io_ctx_intern_string (1-based) instead.
+ * External adapters should use wirelog_io_ctx_intern_string (1-based) instead.
  */
 static int64_t
 csv_intern_trampoline(void *opaque, const char *str)
 {
-    wl_io_ctx_t *ctx = (wl_io_ctx_t *)opaque;
+    wirelog_io_ctx_t *ctx = (wirelog_io_ctx_t *)opaque;
     if (!ctx || !ctx->intern)
         return -1;
     return wl_intern_put(ctx->intern, str);
@@ -61,19 +61,19 @@ csv_intern_trampoline(void *opaque, const char *str)
 /* ======================================================================== */
 
 static int
-csv_read(wl_io_ctx_t *ctx, int64_t **out_data,
+csv_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
     uint32_t *out_nrows, void *user_data)
 {
     (void)user_data;
 
     /* ---- filename (required) ---- */
-    const char *filename = wl_io_ctx_param(ctx, "filename");
+    const char *filename = wirelog_io_ctx_param(ctx, "filename");
     if (!filename)
         return -1;
 
     /* ---- delimiter (default: tab) ---- */
     char delimiter = '\t';
-    const char *delim_str = wl_io_ctx_param(ctx, "delimiter");
+    const char *delim_str = wirelog_io_ctx_param(ctx, "delimiter");
     if (delim_str) {
         if (strcmp(delim_str, "\\t") == 0)
             delimiter = '\t';
@@ -102,10 +102,10 @@ csv_read(wl_io_ctx_t *ctx, int64_t **out_data,
     }
 
     /* ---- check for STRING columns ---- */
-    uint32_t num_cols = wl_io_ctx_num_cols(ctx);
+    uint32_t num_cols = wirelog_io_ctx_num_cols(ctx);
     int has_string = 0;
     for (uint32_t i = 0; i < num_cols; i++) {
-        if (wl_io_ctx_col_type(ctx, i) == WIRELOG_TYPE_STRING) {
+        if (wirelog_io_ctx_col_type(ctx, i) == WIRELOG_TYPE_STRING) {
             has_string = 1;
             break;
         }
@@ -117,7 +117,7 @@ csv_read(wl_io_ctx_t *ctx, int64_t **out_data,
         if (!types)
             return -1;
         for (uint32_t i = 0; i < num_cols; i++)
-            types[i] = wl_io_ctx_col_type(ctx, i);
+            types[i] = wirelog_io_ctx_col_type(ctx, i);
 
         uint32_t out_ncols = 0;
         int rc = wl_csv_read_file_via_ctx(resolved_path, delimiter,
@@ -138,8 +138,8 @@ csv_read(wl_io_ctx_t *ctx, int64_t **out_data,
 /* Adapter Definition                                                       */
 /* ======================================================================== */
 
-const wl_io_adapter_t wl_csv_adapter = {
-    .abi_version = WL_IO_ABI_VERSION,
+const wirelog_io_adapter_t wl_csv_adapter = {
+    .abi_version = WIRELOG_IO_ABI_VERSION,
     .scheme = "csv",
     .description = "Built-in CSV/TSV file reader",
     .read = csv_read,

--- a/wirelog/io/io_adapter.c
+++ b/wirelog/io/io_adapter.c
@@ -63,11 +63,11 @@ set_error(const char *msg)
 #define SCHEME_MAX_LEN 64
 
 typedef struct {
-    const wl_io_adapter_t *adapter;
+    const wirelog_io_adapter_t *adapter;
     char scheme[SCHEME_MAX_LEN];
 } registry_entry_t;
 
-static registry_entry_t s_registry[WL_IO_MAX_ADAPTERS];
+static registry_entry_t s_registry[WIRELOG_IO_MAX_ADAPTERS];
 static uint32_t s_count;
 /* Mutex initialization strategy (3-tier, Issue #494):
  *
@@ -97,7 +97,7 @@ static mutex_t s_mutex = { PTHREAD_MUTEX_INITIALIZER };
 static bool s_initialized;
 
 /* Built-in CSV adapter (implemented in csv_adapter.c) */
-extern const wl_io_adapter_t wl_csv_adapter;
+extern const wirelog_io_adapter_t wl_csv_adapter;
 
 /* ======================================================================== */
 /* One-Shot Initialization                                                  */
@@ -147,7 +147,7 @@ ensure_builtins(void)
 /* ======================================================================== */
 
 int
-wl_io_register_adapter(const wl_io_adapter_t *adapter)
+wirelog_io_register_adapter(const wirelog_io_adapter_t *adapter)
 {
     ensure_builtins();
 
@@ -159,7 +159,7 @@ wl_io_register_adapter(const wl_io_adapter_t *adapter)
         set_error("adapter scheme is NULL");
         return -1;
     }
-    if (adapter->abi_version != WL_IO_ABI_VERSION) {
+    if (adapter->abi_version != WIRELOG_IO_ABI_VERSION) {
         set_error("ABI version mismatch");
         return -1;
     }
@@ -176,7 +176,7 @@ wl_io_register_adapter(const wl_io_adapter_t *adapter)
     }
 
     /* Check capacity */
-    if (s_count >= WL_IO_MAX_ADAPTERS) {
+    if (s_count >= WIRELOG_IO_MAX_ADAPTERS) {
         mutex_unlock(&s_mutex);
         set_error("registry full");
         return -1;
@@ -194,7 +194,7 @@ wl_io_register_adapter(const wl_io_adapter_t *adapter)
 }
 
 int
-wl_io_unregister_adapter(const char *scheme)
+wirelog_io_unregister_adapter(const char *scheme)
 {
     ensure_builtins();
 
@@ -224,8 +224,8 @@ wl_io_unregister_adapter(const char *scheme)
     return -1;
 }
 
-const wl_io_adapter_t *
-wl_io_find_adapter(const char *scheme)
+const wirelog_io_adapter_t *
+wirelog_io_find_adapter(const char *scheme)
 {
     ensure_builtins();
 
@@ -238,7 +238,7 @@ wl_io_find_adapter(const char *scheme)
 
     for (uint32_t i = 0; i < s_count; i++) {
         if (strcmp(s_registry[i].scheme, scheme) == 0) {
-            const wl_io_adapter_t *found = s_registry[i].adapter;
+            const wirelog_io_adapter_t *found = s_registry[i].adapter;
             mutex_unlock(&s_mutex);
             set_error(NULL);
             return found;
@@ -251,7 +251,7 @@ wl_io_find_adapter(const char *scheme)
 }
 
 const char *
-wl_io_last_error(void)
+wirelog_io_last_error(void)
 {
     return s_errbuf;
 }

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -37,41 +37,55 @@ extern "C" {
 /* Constants                                                                */
 /* ======================================================================== */
 
-#define WL_IO_ABI_VERSION   1u
-#define WL_IO_MAX_ADAPTERS  32
+/* WIRELOG_IO_ABI_VERSION:
+ *   1u (v0.30.0): symbols carried internal `wl_io_*` / `WL_IO_*`
+ *      prefixes on this public installed header, contradicting the
+ *      AGENTS.md naming-convention rule that public symbols must use
+ *      `wirelog_*` / `WIRELOG_*`.
+ *   2u (v0.40+): symbols renamed; the registration-time
+ *      `adapter->abi_version != WIRELOG_IO_ABI_VERSION` check rejects
+ *      v0.30.0 plugins (abi_version == 1u) loud, with a diagnostic
+ *      retrievable via `wirelog_io_last_error()`.  Plugin authors
+ *      built against v0.30.0 must rebuild against v0.40+ to
+ *      ABI-version 2u.
+ */
+#define WIRELOG_IO_ABI_VERSION   2u
+#define WIRELOG_IO_MAX_ADAPTERS  32
 
 /* ======================================================================== */
 /* Opaque Context                                                           */
 /* ======================================================================== */
 
-typedef struct wl_io_ctx wl_io_ctx_t;
+typedef struct wirelog_io_ctx wirelog_io_ctx_t;
 
 /* ======================================================================== */
 /* Context Accessors (implemented in #453)                                  */
 /* ======================================================================== */
 
-const char *wl_io_ctx_relation_name(const wl_io_ctx_t *ctx);
-uint32_t    wl_io_ctx_num_cols(const wl_io_ctx_t *ctx);
-wirelog_column_type_t wl_io_ctx_col_type(const wl_io_ctx_t *ctx, uint32_t col);
-const char *wl_io_ctx_param(const wl_io_ctx_t *ctx, const char *key);
-int64_t     wl_io_ctx_intern_string(wl_io_ctx_t *ctx, const char *utf8);
-void       *wl_io_ctx_platform(const wl_io_ctx_t *ctx);
-int         wl_io_ctx_set_platform(wl_io_ctx_t *ctx, void *ptr);
+const char *wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx);
+uint32_t    wirelog_io_ctx_num_cols(const wirelog_io_ctx_t *ctx);
+wirelog_column_type_t wirelog_io_ctx_col_type(const wirelog_io_ctx_t *ctx,
+    uint32_t col);
+const char *wirelog_io_ctx_param(const wirelog_io_ctx_t *ctx, const char *key);
+int64_t     wirelog_io_ctx_intern_string(wirelog_io_ctx_t *ctx,
+    const char *utf8);
+void       *wirelog_io_ctx_platform(const wirelog_io_ctx_t *ctx);
+int         wirelog_io_ctx_set_platform(wirelog_io_ctx_t *ctx, void *ptr);
 
 /* ======================================================================== */
 /* Adapter VTable                                                           */
 /* ======================================================================== */
 
-typedef struct wl_io_adapter {
+typedef struct wirelog_io_adapter {
     uint32_t abi_version;
     const char *scheme;
     const char *description;
-    int (*read)(wl_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
+    int (*read)(wirelog_io_ctx_t *ctx, int64_t **out_data, uint32_t *out_nrows,
         void *user_data);
-    int (*validate)(wl_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
+    int (*validate)(wirelog_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
         void *user_data);
     void *user_data;
-} wl_io_adapter_t;
+} wirelog_io_adapter_t;
 
 /* ======================================================================== */
 /* Registration API                                                         */
@@ -80,18 +94,18 @@ typedef struct wl_io_adapter {
 /* __attribute__((used)) prevents iOS static-library dead-stripping.
  * MSVC does not support it; use #pragma comment(linker, /include:) if needed. */
 #if defined(__GNUC__) || defined(__clang__)
-#define WL_IO_USED __attribute__((used))
+#define WIRELOG_IO_USED __attribute__((used))
 #else
-#define WL_IO_USED
+#define WIRELOG_IO_USED
 #endif
 
 /*
  * Adapter Lifetime Contract
  * -------------------------
- * The wl_io_adapter_t pointer passed to wl_io_register_adapter() MUST remain
+ * The wirelog_io_adapter_t pointer passed to wirelog_io_register_adapter() MUST remain
  * valid (i.e. the pointed-to struct must not be freed or modified) until the
- * corresponding wl_io_unregister_adapter() call or process exit.  The registry
- * stores the raw pointer and returns it verbatim from wl_io_find_adapter().
+ * corresponding wirelog_io_unregister_adapter() call or process exit.  The registry
+ * stores the raw pointer and returns it verbatim from wirelog_io_find_adapter().
  *
  * The scheme string within the adapter struct is copied into an internal
  * fixed-size buffer (SCHEME_MAX_LEN-1 characters) at registration time, so
@@ -106,26 +120,27 @@ typedef struct wl_io_adapter {
  * Error Reporting
  * ---------------
  * On failure, functions return -1 and record a human-readable reason in a
- * thread-local buffer retrievable via wl_io_last_error().  On success the
+ * thread-local buffer retrievable via wirelog_io_last_error().  On success the
  * error buffer is cleared.  The returned pointer is valid until the next call
  * on the same thread.
  *
  * Return values:
- *   wl_io_register_adapter   0 on success, -1 on error (NULL input, ABI
+ *   wirelog_io_register_adapter   0 on success, -1 on error (NULL input, ABI
  *                             mismatch, duplicate scheme, or registry full)
- *   wl_io_unregister_adapter 0 on success, -1 if scheme is not registered
- *   wl_io_find_adapter        pointer to adapter, or NULL if not found
+ *   wirelog_io_unregister_adapter 0 on success, -1 if scheme is not registered
+ *   wirelog_io_find_adapter        pointer to adapter, or NULL if not found
  */
 
-WIRELOG_PUBLIC int wl_io_register_adapter(
-    const wl_io_adapter_t *adapter) WL_IO_USED;
+WIRELOG_PUBLIC int wirelog_io_register_adapter(
+    const wirelog_io_adapter_t *adapter) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC int wl_io_unregister_adapter(const char *scheme) WL_IO_USED;
+WIRELOG_PUBLIC int wirelog_io_unregister_adapter(
+    const char *scheme) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC const wl_io_adapter_t *wl_io_find_adapter(
-    const char *scheme) WL_IO_USED;
+WIRELOG_PUBLIC const wirelog_io_adapter_t *wirelog_io_find_adapter(
+    const char *scheme) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC const char *wl_io_last_error(void);
+WIRELOG_PUBLIC const char *wirelog_io_last_error(void);
 
 /* ======================================================================== */
 /* Plugin Entry Point (Path B, Issue #461)                                  */
@@ -137,24 +152,24 @@ WIRELOG_PUBLIC const char *wl_io_last_error(void);
  * does not strip it even under -fvisibility=hidden or LTO.
  */
 #if defined(_WIN32) || defined(__CYGWIN__)
-#define WL_IO_PLUGIN_EXPORT __declspec(dllexport)
+#define WIRELOG_IO_PLUGIN_EXPORT __declspec(dllexport)
 #elif defined(__GNUC__) || defined(__clang__)
-#define WL_IO_PLUGIN_EXPORT __attribute__((visibility("default")))
+#define WIRELOG_IO_PLUGIN_EXPORT __attribute__((visibility("default")))
 #else
-#define WL_IO_PLUGIN_EXPORT
+#define WIRELOG_IO_PLUGIN_EXPORT
 #endif
 
 /*
  * Plugin entry point signature.
  *
  * A plugin shared library must export exactly one symbol named
- * "wl_io_plugin_entry" with this signature.  The CLI plugin loader
+ * "wirelog_io_plugin_entry" with this signature.  The CLI plugin loader
  * calls dlopen() on the library, resolves this symbol via dlsym(),
  * validates the ABI version, and bulk-registers all returned adapters.
  *
  * Parameters:
  *   n_out    [out] Number of adapters in the returned array.
- *   abi_ver  [in]  Host's WL_IO_ABI_VERSION.  The plugin should check
+ *   abi_ver  [in]  Host's WIRELOG_IO_ABI_VERSION.  The plugin should check
  *                  this against its own compiled version and return NULL
  *                  on mismatch.
  *
@@ -162,10 +177,10 @@ WIRELOG_PUBLIC const char *wl_io_last_error(void);
  *   Array of adapter pointers (must remain valid for process lifetime),
  *   or NULL on ABI mismatch / error.
  */
-typedef const wl_io_adapter_t *const *(*wl_io_plugin_entry_fn)(
+typedef const wirelog_io_adapter_t *const *(*wirelog_io_plugin_entry_fn)(
     uint32_t *n_out, uint32_t abi_ver);
 
-#define WL_IO_PLUGIN_ENTRY_SYMBOL "wl_io_plugin_entry"
+#define WIRELOG_IO_PLUGIN_ENTRY_SYMBOL "wirelog_io_plugin_entry"
 
 #ifdef __cplusplus
 }

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -4,7 +4,7 @@
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
  *
- * Implements the wl_io_ctx_t accessor functions declared in
+ * Implements the wirelog_io_ctx_t accessor functions declared in
  * io_adapter.h (#451) and the test constructor/destructor from
  * io_ctx_internal.h.
  *
@@ -20,14 +20,14 @@
 /* Production Constructor (from relation metadata)                          */
 /* ------------------------------------------------------------------------ */
 
-wl_io_ctx_t *
-wl_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
+wirelog_io_ctx_t *
+wirelog_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
     wl_intern_t *intern)
 {
     if (!rel)
         return NULL;
 
-    wl_io_ctx_t *ctx = (wl_io_ctx_t *)calloc(1, sizeof(*ctx));
+    wirelog_io_ctx_t *ctx = (wirelog_io_ctx_t *)calloc(1, sizeof(*ctx));
     if (!ctx)
         return NULL;
 
@@ -57,13 +57,13 @@ wl_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
 /* Test Constructor / Destructor                                            */
 /* ------------------------------------------------------------------------ */
 
-wl_io_ctx_t *
-wl_io_ctx_create_test(const char *relation_name,
+wirelog_io_ctx_t *
+wirelog_io_ctx_create_test(const char *relation_name,
     const wirelog_column_type_t *col_types, uint32_t num_cols,
     const char **param_keys, const char **param_values,
     uint32_t num_params, wl_intern_t *intern)
 {
-    wl_io_ctx_t *ctx = (wl_io_ctx_t *)calloc(1, sizeof(*ctx));
+    wirelog_io_ctx_t *ctx = (wirelog_io_ctx_t *)calloc(1, sizeof(*ctx));
     if (!ctx)
         return NULL;
 
@@ -90,7 +90,7 @@ wl_io_ctx_create_test(const char *relation_name,
 }
 
 void
-wl_io_ctx_destroy(wl_io_ctx_t *ctx)
+wirelog_io_ctx_destroy(wirelog_io_ctx_t *ctx)
 {
     if (!ctx)
         return;
@@ -103,7 +103,7 @@ wl_io_ctx_destroy(wl_io_ctx_t *ctx)
 /* ------------------------------------------------------------------------ */
 
 const char *
-wl_io_ctx_relation_name(const wl_io_ctx_t *ctx)
+wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx)
 {
     if (!ctx)
         return NULL;
@@ -111,7 +111,7 @@ wl_io_ctx_relation_name(const wl_io_ctx_t *ctx)
 }
 
 uint32_t
-wl_io_ctx_num_cols(const wl_io_ctx_t *ctx)
+wirelog_io_ctx_num_cols(const wirelog_io_ctx_t *ctx)
 {
     if (!ctx)
         return 0;
@@ -119,7 +119,7 @@ wl_io_ctx_num_cols(const wl_io_ctx_t *ctx)
 }
 
 wirelog_column_type_t
-wl_io_ctx_col_type(const wl_io_ctx_t *ctx, uint32_t col)
+wirelog_io_ctx_col_type(const wirelog_io_ctx_t *ctx, uint32_t col)
 {
     if (!ctx || col >= ctx->num_cols)
         return (wirelog_column_type_t)-1;
@@ -127,7 +127,7 @@ wl_io_ctx_col_type(const wl_io_ctx_t *ctx, uint32_t col)
 }
 
 const char *
-wl_io_ctx_param(const wl_io_ctx_t *ctx, const char *key)
+wirelog_io_ctx_param(const wirelog_io_ctx_t *ctx, const char *key)
 {
     if (!ctx || !key)
         return NULL;
@@ -139,7 +139,7 @@ wl_io_ctx_param(const wl_io_ctx_t *ctx, const char *key)
 }
 
 int64_t
-wl_io_ctx_intern_string(wl_io_ctx_t *ctx, const char *utf8)
+wirelog_io_ctx_intern_string(wirelog_io_ctx_t *ctx, const char *utf8)
 {
     if (!ctx || !ctx->intern)
         return -1;
@@ -151,7 +151,7 @@ wl_io_ctx_intern_string(wl_io_ctx_t *ctx, const char *utf8)
 }
 
 void *
-wl_io_ctx_platform(const wl_io_ctx_t *ctx)
+wirelog_io_ctx_platform(const wirelog_io_ctx_t *ctx)
 {
     if (!ctx)
         return NULL;
@@ -159,7 +159,7 @@ wl_io_ctx_platform(const wl_io_ctx_t *ctx)
 }
 
 int
-wl_io_ctx_set_platform(wl_io_ctx_t *ctx, void *ptr)
+wirelog_io_ctx_set_platform(wirelog_io_ctx_t *ctx, void *ptr)
 {
     if (!ctx)
         return -1;

--- a/wirelog/io/io_ctx_internal.h
+++ b/wirelog/io/io_ctx_internal.h
@@ -5,7 +5,7 @@
  * Licensed under LGPL-3.0
  *
  * INTERNAL HEADER - not installed, not part of public API.
- * Defines the concrete wl_io_ctx struct so that the opaque typedef
+ * Defines the concrete wirelog_io_ctx struct so that the opaque typedef
  * in io_adapter.h is preserved for library consumers.
  *
  * Part of #446 (I/O adapter umbrella).
@@ -18,7 +18,7 @@
 #include "wirelog/intern.h"
 #include "wirelog/ir/program.h"  /* for wl_ir_relation_info_t */
 
-struct wl_io_ctx {
+struct wirelog_io_ctx {
     const char             *relation_name;
     uint32_t num_cols;
     wirelog_column_type_t  *col_types;       /* owned copy */
@@ -29,15 +29,15 @@ struct wl_io_ctx {
     void                   *platform_ctx;
 };
 
-wl_io_ctx_t *wl_io_ctx_create_test(
+wirelog_io_ctx_t *wirelog_io_ctx_create_test(
     const char *relation_name,
     const wirelog_column_type_t *col_types, uint32_t num_cols,
     const char **param_keys, const char **param_values, uint32_t num_params,
     wl_intern_t *intern);
 
-void wl_io_ctx_destroy(wl_io_ctx_t *ctx);
+void wirelog_io_ctx_destroy(wirelog_io_ctx_t *ctx);
 
-wl_io_ctx_t *wl_io_ctx_create_for_relation(
+wirelog_io_ctx_t *wirelog_io_ctx_create_for_relation(
     const wl_ir_relation_info_t *rel,
     wl_intern_t *intern);
 

--- a/wirelog/session_facts.c
+++ b/wirelog/session_facts.c
@@ -62,7 +62,7 @@ wl_session_load_input_files(wl_session_t *sess,
         const char *scheme = rel->input_io_scheme ? rel->input_io_scheme
                                                   : "csv";
 
-        const wl_io_adapter_t *adapter = wl_io_find_adapter(scheme);
+        const wirelog_io_adapter_t *adapter = wirelog_io_find_adapter(scheme);
         if (!adapter) {
             fprintf(stderr,
                 "error: no I/O adapter registered for scheme '%s' "
@@ -71,8 +71,8 @@ wl_session_load_input_files(wl_session_t *sess,
             return -1;
         }
 
-        wl_io_ctx_t *ctx =
-            wl_io_ctx_create_for_relation(rel, prog->intern);
+        wirelog_io_ctx_t *ctx =
+            wirelog_io_ctx_create_for_relation(rel, prog->intern);
         if (!ctx) {
             fprintf(stderr,
                 "error: failed to create I/O context for '%s'\n",
@@ -90,7 +90,7 @@ wl_session_load_input_files(wl_session_t *sess,
                 fprintf(stderr,
                     "error: validation failed for '%s': %s\n",
                     rel->name, errbuf);
-                wl_io_ctx_destroy(ctx);
+                wirelog_io_ctx_destroy(ctx);
                 return -1;
             }
         }
@@ -100,7 +100,7 @@ wl_session_load_input_files(wl_session_t *sess,
         uint32_t nrows = 0;
 
         int rc = adapter->read(ctx, &data, &nrows, adapter->user_data);
-        wl_io_ctx_destroy(ctx);
+        wirelog_io_ctx_destroy(ctx);
 
         if (rc != 0) {
             fprintf(stderr,


### PR DESCRIPTION
## Summary

Renames the entire `wirelog/io/io_adapter.h` public surface
(20 identifiers) from `wl_io_*` / `WL_IO_*` to `wirelog_io_*` /
`WIRELOG_IO_*` per `AGENTS.md:17-20`, and bumps
`WIRELOG_IO_ABI_VERSION` from `1u` to `2u` so v0.30.0 plugins
fail loud at registration.

Path-B plugins (dynamic `dlopen` load) must rebuild and rename
their exported entry symbol from `wl_io_plugin_entry` to
`wirelog_io_plugin_entry`; otherwise the loader's `dlsym` returns
NULL with a clear "missing entry symbol" diagnostic.

## Test plan

- [x] `grep -rE '\bwl_io_|\bWL_IO_'` returns zero matches across
      the entire repo
- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] `WIRELOG_IO_ABI_VERSION` is `2u` at the macro definition
- [x] `examples/path_a_pcap_skeleton/main.c` (CI regression gate
      per #449) uses the renamed symbols
- [x] CHANGELOG `[Unreleased]` records the rename + ABI bump
- [x] `docs/MIGRATION.md` 0.30 -> 1.0 section gains the entry
- [ ] CI: full default + abi + sanitizer matrix

Closes #762 (replaces audit-era #706).  Part of public-API
prefix audit epic #755.