### PR TITLE
abi: hidden symbol visibility + SOVERSION=1 for libwirelog (#733 K1)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -272,7 +272,22 @@ wirelog_lib = library(
   c_args: ['-DWIRELOG_BUILDING'],
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: true,
+  # SOVERSION ('soversion') is decoupled from project_version so the
+  # 1.0 ABI commitment is fixed at SOVERSION=1 ahead of project_version
+  # actually reaching 1.0.0.  Linux: libwirelog.so.1 -> libwirelog.so.1.0.0.
+  # macOS: compatibility_version=1, current_version=1.0.0.
+  # Windows: meson auto-derives wirelog-1.dll from version major.
+  # See #733.
   version: project_version,
+  soversion: '1',
+  darwin_versions: ['1', '1.0.0'],
+  # Symbol-visibility default: hidden.  Every public-API function on the
+  # 9 installed headers carries WIRELOG_PUBLIC (= visibility("default")
+  # / dllexport) per #733 K0.  Internal symbols (wl_*, col_*, arr_*)
+  # are now hidden from the dynamic-symbol table; consumers who relied
+  # on resolving them through libwirelog.so must rebuild against the
+  # public surface.  See #733.
+  gnu_symbol_visibility: 'hidden',
 )
 
 #Static library(optional)

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -62,15 +62,20 @@ typedef struct wirelog_io_ctx wirelog_io_ctx_t;
 /* Context Accessors (implemented in #453)                                  */
 /* ======================================================================== */
 
-const char *wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx);
-uint32_t    wirelog_io_ctx_num_cols(const wirelog_io_ctx_t *ctx);
-wirelog_column_type_t wirelog_io_ctx_col_type(const wirelog_io_ctx_t *ctx,
-    uint32_t col);
-const char *wirelog_io_ctx_param(const wirelog_io_ctx_t *ctx, const char *key);
-int64_t     wirelog_io_ctx_intern_string(wirelog_io_ctx_t *ctx,
-    const char *utf8);
-void       *wirelog_io_ctx_platform(const wirelog_io_ctx_t *ctx);
-int         wirelog_io_ctx_set_platform(wirelog_io_ctx_t *ctx, void *ptr);
+WIRELOG_PUBLIC const char *
+wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx);
+WIRELOG_PUBLIC uint32_t
+wirelog_io_ctx_num_cols(const wirelog_io_ctx_t *ctx);
+WIRELOG_PUBLIC wirelog_column_type_t
+wirelog_io_ctx_col_type(const wirelog_io_ctx_t *ctx, uint32_t col);
+WIRELOG_PUBLIC const char *
+wirelog_io_ctx_param(const wirelog_io_ctx_t *ctx, const char *key);
+WIRELOG_PUBLIC int64_t
+wirelog_io_ctx_intern_string(wirelog_io_ctx_t *ctx, const char *utf8);
+WIRELOG_PUBLIC void *
+wirelog_io_ctx_platform(const wirelog_io_ctx_t *ctx);
+WIRELOG_PUBLIC int
+wirelog_io_ctx_set_platform(wirelog_io_ctx_t *ctx, void *ptr);
 
 /* ======================================================================== */
 /* Adapter VTable                                                           */


### PR DESCRIPTION
## Summary

K1 of #733 SONAME + symbol-visibility audit.  Builds on K0
(merged via #773 which annotated every public prototype with
`WIRELOG_PUBLIC`).

Three meson `library()` args added:

- `soversion: '1'` (decoupled from `project_version` so the 1.0
  ABI commitment is fixed at SOVERSION=1)
- `darwin_versions: ['1', '1.0.0']` (explicit
  compatibility_version=1, current_version=1.0.0 on macOS)
- `gnu_symbol_visibility: 'hidden'` (turns `-fvisibility=hidden`
  on for the shared-library link)

## Result

| Metric | Before | After |
|---|---|---|
| `readelf -d ... \| grep SONAME` | `libwirelog.so.0` | **`libwirelog.so.1`** |
| Exported `T` symbols | 348 | **46** |
| `\bwirelog_` exports | 56 | 46 |
| Internal-prefix exports (`wl_*`, `col_*`, `arr_*`, etc.) | ~292 | **0** |

All 46 visible symbols match `\bwirelog_*` — zero internal-
prefix leaks.

## Test plan

- [x] `meson test -C build`: **225 OK / 0 FAIL / 8 SKIP**
- [x] SONAME verified `libwirelog.so.1`
- [x] Dynamic-symbol table contains only `wirelog_*` (46 entries)
- [x] Tests still build (object-source linkage; no `link_with:
      wirelog_lib`)
- [ ] CI: full default + abi + sanitizer matrix on
      Linux/macOS/Windows

K2 follow-up (next PR) lands an abi-suite gate that pins the 46
exported symbols against an allowlist, preventing future
visibility-default leaks.

Part of #733.  Sequenced after #773 (K0).