### PR TITLE
release: cut v0.40.0 (API audit milestone closes #680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.40.0] - 2026-05-12
+
+### Added
+
 - **File-level Doxygen markers on every public header + CI gate**
   (#780, closes #680 exit condition): every entry in
   `wirelog_public_headers` (plus the standalone

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.39.0',
+  version: '0.40.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

- Bumps `meson.build` `project_version` from `0.39.0` to `0.40.0`.
- Cuts the `[Unreleased]` section in `CHANGELOG.md` over to `## [0.40.0] - 2026-05-12` and resets `[Unreleased]` to the empty-category placeholder shape per `CONTRIBUTING.md` "Changelog Conventions" + `docs/RELEASE_PROCESS.md` section 2.
- Closes epic #680 v0.40 API Audit (all 7 exit conditions verified on `main` at `c8c7749` and recorded in the closing comment).

## Milestone exit conditions (all met)

| # | Exit condition | Landing PR(s) |
|---|---|---|
| 1 | `WIRELOG_VERSION_*` auto-generated from `meson.build` | #688, #704 |
| 2 | `install_headers` SSOT | #689, #705 |
| 3 | `io_adapter.h` public/internal decision | #706, #762 |
| 4 | `wirelog-advanced.h` skeleton + thin wrappers | #703, #717 |
| 5 | README `wl_session_*` rewrite | #717 |
| 6 | `WIRELOG_API` / `WIRELOG_DEPRECATED_SINCE` introduced | (definitions in `wirelog/wirelog-export.h`; adoption sweep carried forward as #782 under v0.41) |
| 7 | SPDX + Doxygen on every public header | #780 |

The companion public-API rename epic #755 also closed in v0.40, in seven PRs (#756 / #757 / #758 / #759 / #760 / #761 / #762).

## ABI status at v0.40.0

- SOVERSION pinned at `1` (`meson.build:282 soversion: '1'`), decoupled from `project_version` so the v1.0 ABI commitment is fixed ahead of the `1.0.0` tag.
- `gnu_symbol_visibility: 'hidden'` reduces the dynamic-symbol surface from 348 to 53 (#733 K1).
- 53-entry allowlist at `abi/libwirelog-1.0.symbols` enforced by `meson test --suite abi:abi_symbols` (#733 K2).
- The richer `.abi.json` (libabigail) half of the ABI manifest lands under #690 in v0.41.

## Verification on `release/v0.40.0`

- `meson setup --reconfigure build` reports `Project version: 0.40.0`.
- `meson test -C build --suite abi` 21/21 pass, including all five v0.40-landed gates (`abi_symbols`, `public_header_surface`, `public_prefix`, `public_doxygen_headers`, `changelog_format`, `release_template` SKIPs cleanly off-tag).
- `scripts/release/extract-changelog-section.sh 0.40.0` emits a clean 205-line `[0.40.0]` section ready to feed `gh release create --notes-file`.

## Release-tag procedure (post-merge)

Per `docs/RELEASE_PROCESS.md` section 2.4-2.5, after this PR merges to `main`:

```bash
git checkout main && git pull --ff-only
git tag -s v0.40.0 -m "wirelog 0.40.0"
git push origin v0.40.0
gh release create v0.40.0 \
    --title "wirelog 0.40.0" \
    --notes-file <(./scripts/release/extract-changelog-section.sh 0.40.0)
```

The signed-tarball / SBOM / SLSA-provenance artefact pipeline (#744, #749, #750, #751) is not yet shipped; v0.40.0 publishes the tag + GitHub Release body only.  Those richer release artefacts are blocking for v1.0.0 GA, not for v0.40.

## Test plan

- [ ] CI `meson test --suite abi` passes (no new gate added in this PR; behaviour unchanged from `c8c7749`).
- [ ] `meson test --suite abi:changelog_format` accepts the new placeholder `[Unreleased]` shape.
- [ ] `meson test --suite abi:release_template` SKIPs cleanly on PR builds (no tag at HEAD).
- [ ] CI matrix (Linux GCC/Clang, macOS Clang, Windows MSVC, Sanitizers, TSan) green.

Closes #680.