### PR TITLE
ci: changelog format gate (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **CHANGELOG format CI gate** (#471):
+  `scripts/ci/check-changelog-format.py` (registered as
+  `meson test --suite abi:changelog_format`) asserts the
+  `[Unreleased]` section follows the Keep-a-Changelog conventions
+  documented in `CONTRIBUTING.md`: every bullet sits under one of
+  the allowed categories (`Added`, `Changed`, `Deprecated`,
+  `Removed`, `Fixed`, `Performance`, `Security`, `Documentation`)
+  and carries at least one `#N` PR or issue reference.  Versioned
+  section headers must use `## [X.Y.Z] - YYYY-MM-DD`.  CONTRIBUTING.md
+  gains a "Changelog Conventions" section documenting the format,
+  cutover procedure, and the freeze rule for `release-1.x`
+  (cross-link with #747 B18).
 - **ABI symbol allowlist gate (#733 K2)**: `meson test --suite abi:abi_symbols`
   diffs `nm -D --defined-only build/libwirelog.so | awk '$2=="T"'`
   against `abi/libwirelog-1.0.symbols`.  53 entries seeded from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,80 @@ See [docs/LINTING.md](docs/LINTING.md) for complete linting documentation, check
 * Write clear, self-documenting code.
 * Add comments for complex logic or design decisions.
 * When adding documentation or updating existing texts, adhere to Markdown formatting.
+
+## Changelog Conventions
+
+`CHANGELOG.md` follows a Keep-a-Changelog-style format with a project-
+specific format gate enforced by
+`scripts/ci/check-changelog-format.py` (registered as
+`meson test --suite abi:changelog_format`).  Every PR that introduces
+user-visible behaviour MUST add a bullet to the `[Unreleased]` section
+under the appropriate category, with a reference to the PR or
+originating issue.
+
+### Allowed categories
+
+Each `[Unreleased]` bullet sits under exactly one of:
+
+* `### Added` — new public-facing functionality
+* `### Changed` — changes to existing behaviour (incl. ABI breaks)
+* `### Deprecated` — soon-to-be-removed features (warning fired)
+* `### Removed` — features removed in this release
+* `### Fixed` — bug fixes
+* `### Performance` — measurable performance changes (gated by
+  `meson test --suite perf`)
+* `### Security` — vulnerability fixes (CVE refs encouraged)
+* `### Documentation` — doc-only changes that nonetheless affect a
+  user-visible contract
+
+### Required content per bullet
+
+Every bullet MUST include at least one PR or issue reference (`#N`).
+The format gate trips when an `[Unreleased]` bullet lacks any `#N`
+match.
+
+Example (good):
+
+```md
+### Added
+
+- **Foo widget** (#123): introduces the `wirelog_foo_*` API for
+  bar-style integration.  See `docs/FOO.md` for usage.
+```
+
+Example (will fail the gate):
+
+```md
+### Added
+
+- Foo widget: introduces the wirelog_foo_* API
+```
+
+### Cutover procedure
+
+When cutting a release tag (`vX.Y.Z`):
+
+1. Move the entire `[Unreleased]` block under a new heading
+   `## [X.Y.Z] - YYYY-MM-DD`.  The format gate enforces the date
+   format on versioned sections.
+2. Reset `[Unreleased]` to the placeholder shape:
+   ```md
+   ## [Unreleased]
+
+   ### Added
+
+   ### Changed
+
+   ...
+   ```
+   Empty category bullets are fine; the gate only fails on bullets
+   that lack a #N reference, not on empty categories.
+3. Open the release PR; CI will refuse to merge if the gate fails.
+
+### Freeze rule (post-release-1.x cut)
+
+After `release-1.x` is cut for v1.0 RC1 (#685), the `[Unreleased]`
+section on `release-1.x` is **frozen** — every hotfix landing on
+`release-1.x` between rc1 cut and GA tag updates the versioned
+section, not `[Unreleased]`.  This is mechanically enforced by
+the per-branch CI rule landed under #747 (B18).

--- a/scripts/ci/check-changelog-format.py
+++ b/scripts/ci/check-changelog-format.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""check-changelog-format.py - Issue #471 CHANGELOG format gate.
+
+Asserts that `CHANGELOG.md`'s `[Unreleased]` section conforms to the
+project's Keep-a-Changelog-style conventions documented in
+`CONTRIBUTING.md`:
+
+  - Every bullet entry sits under one of the allowed category headings:
+      Added, Changed, Fixed, Performance, Documentation, Removed,
+      Security
+  - Every bullet entry references at least one PR or issue
+    (`#N` token where N is a positive integer).
+  - Every released section header has shape
+    `## [X.Y.Z] - YYYY-MM-DD`.
+  - The file starts with `# Changelog` and contains exactly one
+    `## [Unreleased]` heading.
+
+Run as a lint-stage script under `meson test --suite abi`.
+
+Usage:
+    scripts/ci/check-changelog-format.py [path/to/CHANGELOG.md]
+
+If no path is given, defaults to `<repo_root>/CHANGELOG.md`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+ALLOWED_CATEGORIES = {
+    "Added",
+    "Changed",
+    "Fixed",
+    "Performance",
+    "Documentation",
+    "Removed",
+    "Security",
+    "Deprecated",
+}
+
+# Category heading: `### <Category>`
+CATEGORY_RE = re.compile(r"^###\s+(\S+)\s*$")
+# Bullet entry start: `-` or `*`, possibly indented
+BULLET_RE = re.compile(r"^\s*[-*]\s+\S")
+# Section header: `## [...] - YYYY-MM-DD` or `## [Unreleased]`
+SECTION_RE = re.compile(r"^##\s+\[([^\]]+)\](?:\s*-\s*(\d{4}-\d{2}-\d{2}))?\s*$")
+# Issue / PR reference: `#N` token
+REF_RE = re.compile(r"#\d+")
+
+
+class Diag:
+    def __init__(self, path: pathlib.Path) -> None:
+        self.path = path
+        self.errors: list[str] = []
+
+    def err(self, lineno: int, msg: str) -> None:
+        self.errors.append(f"{self.path}:{lineno}: {msg}")
+
+
+def main() -> int:
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    path = pathlib.Path(arg) if arg else (REPO_ROOT / "CHANGELOG.md")
+    if not path.exists():
+        print(
+            f"check-changelog-format: FAIL: {path} does not exist",
+            file=sys.stderr,
+        )
+        return 1
+
+    text = path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+    diag = Diag(path)
+
+    if not lines or not lines[0].startswith("# Changelog"):
+        diag.err(1, "first line must be `# Changelog`")
+
+    in_unreleased = False
+    saw_unreleased = False
+    current_category: str | None = None
+    # Accumulate the current bullet across continuation lines so the
+    # PR/issue-reference check sees the whole entry.
+    bullet_buf: list[str] = []
+    bullet_start_lineno = 0
+
+    def flush_bullet() -> None:
+        nonlocal bullet_buf, bullet_start_lineno
+        if not bullet_buf:
+            return
+        full = " ".join(bullet_buf)
+        if not REF_RE.search(full):
+            diag.err(
+                bullet_start_lineno,
+                "[Unreleased] entry has no #N or PR-#N reference: "
+                f"{full[:80]!r}",
+            )
+        bullet_buf = []
+        bullet_start_lineno = 0
+
+    for i, line in enumerate(lines, start=1):
+        m_section = SECTION_RE.match(line)
+        if m_section:
+            flush_bullet()
+            tag, date = m_section.group(1), m_section.group(2)
+            if tag == "Unreleased":
+                if saw_unreleased:
+                    diag.err(i, "duplicate [Unreleased] section")
+                saw_unreleased = True
+                in_unreleased = True
+                current_category = None
+            else:
+                in_unreleased = False
+                # Versioned section header must have a date.
+                if not date:
+                    diag.err(
+                        i,
+                        f"versioned section [{tag}] missing - YYYY-MM-DD date",
+                    )
+            continue
+
+        if not in_unreleased:
+            continue
+
+        m_cat = CATEGORY_RE.match(line)
+        if m_cat:
+            flush_bullet()
+            cat = m_cat.group(1)
+            if cat not in ALLOWED_CATEGORIES:
+                diag.err(
+                    i,
+                    f"unknown category {cat!r}; "
+                    f"allowed: {sorted(ALLOWED_CATEGORIES)}",
+                )
+            current_category = cat
+            continue
+
+        if BULLET_RE.match(line):
+            flush_bullet()
+            if current_category is None:
+                diag.err(
+                    i,
+                    "bullet outside any category heading "
+                    f"(must follow ### Added|Changed|...): "
+                    f"{line.strip()[:80]!r}",
+                )
+            bullet_buf = [line.strip().lstrip("-*").strip()]
+            bullet_start_lineno = i
+            continue
+
+        # Continuation line: append to current bullet if non-empty.
+        if bullet_buf and line.strip():
+            bullet_buf.append(line.strip())
+        elif not line.strip() and bullet_buf:
+            # Blank line ends a bullet.
+            flush_bullet()
+
+    flush_bullet()
+
+    if not saw_unreleased:
+        diag.err(0, "missing `## [Unreleased]` section")
+
+    if diag.errors:
+        print(
+            f"check-changelog-format: FAIL ({len(diag.errors)} issues)",
+            file=sys.stderr,
+        )
+        for e in diag.errors:
+            print(f"  {e}", file=sys.stderr)
+        print(
+            "\nFix per CONTRIBUTING.md > Changelog Conventions:\n"
+            f"  - categories: {sorted(ALLOWED_CATEGORIES)}\n"
+            "  - every bullet must reference a PR or issue "
+            "(`#N`).\n"
+            "  - versioned sections need `## [X.Y.Z] - YYYY-MM-DD`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check-changelog-format: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -414,6 +414,15 @@ test('public_prefix', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-prefix.py'],
      suite: 'abi')
 
+# Issue #471: CHANGELOG format gate.  Asserts the [Unreleased] section
+# follows Keep-a-Changelog conventions documented in CONTRIBUTING.md
+# (categories, PR/issue refs, dated versioned sections).  Static text
+# scan; no build-tree input required.
+test('changelog_format', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-changelog-format.py',
+            meson.project_source_root() / 'CHANGELOG.md'],
+     suite: 'abi')
+
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss


### PR DESCRIPTION
## Summary

Closes #471 (narrowed scope: CHANGELOG infrastructure).
Adds `scripts/ci/check-changelog-format.py` registered as
`meson test --suite abi:changelog_format`.

The gate parses `CHANGELOG.md` and asserts the `[Unreleased]`
section follows the project's Keep-a-Changelog conventions:

- Every bullet sits under one of the allowed categories
  (Added / Changed / Deprecated / Removed / Fixed / Performance /
  Security / Documentation).
- Every bullet carries at least one `#N` PR or issue reference.
- Versioned section headers use `## [X.Y.Z] - YYYY-MM-DD`.

`CONTRIBUTING.md` gains a "Changelog Conventions" section
documenting the format, the cutover procedure, and the
release-1.x freeze rule (cross-link #747 B18).

## Test plan

- [x] `./scripts/ci/check-changelog-format.py`: OK on current main
- [x] `meson test -C build wirelog:changelog_format`: **1 OK / 0 FAIL**
- [x] Synthetic violation reproduction: bullet without `#N` inside
      `[Unreleased]/### Added` trips the gate with the expected
      diagnostic
- [x] Synthetic violation outside `[Unreleased]` (frozen versioned
      section): correctly skipped
- [ ] CI: full default + abi + sanitizer matrix

Closes #471.  Part of #681 v0.41 ABI Infrastructure.