### PR TITLE
docs(release): release process + release-template gate (#772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Release-process documentation + release-template CI gate** (#772):
+  `docs/RELEASE_PROCESS.md` defines the canonical procedure for cutting
+  a release tag, including the 9-section release-note template and the
+  publication procedure (release PR, tag, GitHub Releases body, signed
+  artefacts).  Two helper scripts land alongside:
+  `scripts/release/extract-changelog-section.sh` (emits one CHANGELOG
+  versioned section to stdout, used by `gh release create
+  --notes-file`), and `scripts/ci/check-release-template.sh`
+  (registered as `meson test --suite abi:release_template`) which
+  diffs the published GitHub Releases body for the current tag against
+  the corresponding CHANGELOG section.  The gate SKIPs outside
+  tag-triggered CI context (PR builds, main branch) and enforces
+  inside the release-tag.yml workflow (#749 B19).
 - **CHANGELOG format CI gate** (#471):
   `scripts/ci/check-changelog-format.py` (registered as
   `meson test --suite abi:changelog_format`) asserts the

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,194 @@
+# wirelog Release Process
+
+This document is the **canonical procedure for cutting a wirelog
+release tag and publishing the release notes that accompany it**.
+It is the operational counterpart of:
+
+- `CONTRIBUTING.md` — Changelog Conventions (the per-PR rules).
+- `CHANGELOG.md` — the source-of-truth changelog.
+- `docs/MIGRATION.md` — version-to-version migration recipes.
+- `docs/SECURITY_MODEL.md` — vulnerability-disclosure policy.
+- `stable-release-plan.md` — long-form roadmap to v1.0 GA.
+
+It is the deliverable for issue **#772** (release-note template +
+publication procedure) and is referenced by **#687** (v1.0.0 GA
+epic) which lists "CHANGELOG `[1.0.0]` section merged" as an exit
+condition without specifying the publication side.
+
+---
+
+## 1. Release-note template
+
+Every release tag carries a release note authored from this
+template.  The note is published in **two places** that must agree:
+
+1. The versioned section of `CHANGELOG.md` (under
+   `## [X.Y.Z] - YYYY-MM-DD`).
+2. The GitHub Releases body for the corresponding tag.
+
+The CI gate `scripts/ci/check-release-template.sh` (registered as
+`meson test --suite abi:release_template`) diffs the two sources
+when a published release exists for the tag at HEAD; it SKIPs
+cleanly on PR builds and on tags whose release does not yet
+exist.
+
+### Template (Markdown)
+
+```md
+# wirelog X.Y.Z (YYYY-MM-DD)
+
+## Headline
+
+<1-3 sentences summarising what this release brings to users.>
+
+## Highlights
+
+- <Bullet 1>
+- <Bullet 2>
+- <Bullet 3>
+
+## Changes
+
+### Added
+- <items from CHANGELOG[X.Y.Z]/Added>
+
+### Changed
+- <items from CHANGELOG[X.Y.Z]/Changed>
+
+### Deprecated
+- <items from CHANGELOG[X.Y.Z]/Deprecated, if any>
+
+### Removed
+- <items from CHANGELOG[X.Y.Z]/Removed, if any>
+
+### Fixed
+- <items from CHANGELOG[X.Y.Z]/Fixed>
+
+### Performance
+- <items from CHANGELOG[X.Y.Z]/Performance, if any>
+
+### Security
+- <items from CHANGELOG[X.Y.Z]/Security, if any>
+
+### Documentation
+- <items from CHANGELOG[X.Y.Z]/Documentation, if any>
+
+## Migration
+
+See [`docs/MIGRATION.md`](../docs/MIGRATION.md) section
+`X.Y → X.Y'.0` for upgrade recipes.
+
+## Performance
+
+See [`docs/PERFORMANCE.md`](../docs/PERFORMANCE.md) for the
+release-pinned benchmark snapshot.
+
+## Security
+
+<Inline CVE refs (if any), or "No advisories.">
+
+## Verification artefacts
+
+- **Signed tag**: `vX.Y.Z` (GPG fingerprint <maintainer>;
+  `git verify-tag` clean).
+- **Tarball**: `wirelog-X.Y.Z.tar.gz` (SHA256 / BLAKE3
+  checksums committed alongside).
+- **SBOM**: `wirelog-X.Y.Z.spdx.json` (SPDX 2.3) +
+  `wirelog-X.Y.Z.cdx.json` (CycloneDX 1.5).
+- **ABI manifest**: `abi/libwirelog-1.0.symbols` +
+  `abi/libwirelog-1.0.abi.json` (libabigail).
+
+## Acknowledgments
+
+<Optional: contributors of note for this release.>
+```
+
+---
+
+## 2. Publication procedure
+
+When cutting a release tag:
+
+1. **Open a release PR** that:
+   - Moves the entire `[Unreleased]` block in `CHANGELOG.md`
+     under a new heading `## [X.Y.Z] - YYYY-MM-DD`.
+   - Resets `[Unreleased]` to the placeholder shape (empty
+     category headings).
+   - Bumps `project_version` in `meson.build`.
+   - Updates `docs/MIGRATION.md` with any release-specific
+     entries (per-issue MIGRATION entries land alongside their
+     PRs; the release PR consolidates).
+2. **Wait for the full CI matrix** to pass on the release PR
+   (default + `--suite abi` + `--suite asan` + `--suite tsan`
+   + `--suite perf` on a `WIRELOG_PERF_REQUIRE=1` runner per
+   #695 B8).
+3. **Merge** the release PR via rebase (no squash, no merge
+   commit; matches project convention).
+4. **Tag** on `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   git tag -s vX.Y.Z -m "wirelog X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+   The `release-tag.yml` workflow (#749 B19, when shipped) re-runs
+   the full CI matrix on the tagged commit and produces the
+   verification artefacts (signed tarball, checksums, SBOM, ABI
+   manifest, SLSA provenance attestation).
+5. **Author the GitHub Release**:
+   ```bash
+   gh release create vX.Y.Z \
+       --title "wirelog X.Y.Z" \
+       --notes-file <(./scripts/release/extract-changelog-section.sh X.Y.Z)
+   ```
+   The release body MUST be the verbatim CHANGELOG section for
+   `[X.Y.Z]`.  The CI gate enforces equality.
+6. **Attach release artefacts** produced by the at-tag workflow:
+   tarball + checksums + SBOM + ABI manifest + provenance file.
+
+---
+
+## 3. Branch-protection and freeze rules
+
+### After release-1.x cut (post-#685 v1.0 RC1)
+
+- The `[Unreleased]` section in `CHANGELOG.md` is **frozen** on
+  `release-1.x` between rc1 and GA.  Hotfixes update the `[1.0.0]`
+  versioned section, not `[Unreleased]`.  Mechanically enforced
+  by the per-branch CI rule under #747 B18.
+
+### Branch-protection (release-1.x)
+
+Per #746 B17, `release-1.x` requires:
+
+- At least one CODEOWNER review.
+- Required status checks (default + abi + asan + tsan + perf).
+- Linear history (no force-push, no merge commits).
+- Signed commits (GPG verified).
+- Tag protection on `v1.x.*`.
+
+---
+
+## 4. Per-release security review
+
+- License/export-control reclassification per
+  `docs/SECURITY_MODEL.md` — see #715 (subprojects pin
+  verification) and the per-release checklist tracked under
+  v1.0.0 GA.
+- CVE intake / PSIRT activation per #698 B11.
+- Subprojects pin SHA256 verification at release time.
+
+---
+
+## 5. Internal references
+
+- #687 — v1.0.0 GA epic (this document is the publication side
+  of its "CHANGELOG [1.0.0] section merged" exit condition).
+- #471 — CHANGELOG infrastructure (format gate; landed via
+  #777).
+- #772 — this document.
+- #745 — `docs/MIGRATION.md` 0.30 → 1.0 entry.
+- #749 (B19) — at-tag CI re-verification workflow.
+- #750 — GPG + cosign-keyless signing pipeline.
+- #751 — tarball + SHA256 + BLAKE3 + provenance attestation.
+- #744 — SBOM automation (SPDX + CycloneDX).
+- `stable-release-plan.md` §12.8 — GA exit conditions.

--- a/scripts/ci/check-release-template.sh
+++ b/scripts/ci/check-release-template.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-release-template.sh - Issue #772 release-template gate.
+#
+# Asserts the GitHub Releases body for the current tag matches the
+# corresponding section of CHANGELOG.md byte-for-byte (modulo
+# trailing whitespace), per docs/RELEASE_PROCESS.md section 1.
+#
+# Intended invocation contexts:
+#
+#   - PR builds              : SKIP (no tag, no release).
+#   - Untagged main builds   : SKIP.
+#   - Tag-triggered workflow : enforce.  The release-tag.yml workflow
+#                              (#749 B19) calls this script after the
+#                              full CI matrix passes.
+#
+# Usage:
+#   scripts/ci/check-release-template.sh
+#
+# Exit codes:
+#   0 - OK or SKIP (with diagnostic to stderr).
+#   1 - mismatch between CHANGELOG[X.Y.Z] and the published GitHub
+#       Release body, or other hard failure.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+# Detect tag context.  We only enforce when HEAD is exactly a vX.Y.Z
+# tag.  Outside that context, SKIP cleanly so PR builds and main-
+# branch CI do not flake on this gate.
+if ! tag=$(git -C "$repo_root" describe --tags --exact-match 2>/dev/null); then
+    echo "check-release-template: SKIP: HEAD is not a release tag" >&2
+    exit 0
+fi
+
+case "$tag" in
+    v[0-9]*)
+        version="${tag#v}"
+        ;;
+    *)
+        echo "check-release-template: SKIP: tag '$tag' is not a vX.Y.Z release tag" >&2
+        exit 0
+        ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "check-release-template: SKIP: gh CLI not available" >&2
+    exit 0
+fi
+
+# Fetch the published release body, if any.  Absent release => SKIP.
+release_body=$(gh release view "$tag" --json body --jq .body 2>/dev/null || true)
+if [ -z "$release_body" ]; then
+    echo "check-release-template: SKIP: no published GitHub Release for $tag yet" >&2
+    exit 0
+fi
+
+# Extract the matching CHANGELOG section.
+changelog_section=$("$script_dir/../release/extract-changelog-section.sh" \
+    "$version" "$repo_root/CHANGELOG.md")
+if [ -z "$changelog_section" ]; then
+    echo "check-release-template: FAIL: no CHANGELOG section for [$version]" >&2
+    echo "  Update CHANGELOG.md with '## [$version] - YYYY-MM-DD' and reset" >&2
+    echo "  [Unreleased] per docs/RELEASE_PROCESS.md section 2." >&2
+    exit 1
+fi
+
+# Normalize trailing whitespace before diffing.
+norm() {
+    sed -e 's/[[:space:]]*$//' "$1"
+}
+gh_file=$(mktemp)
+cl_file=$(mktemp)
+trap 'rm -f "$gh_file" "$cl_file"' EXIT
+printf '%s\n' "$release_body"   > "$gh_file"
+printf '%s\n' "$changelog_section" > "$cl_file"
+
+if diff -q <(norm "$gh_file") <(norm "$cl_file") >/dev/null 2>&1; then
+    echo "check-release-template: OK; GitHub Release body matches CHANGELOG[$version]"
+    exit 0
+fi
+
+echo "check-release-template: FAIL: GitHub Release body for $tag differs from CHANGELOG[$version]" >&2
+echo "" >&2
+diff <(norm "$gh_file") <(norm "$cl_file") >&2 || true
+echo "" >&2
+echo "To fix: regenerate the release body from CHANGELOG via" >&2
+echo "" >&2
+echo "  gh release edit $tag \\" >&2
+echo "      --notes-file <($script_dir/../release/extract-changelog-section.sh $version)" >&2
+echo "" >&2
+echo "or update CHANGELOG.md to reflect the published release body." >&2
+exit 1

--- a/scripts/release/extract-changelog-section.sh
+++ b/scripts/release/extract-changelog-section.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# extract-changelog-section.sh - emit one CHANGELOG section to stdout.
+#
+# Usage:
+#   scripts/release/extract-changelog-section.sh <version> [path]
+#
+# Where <version> is a Semver string (e.g. 1.0.0) and the optional
+# [path] defaults to <repo_root>/CHANGELOG.md.
+#
+# Emits the lines between `## [<version>] - YYYY-MM-DD` (inclusive)
+# and the next `## [...]` heading (exclusive), so the result is the
+# verbatim release-section content.  Designed to feed `gh release
+# create --notes-file` per docs/RELEASE_PROCESS.md §2.5 and to back
+# the CI gate at scripts/ci/check-release-template.sh.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <version> [path/to/CHANGELOG.md]" >&2
+    exit 1
+fi
+
+version="$1"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+path="${2:-$repo_root/CHANGELOG.md}"
+
+if [ ! -f "$path" ]; then
+    echo "extract-changelog-section: $path does not exist" >&2
+    exit 1
+fi
+
+# Stream the lines starting at `## [<version>] - ...` and stop at the
+# next `## [` line (the next versioned or `[Unreleased]` heading).
+awk -v v="$version" '
+    BEGIN { active = 0 }
+    /^## \[/ {
+        if (active) { exit }
+        if ($0 ~ "^## \\[" v "\\] - ") { active = 1; print; next }
+    }
+    active { print }
+' "$path"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -423,12 +423,28 @@ test('changelog_format', py3,
             meson.project_source_root() / 'CHANGELOG.md'],
      suite: 'abi')
 
