### PR TITLE
abi: annotate public prototypes with WIRELOG_PUBLIC (#733 K0)

### DIFF
--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -42,6 +42,8 @@
 #ifndef WIRELOG_ADVANCED_H
 #define WIRELOG_ADVANCED_H
 
+#include "wirelog/wirelog-export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -115,7 +117,7 @@ typedef enum {
  * backend selection, WIRELOG_ERR_INVALID_IR on plan generation failure,
  * WIRELOG_ERR_MEMORY on allocation failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_create(wirelog_program_t *program,
     wirelog_backend_kind_t backend, uint32_t num_workers,
     wirelog_session_t **out);
@@ -127,7 +129,7 @@ wirelog_session_create(wirelog_program_t *program,
  * Release the session and its plan.  Does NOT free the program passed
  * to wirelog_session_create(); the caller still owns it.
  */
-void
+WIRELOG_PUBLIC void
 wirelog_session_destroy(wirelog_session_t *session);
 
 /**
@@ -145,7 +147,7 @@ wirelog_session_destroy(wirelog_session_t *session);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_insert(wirelog_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
@@ -163,7 +165,7 @@ wirelog_session_insert(wirelog_session_t *session, const char *relation,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure or if
  * the backend does not support retraction.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_remove(wirelog_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
@@ -177,7 +179,7 @@ wirelog_session_remove(wirelog_session_t *session, const char *relation,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_step(wirelog_session_t *session);
 
 /**
@@ -193,7 +195,7 @@ wirelog_session_step(wirelog_session_t *session);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on NULL @session.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_set_delta_cb(wirelog_session_t *session,
     wirelog_on_delta_fn callback, void *user_data);
 
@@ -211,7 +213,7 @@ wirelog_session_set_delta_cb(wirelog_session_t *session,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_snapshot(wirelog_session_t *session,
     wirelog_on_tuple_fn callback,
     void *user_data);
@@ -235,7 +237,7 @@ wirelog_session_snapshot(wirelog_session_t *session,
  * temporarily frozen; WIRELOG_ERR_MEMORY on allocation failure;
  * WIRELOG_ERR_EXEC on invalid arguments or session-side errors.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_session_make_compound(wirelog_session_t *session, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
 

--- a/wirelog/wirelog-easy.h
+++ b/wirelog/wirelog-easy.h
@@ -24,6 +24,8 @@
 #ifndef WIRELOG_WL_EASY_H
 #define WIRELOG_WL_EASY_H
 
+#include "wirelog/wirelog-export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,7 +118,7 @@ typedef struct {
  *
  * Returns: WIRELOG_OK on success; *out set to NULL on any error.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_open_opts(const char *dl_src,
     const wirelog_easy_open_opts_t *opts,
     wirelog_easy_session_t **out);
@@ -146,7 +148,7 @@ wirelog_easy_open_opts(const char *dl_src,
  * WIRELOG_ERR_MEMORY on allocation failure, or another wirelog_error_t on
  * other failure modes.  *out is set to NULL on error.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out);
 
 /**
@@ -155,7 +157,7 @@ wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out);
  *
  * Release the session, plan, program, and intern table in the correct order.
  */
-void
+WIRELOG_PUBLIC void
 wirelog_easy_close(wirelog_easy_session_t *s);
 
 /**
@@ -173,7 +175,7 @@ wirelog_easy_close(wirelog_easy_session_t *s);
  *
  * Returns: non-negative ID on success, -1 on NULL args or internal error.
  */
-int64_t
+WIRELOG_PUBLIC int64_t
 wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym);
 
 /**
@@ -196,7 +198,7 @@ wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym);
  * WIRELOG_ERR_EXEC for invalid arguments, plan/session build failure,
  * side-relation registration failure, or insertion failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
 
@@ -212,8 +214,9 @@ wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
-wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
+WIRELOG_PUBLIC wirelog_error_t
+wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation,
+    const int64_t *row,
     uint32_t ncols);
 
 /**
@@ -227,8 +230,9 @@ wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
-wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
+WIRELOG_PUBLIC wirelog_error_t
+wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation,
+    const int64_t *row,
     uint32_t ncols);
 
 /**
@@ -241,7 +245,7 @@ wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
@@ -251,7 +255,7 @@ wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
@@ -262,7 +266,7 @@ wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_step(wirelog_easy_session_t *s);
 
 /**
@@ -279,7 +283,7 @@ wirelog_easy_step(wirelog_easy_session_t *s);
  * Returns: WIRELOG_OK on success, or a wirelog_error_t describing the
  * plan/session build failure.  A NULL @s returns WIRELOG_ERR_EXEC.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
     void *user_data);
 
@@ -297,8 +301,9 @@ wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
  * STRING column cannot be reverse-interned, the function calls abort() to
  * prevent silent corruption (NDEBUG-safe — assert() would compile out).
  */
-void
-wirelog_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
+WIRELOG_PUBLIC void
+wirelog_easy_print_delta(const char *relation, const int64_t *row,
+    uint32_t ncols,
     int32_t diff, void *user_data);
 
 /**
@@ -307,7 +312,7 @@ wirelog_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncol
  *
  * Print a small "=== @label ===" banner used by examples.
  */
-void
+WIRELOG_PUBLIC void
 wirelog_easy_banner(const char *label);
 
 /**
@@ -331,7 +336,7 @@ wirelog_easy_banner(const char *label);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-wirelog_error_t
+WIRELOG_PUBLIC wirelog_error_t
 wirelog_easy_snapshot(wirelog_easy_session_t *s, const char *relation,
     wirelog_on_tuple_fn cb,
     void *user_data);

--- a/wirelog/wirelog-ir.h
+++ b/wirelog/wirelog-ir.h
@@ -24,6 +24,8 @@
 #ifndef WIRELOG_IR_H
 #define WIRELOG_IR_H
 
+#include "wirelog/wirelog-export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -68,7 +70,7 @@ typedef enum {
  *
  * Returns: Node type
  */
-wirelog_ir_node_type_t
+WIRELOG_PUBLIC wirelog_ir_node_type_t
 wirelog_ir_node_get_type(const wirelog_ir_node_t *node);
 
 /**
@@ -79,7 +81,7 @@ wirelog_ir_node_get_type(const wirelog_ir_node_t *node);
  *
  * Returns: (transfer none): Relation name string
  */
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_ir_node_get_relation_name(const wirelog_ir_node_t *node);
 
 /**
@@ -90,7 +92,7 @@ wirelog_ir_node_get_relation_name(const wirelog_ir_node_t *node);
  *
  * Returns: Child count (0 for leaf nodes like SCAN)
  */
-uint32_t
+WIRELOG_PUBLIC uint32_t
 wirelog_ir_node_get_child_count(const wirelog_ir_node_t *node);
 
 /**
@@ -102,7 +104,7 @@ wirelog_ir_node_get_child_count(const wirelog_ir_node_t *node);
  *
  * Returns: (transfer none): Child node, or NULL if invalid index
  */
-const wirelog_ir_node_t *
+WIRELOG_PUBLIC const wirelog_ir_node_t *
 wirelog_ir_node_get_child(const wirelog_ir_node_t *node, uint32_t index);
 
 /* ======================================================================== */
@@ -116,7 +118,7 @@ wirelog_ir_node_get_child(const wirelog_ir_node_t *node, uint32_t index);
  *
  * Print an IR node (for debugging).
  */
-void
+WIRELOG_PUBLIC void
 wirelog_ir_node_print(const wirelog_ir_node_t *node, uint32_t indent);
 
 /**
@@ -127,7 +129,7 @@ wirelog_ir_node_print(const wirelog_ir_node_t *node, uint32_t indent);
  *
  * Returns: (transfer full): String representation (must be freed)
  */
-char *
+WIRELOG_PUBLIC char *
 wirelog_ir_node_to_string(const wirelog_ir_node_t *node);
 
 #ifdef __cplusplus

--- a/wirelog/wirelog-optimizer.h
+++ b/wirelog/wirelog-optimizer.h
@@ -24,6 +24,8 @@
 #ifndef WIRELOG_OPTIMIZER_H
 #define WIRELOG_OPTIMIZER_H
 
+#include "wirelog/wirelog-export.h"
+
 /*
  * Pull in wirelog.h for the foundational opaque types
  * (wirelog_program_t) and the wirelog_error_t enum.  The umbrella
@@ -100,7 +102,7 @@ typedef struct {
  *
  * Returns: Default configuration (all optimizations enabled)
  */
-wirelog_opt_config_t
+WIRELOG_PUBLIC wirelog_opt_config_t
 wirelog_optimizer_get_default_config(void);
 
 /* Note: wirelog_optimize() lives in wirelog.h — this header adds the
@@ -124,7 +126,7 @@ wirelog_optimizer_get_default_config(void);
  *
  * Returns: true on success, false on error
  */
-bool
+WIRELOG_PUBLIC bool
 wirelog_optimize_with_config(wirelog_program_t *program,
     const wirelog_opt_config_t *config,
     wirelog_error_t *error);
@@ -141,7 +143,7 @@ wirelog_optimize_with_config(wirelog_program_t *program,
  *
  * Returns: true on success, false on error
  */
-bool
+WIRELOG_PUBLIC bool
 wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
     wirelog_error_t *error);
 
@@ -158,7 +160,7 @@ wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
  *
  * Returns: true if stats were collected, false otherwise
  */
-bool
+WIRELOG_PUBLIC bool
 wirelog_optimizer_get_stats(const wirelog_program_t *program,
     wirelog_opt_stats_t *stats);
 
@@ -174,7 +176,7 @@ wirelog_optimizer_get_stats(const wirelog_program_t *program,
  * - Cost model decisions
  * - Join ordering rationale
  */
-void
+WIRELOG_PUBLIC void
 wirelog_optimizer_debug_print(const wirelog_program_t *program);
 
 /**
@@ -185,7 +187,7 @@ wirelog_optimizer_debug_print(const wirelog_program_t *program);
  *
  * Returns: Estimated cost (arbitrary units), or 0 if not available
  */
-uint64_t
+WIRELOG_PUBLIC uint64_t
 wirelog_optimizer_cost_estimate(const wirelog_program_t *program);
 
 #ifdef __cplusplus

--- a/wirelog/wirelog-parser.h
+++ b/wirelog/wirelog-parser.h
@@ -24,6 +24,8 @@
 #ifndef WIRELOG_PARSER_H
 #define WIRELOG_PARSER_H
 
+#include "wirelog/wirelog-export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,7 +65,7 @@ typedef struct {
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-wirelog_program_t *
+WIRELOG_PUBLIC wirelog_program_t *
 wirelog_parse_with_error_info(const char *filename,
     wirelog_parse_error_t *error_info);
 
@@ -79,7 +81,7 @@ wirelog_parse_with_error_info(const char *filename,
  *
  * Returns: Number of strata (always >= 1)
  */
-uint32_t
+WIRELOG_PUBLIC uint32_t
 wirelog_program_get_stratum_count(const wirelog_program_t *program);
 
 /**
@@ -91,7 +93,7 @@ wirelog_program_get_stratum_count(const wirelog_program_t *program);
  *
  * Returns: (transfer none): Stratum info, or NULL if invalid ID
  */
-const wirelog_stratum_t *
+WIRELOG_PUBLIC const wirelog_stratum_t *
 wirelog_program_get_stratum(const wirelog_program_t *program,
     uint32_t stratum_id);
 
@@ -103,7 +105,7 @@ wirelog_program_get_stratum(const wirelog_program_t *program,
  *
  * Returns: Total rule count
  */
-uint32_t
+WIRELOG_PUBLIC uint32_t
 wirelog_program_get_rule_count(const wirelog_program_t *program);
 
 /**
@@ -115,7 +117,7 @@ wirelog_program_get_rule_count(const wirelog_program_t *program);
  *
  * Returns: (transfer none): Schema info, or NULL if not found
  */
-const wirelog_schema_t *
+WIRELOG_PUBLIC const wirelog_schema_t *
 wirelog_program_get_schema(const wirelog_program_t *program,
     const char *relation_name);
 
@@ -127,7 +129,7 @@ wirelog_program_get_schema(const wirelog_program_t *program,
  *
  * Returns: true if stratified, false otherwise
  */
-bool
+WIRELOG_PUBLIC bool
 wirelog_program_is_stratified(const wirelog_program_t *program);
 
 /* Note: wirelog_program_free() lives in wirelog.h. */

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -24,6 +24,8 @@
 #ifndef WIRELOG_TYPES_H
 #define WIRELOG_TYPES_H
 
+#include "wirelog/wirelog-export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -109,11 +111,11 @@ typedef enum {
 /* Operator String Conversion                                               */
 /* ======================================================================== */
 
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_cmp_op_str(wirelog_cmp_op_t op);
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_arith_op_str(wirelog_arith_op_t op);
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_agg_fn_str(wirelog_agg_fn_t fn);
 
 /* ======================================================================== */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -41,6 +41,7 @@
 extern "C" {
 #endif
 
+#include "wirelog/wirelog-export.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -122,7 +123,7 @@ typedef enum {
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-wirelog_program_t *
+WIRELOG_PUBLIC wirelog_program_t *
 wirelog_parse(const char *filename, wirelog_error_t *error);
 
 /**
@@ -134,7 +135,7 @@ wirelog_parse(const char *filename, wirelog_error_t *error);
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-wirelog_program_t *
+WIRELOG_PUBLIC wirelog_program_t *
 wirelog_parse_string(const char *program_text, wirelog_error_t *error);
 
 /**
@@ -143,7 +144,7 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error);
  *
  * Free a parsed program and all associated resources.
  */
-void
+WIRELOG_PUBLIC void
 wirelog_program_free(wirelog_program_t *program);
 
 /* ======================================================================== */
@@ -164,7 +165,7 @@ typedef struct wl_intern wirelog_intern_t;
  * @param prog  Compiled program
  * @return Intern table (owned by program, do not free), or NULL
  */
-const wirelog_intern_t *
+WIRELOG_PUBLIC const wirelog_intern_t *
 wirelog_program_get_intern(const wirelog_program_t *prog);
 
 /* ======================================================================== */
@@ -184,7 +185,7 @@ wirelog_program_get_intern(const wirelog_program_t *prog);
  * @param num_cols   Output: number of columns per tuple
  * @return 0 on success, -1 on error (unknown relation), 1 if no facts
  */
-int
+WIRELOG_PUBLIC int
 wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
     int64_t **data, uint32_t *num_rows,
     uint32_t *num_cols);
@@ -201,7 +202,7 @@ wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
  * @param worker  DD worker handle to load facts into
  * @return 0 on success, -1 on error (NULL args or EDB load failure)
  */
-int
+WIRELOG_PUBLIC int
 wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
 
 /**
@@ -215,74 +216,74 @@ wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
  * @param worker  DD worker handle to load facts into
  * @return 0 on success, -1 on error (NULL args, missing file, parse error)
  */
-int
+WIRELOG_PUBLIC int
 wirelog_load_input_files(const wirelog_program_t *prog, void *worker);
 
 /* ======================================================================== */
 /* Optimizer API                                                            */
 /* ======================================================================== */
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_optimize(wirelog_program_t *program, wirelog_error_t *error);
 
-void
+WIRELOG_PUBLIC void
 wirelog_optimizer_debug(const wirelog_program_t *program);
 
 /* ======================================================================== */
 /* Executor API                                                             */
 /* ======================================================================== */
 
-wirelog_executor_t *
+WIRELOG_PUBLIC wirelog_executor_t *
 wirelog_executor_create(wirelog_program_t *program, wirelog_error_t *error);
 
-void
+WIRELOG_PUBLIC void
 wirelog_executor_free(wirelog_executor_t *executor);
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_load_facts_from_csv(wirelog_executor_t *executor,
     const char *relation_name, const char *csv_file,
     wirelog_error_t *error);
 
-wirelog_result_t *
+WIRELOG_PUBLIC wirelog_result_t *
 wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error);
 
 /* ======================================================================== */
 /* Result API                                                               */
 /* ======================================================================== */
 
-const void *
+WIRELOG_PUBLIC const void *
 wirelog_result_get_relation(const wirelog_result_t *result,
     const char *relation_name);
 
-uint64_t
+WIRELOG_PUBLIC uint64_t
 wirelog_result_relation_cardinality(const wirelog_result_t *result,
     const char *relation_name);
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_result_write_csv(const wirelog_result_t *result,
     const char *relation_name, const char *output_file,
     wirelog_error_t *error);
 
-void
+WIRELOG_PUBLIC void
 wirelog_result_free(wirelog_result_t *result);
 
 /* ======================================================================== */
 /* Utility API                                                              */
 /* ======================================================================== */
 
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_version_string(void);
 
-const char *
+WIRELOG_PUBLIC const char *
 wirelog_error_string(wirelog_error_t error);
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_config_embedded(void);
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_config_ipc(void);
 
-bool
+WIRELOG_PUBLIC bool
 wirelog_config_threads(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

K0 of #733 SONAME + symbol-visibility audit.  Pre-flight for the
visibility=hidden flip in K1: every public function prototype on
the 8 installed headers must carry `WIRELOG_PUBLIC` so it stays
exported when default visibility flips to hidden.

Coverage was 0% on 7 of 8 public headers (only `wirelog/io/io_adapter.h`
was annotated, via the v0.30 #446 / v0.40 #762 work).

## Changes

- 65 prototypes annotated with `WIRELOG_PUBLIC` across 7 headers
  (`wirelog.h` 22, `wirelog-types.h` 3, `wirelog-parser.h` 6,
  `wirelog-ir.h` 6, `wirelog-optimizer.h` 6, `wirelog-easy.h` 14,
  `wirelog-advanced.h` 8).
- 6 headers gain explicit `#include "wirelog/wirelog-export.h"`
  immediately after the include guard so the macro resolves at
  the point of declaration.
- `wirelog/wirelog.h` moves its existing `wirelog-export.h` include
  from line 300 (after declarations) to line 44 (before them).

## Test plan

- [x] `meson compile -C build`: clean (no new warnings)
- [x] `meson test -C build`: **225 OK / 0 FAIL / 8 SKIP**
- [x] `nm -D --defined-only build/libwirelog.so | wc -l` unchanged
      at ~348 (byte-identical .so today; visibility flip is K1)
- [x] `grep -rE 'WIRELOG_(PUBLIC|API)' wirelog/*.h wirelog/io/*.h`
      covers every `wirelog_*` function prototype
- [ ] CI: full default + abi + sanitizer matrix on Linux/macOS/Windows

Part of #733.  K1 (visibility=hidden + SONAME) and K2 (CI gate)
follow once K0 lands.