### PR TITLE
[codex] Support static Windows consumers

### DIFF
--- a/wirelog/wirelog-export.h
+++ b/wirelog/wirelog-export.h
@@ -10,7 +10,9 @@
 #define WIRELOG_EXPORT_H
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-  #ifdef WIRELOG_BUILDING
+  #if defined(WIRELOG_STATIC)
+    #define WIRELOG_PUBLIC
+  #elif defined(WIRELOG_BUILDING)
     #define WIRELOG_PUBLIC __declspec(dllexport)
   #else
     #define WIRELOG_PUBLIC __declspec(dllimport)


### PR DESCRIPTION
## Summary
- Add a `WIRELOG_STATIC` visibility mode so static Windows consumers do not compile public API calls as `dllimport`.
- Keep existing `WIRELOG_BUILDING` DLL export behavior unchanged.

## Validation
- Consumed by the wyrelog Windows CI path that links Wirelog as a static `.a` library.