+# Shell interpreter for the abi-suite shell scripts below.  Resolved
+# once and reused; tests that depend on `sh.found()` are gated on
+# the same handle so platforms without bash (e.g. some Windows
+# runners) silently skip both gates instead of failing
+# inconsistently.
+sh = find_program('bash', required: false)
+
+# Issue #772: release-template gate.  Asserts that the GitHub Releases
+# body for the current tag matches the corresponding CHANGELOG section.
+# SKIPs cleanly outside tag-triggered CI context (PR builds, main
+# branch); enforces inside the release-tag.yml workflow (#749 B19).
+if sh.found()
+  test('release_template', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-release-template.sh'],
+       suite: 'abi')
+endif
+
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss
 # of an exported symbol fails the gate.  Linux/ELF-focused; SKIPs
 # cleanly on platforms without `libwirelog.so` (Windows, static-only).
-sh = find_program('bash', required: false)
 if sh.found()
   test('abi_symbols', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols.sh',


### PR DESCRIPTION
## Summary

Closes #772.  Adds the v0.41 release-notes deliverable carved out
of #471 by #732.

- **docs/RELEASE_PROCESS.md**: canonical release procedure with
  9-section release-note template.
- **scripts/release/extract-changelog-section.sh**: emits one
  CHANGELOG versioned section to stdout (used by
  `gh release create --notes-file <(extract...)`).
- **scripts/ci/check-release-template.sh**: the
  `meson test --suite abi:release_template` gate that diffs the
  published GitHub Releases body against the CHANGELOG section.
  SKIPs outside tag-triggered context (PR / main branch);
  enforces inside the release-tag.yml workflow (#749 B19).

## Test plan

- [x] `meson test -C build wirelog:release_template`: SKIP
      cleanly on this branch (HEAD is not a release tag)
- [x] `meson test -C build wirelog:abi_symbols`: 53/53 OK
      (unchanged)
- [x] `extract-changelog-section.sh 0.30.0` emits the expected
      versioned block from CHANGELOG
- [ ] CI: full default + abi + sanitizer matrix

Closes #772.  Cross-ref: #471 (changelog format gate, landed
via #777), #687 v1.0.0 GA epic, #749 B19, #746 B17, #747 B18.