### PR TITLE
chore(version): bump project_version to 0.40.99 (post-v0.40.0 dev cycle)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.40.0',
+  version: '0.40.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

- Bumps `meson.build` `project_version` from `0.40.0` to `0.40.99`.
- Marks the trunk as in-development between the v0.40.0 tag (just published) and the next v0.41.x cut, so any build off `main` carries a version string that cannot be mistaken for a published release.

## Why `.99`

The PATCH component `99` is the conventional "post-release trunk" marker used by many C/C++ projects on Meson/Autotools. A consumer who builds `main` and checks `WIRELOG_VERSION_PATCH` sees `99`, distinct from any published `0.40.x` release (which will be `0`, `1`, `2`, ...).  When v0.41 is cut, the release PR will bump `0.40.99` to `0.41.0` and reset the `[Unreleased]` block in `CHANGELOG.md`.

## Verification

- `meson setup --reconfigure build` reports `Project version: 0.40.99`.
- Version parser at `meson.build:210-219` accepts `0.40.99` cleanly; `WIRELOG_VERSION_MAJOR=0`, `WIRELOG_VERSION_MINOR=40`, `WIRELOG_VERSION_PATCH=99`, `WIRELOG_VERSION_STRING="0.40.99"`.
- `meson test -C build --suite abi` 21/21 (including `version_sync` which cross-checks `meson.build` against `wirelog/wirelog-version.h.in`).
- No ABI surface change: this is a pure metadata bump.

## Test plan

- [ ] CI matrix green.
- [ ] `version_sync` test passes.
- [ ] No other version references in `README.md`, `docs/*.md` need a sync (only `meson.build` is the SoT; `wirelog-version.h` is generated).