### PR TITLE
ci: standalone-include compile matrix for public headers (#689 B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Standalone-include compile matrix for public headers** (#689):
+  9 small `tests/standalone/test_standalone_<HEADER>.c` stubs, each
+  including exactly one public installed header and a trivial
+  `main()`, registered as `meson test --suite abi:standalone_include_*`.
+  Failure = a public header has a hidden dependency on another
+  header being included first (broken self-containment).  The
+  GCC/Clang/MSVC compiler matrix is realised at the GitHub Actions
+  level: each platform compiles every stub via its native CC.  Closes
+  Blocker B2 of the v0.40 API audit and supplements the existing
+  3-way SSoT verification at `scripts/ci/check-public-header-surface.py`.
 - **CI lint backstop for public-API prefix conformance** (#761):
   `scripts/ci/check-public-prefix.py` (registered as
   `meson test --suite abi:public_prefix`) scans the 9 public

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -414,6 +414,34 @@ test('public_prefix', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-prefix.py'],
      suite: 'abi')
 
+# Issue #689 / Blocker B2: standalone-include compile matrix for the
+# public-headers SSoT.  One executable per public header, each
+# compiled in isolation against tests/standalone/test_standalone_<H>.c
+# whose body is `#include "wirelog/<H>.h"; int main(void) { return 0; }`.
+# Failure = the header has a hidden dependency on another header being
+# included first.  The cross-compiler matrix (GCC / Clang / MSVC) is
+# realised at the GitHub Actions level: each platform compiles every
+# stub via its native CC.
+public_standalone_headers = [
+  ['wirelog',           'test_standalone_wirelog.c'],
+  ['wirelog_types',     'test_standalone_wirelog_types.c'],
+  ['wirelog_ir',        'test_standalone_wirelog_ir.c'],
+  ['wirelog_parser',    'test_standalone_wirelog_parser.c'],
+  ['wirelog_optimizer', 'test_standalone_wirelog_optimizer.c'],
+  ['wirelog_export',    'test_standalone_wirelog_export.c'],
+  ['wirelog_easy',      'test_standalone_wirelog_easy.c'],
+  ['wirelog_advanced',  'test_standalone_wirelog_advanced.c'],
+  ['io_adapter',        'test_standalone_io_adapter.c'],
+]
+foreach hdr : public_standalone_headers
+  exe = executable(
+    'test_standalone_' + hdr[0],
+    files('standalone/' + hdr[1]),
+    include_directories: [wirelog_inc, wirelog_src_inc],
+  )
+  test('standalone_include_' + hdr[0], exe, suite: 'abi')
+endforeach
+
 test_intern_exe = executable(
   'test_intern',
   files('test_intern.c'),

--- a/tests/standalone/test_standalone_io_adapter.c
+++ b/tests/standalone/test_standalone_io_adapter.c
@@ -1,0 +1,8 @@
+/* Standalone-include compile gate for wirelog/io/io_adapter.h.
+ * Issue #689 (Blocker B2). */
+#include "wirelog/io/io_adapter.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog.c
+++ b/tests/standalone/test_standalone_wirelog.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_advanced.c
+++ b/tests/standalone/test_standalone_wirelog_advanced.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-advanced.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-advanced.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_easy.c
+++ b/tests/standalone/test_standalone_wirelog_easy.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-easy.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-easy.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_export.c
+++ b/tests/standalone/test_standalone_wirelog_export.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-export.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-export.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_ir.c
+++ b/tests/standalone/test_standalone_wirelog_ir.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-ir.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-ir.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_optimizer.c
+++ b/tests/standalone/test_standalone_wirelog_optimizer.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-optimizer.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-optimizer.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_parser.c
+++ b/tests/standalone/test_standalone_wirelog_parser.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-parser.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-parser.h"
+int
+main(void)
+{
+    return 0;
+}

--- a/tests/standalone/test_standalone_wirelog_types.c
+++ b/tests/standalone/test_standalone_wirelog_types.c
@@ -1,0 +1,13 @@
+/* Standalone-include compile gate for wirelog/wirelog-types.h.
+ * Issue #689 (Blocker B2): every public installed header must
+ * compile in isolation -- no hidden dependency on another header
+ * being included first.  Each .c file includes ONE public header
+ * and nothing else (modulo the stdlib that the header itself
+ * pulls).  Failure = the header has an internal-only forward
+ * declaration leaking into its visible API. */
+#include "wirelog/wirelog-types.h"
+int
+main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds the missing "standalone-include compile matrix" leg of
Blocker B2 (#689): every public installed header must compile in
isolation, with no hidden dependency on another header being
included first.

9 stub `.c` files under `tests/standalone/`, each `#include`s
exactly one public header and exits.  9 corresponding meson
`abi`-suite tests declared via a single `foreach` loop in
`tests/meson.build`.  The GCC / Clang / MSVC compiler matrix is
realised at the GitHub Actions level: each platform compiles
every stub via its native CC.

## Test plan

- [x] `meson test -C build --suite abi`: **17 OK / 0 FAIL**
      (9 new `standalone_include_*` tests included; existing 8
      preserved)
- [x] `meson test -C build`: **215 OK / 0 FAIL / 8 SKIP**
- [x] CHANGELOG `[Unreleased]` records the new gate
- [ ] CI: full default + abi + sanitizer + Build/(macOS,
      Ubuntu/clang, Ubuntu/gcc, Windows/MSVC) matrix

The 3-way SSoT verification (meson install_headers vs AGENTS.md
vs stable-release-plan §3.1) was already shipped via
`scripts/ci/check-public-header-surface.py`; this PR completes B2
by adding the standalone-compile leg.

Closes #689.