### PR TITLE
docs(api): Doxygen @file/@brief on every public header + lint gate (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **File-level Doxygen markers on every public header + CI gate**
+  (#780, closes #680 exit condition): every entry in
+  `wirelog_public_headers` (plus the standalone
+  `install_headers('wirelog/io/io_adapter.h', ...)` call) now
+  carries `@file` + `@brief` inside a `/** ... */` JavaDoc block
+  placed between the SPDX C-comment and the include guard.  Eight
+  headers gained both markers; `wirelog/wirelog-advanced.h` gained
+  `@brief` (it already had `@file`).  A new gate
+  `scripts/ci/check-public-doxygen-headers.py` (registered as
+  `meson test --suite abi:public_doxygen_headers`) sources its
+  header list from `parse_meson_sot` in
+  `scripts/ci/check-public-header-surface.py` (the single SoT) and
+  fails when any installed public header is missing either marker.
+  Detection is regex-strict (`^\s*\*\s*@file\b`, `^\s*\*\s*@brief\b`)
+  so per-parameter `@filename:` annotations in GTK-Doc-style function
+  blocks do not satisfy the file-level check.
 - **Release-process documentation + release-template CI gate** (#772):
   `docs/RELEASE_PROCESS.md` defines the canonical procedure for cutting
   a release tag, including the 9-section release-note template and the

--- a/scripts/ci/check-public-doxygen-headers.py
+++ b/scripts/ci/check-public-doxygen-headers.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""check-public-doxygen-headers.py - Issue #780 / Epic #680 exit gate.
+
+File-level Doxygen marker gate.  Asserts that every installed public
+header carries both ``@file`` and ``@brief`` Doxygen tags inside a
+``/** ... */`` documentation block placed near the top of the file
+(after the SPDX/copyright C-comment, before or just after the
+``#ifndef`` guard).
+
+Why both markers must be present
+--------------------------------
+
+Doxygen will only emit a file-level documentation page for a header
+when it finds a ``@file`` directive inside a JavaDoc-style block
+(``/**`` or ``/*!``).  A bare ``@file`` inside a plain ``/*`` block
+is silently ignored.  ``@brief`` is what shows up in the file-index
+tooltip and in IDE hover; without it, the index entry is blank.
+
+Source of truth for the header list
+-----------------------------------
+
+This script does NOT maintain its own list of public headers.  It
+imports ``parse_meson_sot`` from the sibling lint at
+``scripts/ci/check-public-header-surface.py``, which authoritatively
+parses ``meson.build``'s ``wirelog_public_headers`` plus the
+standalone ``install_headers('wirelog/io/io_adapter.h', ...)`` call.
+Any header newly added to (or removed from) the install set is
+picked up automatically -- there is no second list to keep in sync.
+
+Generated headers (``wirelog/wirelog-version.h`` via
+``configure_file``) are not source-tracked and are not returned by
+``parse_meson_sot``; they are intentionally exempt and checked
+elsewhere (``check-version-sync.py``).
+
+Detection rules (deliberately strict)
+-------------------------------------
+
+A header passes when, within its first 80 lines:
+
+  1. A ``/**`` token opens a comment block.
+  2. Inside that block (before its closing ``*/``), a line matches
+     ``^\\s*\\*\\s*@file\\b`` -- the leading-asterisk + word-boundary
+     anchor distinguishes the file-level marker from per-parameter
+     ``@filename:`` annotations that appear in GTK-Doc-style
+     function blocks elsewhere in the same files.
+  3. Inside the same block, a line matches
+     ``^\\s*\\*\\s*@brief\\b``.
+
+Exit codes mirror the sibling lints:
+
+  0 -- every public header carries both markers in a Doxygen block.
+  1 -- at least one header is missing one or both markers.
+
+See also
+--------
+
+  - ``scripts/ci/check-public-prefix.py``        (#761 prefix gate)
+  - ``scripts/ci/check-public-header-surface.py`` (#705 SoT gate)
+  - Doxygen exemplar: ``wirelog/wirelog-advanced.h``
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+HEAD_LINES = 80
+
+FILE_RE = re.compile(r"^\s*\*\s*@file\b")
+BRIEF_RE = re.compile(r"^\s*\*\s*@brief\b")
+OPEN_RE = re.compile(r"/\*\*")
+CLOSE_RE = re.compile(r"\*/")
+
+
+def _load_surface_module():
+    """Load the sibling lint as a module (hyphenated filename requires
+    importlib).  Reused for ``parse_meson_sot``.
+    """
+    path = SCRIPT_DIR / "check-public-header-surface.py"
+    spec = importlib.util.spec_from_file_location("_surface_sot", path)
+    if spec is None or spec.loader is None:
+        die(f"unable to load sibling lint {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def die(msg: str) -> None:
+    print(f"check-public-doxygen-headers: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_doxygen_block(lines: list[str]) -> tuple[int, int] | None:
+    """Return (open_idx, close_idx) of the first ``/** ... */`` block
+    inside the head window, or ``None`` if no JavaDoc block is found.
+    Indexes are 0-based and refer to ``lines``.  A single-line ``/** ...
+    */`` block is permitted.
+    """
+    head = lines[:HEAD_LINES]
+    open_idx: int | None = None
+    for i, line in enumerate(head):
+        if open_idx is None:
+            if OPEN_RE.search(line):
+                open_idx = i
+                if CLOSE_RE.search(line[OPEN_RE.search(line).end():]):
+                    return (i, i)
+        else:
+            if CLOSE_RE.search(line):
+                return (open_idx, i)
+    return None
+
+
+def check_header(path: pathlib.Path) -> list[str]:
+    """Return a list of human-readable missing-marker strings for one
+    header.  Empty list == header passes.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    block = find_doxygen_block(lines)
+    if block is None:
+        return [
+            "no Doxygen /** ... */ block found in first "
+            f"{HEAD_LINES} lines",
+        ]
+    open_idx, close_idx = block
+    body = lines[open_idx : close_idx + 1]
+    missing: list[str] = []
+    if not any(FILE_RE.match(ln) for ln in body):
+        missing.append("@file")
+    if not any(BRIEF_RE.match(ln) for ln in body):
+        missing.append("@brief")
+    return missing
+
+
+def main() -> int:
+    surface = _load_surface_module()
+    headers = sorted(surface.parse_meson_sot(REPO_ROOT))
+    if not headers:
+        die("parse_meson_sot returned no headers")
+
+    failures: list[tuple[str, list[str]]] = []
+    for rel in headers:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            failures.append((rel, ["file missing on disk"]))
+            continue
+        missing = check_header(path)
+        if missing:
+            failures.append((rel, missing))
+
+    if failures:
+        print(
+            "check-public-doxygen-headers: FAIL: "
+            f"{len(failures)} of {len(headers)} public header(s) missing "
+            "file-level Doxygen markers",
+            file=sys.stderr,
+        )
+        for rel, missing in failures:
+            print(f"  {rel}: missing {', '.join(missing)}", file=sys.stderr)
+        print(
+            "",
+            "To fix, add a /** ... */ block between the SPDX C-comment "
+            "and the include guard, for example:",
+            "",
+            "    /**",
+            "     * @file <basename>.h",
+            "     * @brief <one-line description>",
+            "     */",
+            "",
+            "See wirelog/wirelog-advanced.h for the exemplar.",
+            sep="\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "check-public-doxygen-headers: OK; "
+        f"{len(headers)} public headers carry @file + @brief"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -414,6 +414,16 @@ test('public_prefix', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-prefix.py'],
      suite: 'abi')
 
+# Issue #780 / Epic #680 exit gate: every public header must carry
+# `@file` and `@brief` inside a `/** ... */` Doxygen block.  Header
+# list is sourced from `parse_meson_sot` in check-public-header-surface.py
+# (which authoritatively parses meson.build), so the lint adapts
+# automatically to surface additions/removals.  Static text scan; no
+# build-tree input required.
+test('public_doxygen_headers', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-public-doxygen-headers.py'],
+     suite: 'abi')
+
 # Issue #471: CHANGELOG format gate.  Asserts the [Unreleased] section
 # follows Keep-a-Changelog conventions documented in CONTRIBUTING.md
 # (categories, PR/issue refs, dated versioned sections).  Static text

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file io_adapter.h
+ * @brief Pluggable I/O adapter ABI for custom source and sink backends.
+ */
+
 #ifndef WIRELOG_IO_IO_ADAPTER_H
 #define WIRELOG_IO_IO_ADAPTER_H
 

--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -23,6 +23,7 @@
 
 /**
  * @file wirelog-advanced.h
+ * @brief Fine-grained session API; backend selection, worker count, manual stepping.
  *
  * Fine-grained session API.  This header is the public counterpart to the
  * convenience facade in <wirelog/wirelog-easy.h>: it lets a host pick the

--- a/wirelog/wirelog-easy.h
+++ b/wirelog/wirelog-easy.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog-easy.h
+ * @brief Convenience facade API; one-call session lifecycle for embedders.
+ */
+
 #ifndef WIRELOG_WL_EASY_H
 #define WIRELOG_WL_EASY_H
 

--- a/wirelog/wirelog-export.h
+++ b/wirelog/wirelog-export.h
@@ -6,6 +6,11 @@
  * Licensed under LGPL-3.0-or-later
  */
 
+/**
+ * @file wirelog-export.h
+ * @brief Public-symbol visibility and deprecation attribute macros.
+ */
+
 #ifndef WIRELOG_EXPORT_H
 #define WIRELOG_EXPORT_H
 

--- a/wirelog/wirelog-ir.h
+++ b/wirelog/wirelog-ir.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog-ir.h
+ * @brief Intermediate-representation (IR) inspection API for compiled wirelog programs.
+ */
+
 #ifndef WIRELOG_IR_H
 #define WIRELOG_IR_H
 

--- a/wirelog/wirelog-optimizer.h
+++ b/wirelog/wirelog-optimizer.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog-optimizer.h
+ * @brief Query and program optimizer API for compiled wirelog programs.
+ */
+
 #ifndef WIRELOG_OPTIMIZER_H
 #define WIRELOG_OPTIMIZER_H
 

--- a/wirelog/wirelog-parser.h
+++ b/wirelog/wirelog-parser.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog-parser.h
+ * @brief Datalog source parser API: parse .dl text or files into wirelog_program_t.
+ */
+
 #ifndef WIRELOG_PARSER_H
 #define WIRELOG_PARSER_H
 

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog-types.h
+ * @brief Common type definitions and enums for the wirelog public API.
+ */
+
 #ifndef WIRELOG_TYPES_H
 #define WIRELOG_TYPES_H
 

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -21,6 +21,11 @@
  * <https://www.gnu.org/licenses/lgpl-3.0.html>.
  */
 
+/**
+ * @file wirelog.h
+ * @brief Umbrella header for the wirelog public C API.
+ */
+
 #ifndef WIRELOG_H
 #define WIRELOG_H
 


### PR DESCRIPTION
## Summary

- Adds file-level Doxygen markers (`@file` + `@brief`) inside a JavaDoc `/** ... */` block to every entry in the public-header install set: 8 headers gained both markers; `wirelog/wirelog-advanced.h` gained `@brief` (it already carried `@file`).
- Lands a new CI gate at `scripts/ci/check-public-doxygen-headers.py`, registered as `meson test --suite abi:public_doxygen_headers`. It sources its header list from `parse_meson_sot` in the sibling `check-public-header-surface.py` so the canonical `wirelog_public_headers` (plus the standalone `install_headers('wirelog/io/io_adapter.h', ...)` call) in `meson.build` remains the single source of truth.
- Closes the literal Epic #680 v0.40 API audit exit condition *"SPDX + Doxygen file headers on every public header"*. SPDX was already complete on every public header; the Doxygen half was outstanding on 9 of 9.

## Why the marker lives in a separate `/**` block

The SPDX/copyright header on each public file is a plain `/* ... */` C-comment. Doxygen recognises `@file` only inside a JavaDoc-style block (`/**` or `/*!`), so inlining `@file` into the SPDX block would be silently ignored. Each new block is inserted between the SPDX `*/` and the include guard, matching the `wirelog/wirelog-advanced.h:24-41` exemplar.

The same reasoning is why the lint regex (`^\s*\*\s*@file\b`, `^\s*\*\s*@brief\b`) requires a leading asterisk + word-boundary anchor, and why the scanner only inspects content inside a `/** ... */` block. The pre-existing `@file` substrings in `wirelog/wirelog.h:116` and `wirelog/wirelog-parser.h:66` are per-parameter `@filename:` annotations on individual functions, not file-level tags — the gate correctly rejects those as satisfying the file-level requirement.

## Scope

| Item | Change |
|---|---|
| 9 public headers | Doxygen `@file` + `@brief` block (8 new blocks, 1 `@brief` line into existing block) |
| `scripts/ci/check-public-doxygen-headers.py` (new) | 187-line lint, sources header list from `parse_meson_sot` |
| `tests/meson.build` | New `test('public_doxygen_headers', ..., suite: 'abi')` registration adjacent to `public_prefix` |
| `CHANGELOG.md` | `[Unreleased]`/Added entry referencing #780 and #680 |

Out of scope (per the issue body):
- Per-function `@param`/`@return`/`@retval`/`@warning` coverage — separate v0.41+ issue.
- Doxyfile + HTML/PDF render target — separate v1.0-rc1 polish issue.
- `WIRELOG_API` macro adoption on existing prototypes — separate v0.41 housekeeping.

## Verification

- `meson test -C build --suite abi` reports 21/21 OK, including the new `public_doxygen_headers` test.
- Manual run: `python3 scripts/ci/check-public-doxygen-headers.py` exits 0 with `9 public headers carry @file + @brief`.
- Negative-case sanity (off-branch): removing any single `@brief` line drops the lint to exit 1 with a clear per-header diagnostic and a fix template that references the `wirelog/wirelog-advanced.h` exemplar.
- ABI impact: none. `git diff origin/main -- 'wirelog/*.h' 'wirelog/io/*.h' | grep -E '^[-+]\s*\*\s*(Copyright|SPDX|Licensed|GNU Lesser)'` is empty — no SPDX or copyright text changed. No `WIRELOG_PUBLIC` annotations added or removed; existing 53-symbol allowlist (`abi/libwirelog-1.0.symbols`) continues to pass.

## Test plan

- [ ] CI `meson test --suite abi` passes on Linux GCC/Clang.
- [ ] CI `meson test --suite abi` passes on macOS.
- [ ] CI `meson test --suite abi` passes on Windows (MSVC + clang-cl).
- [ ] `public_doxygen_headers` test appears in test output and reports OK.
- [ ] Existing `public_header_surface`, `public_prefix`, `abi_symbols`, `changelog_format`, `release_template` gates continue to pass.

Closes #780.
Refs #680.