### PR TITLE
docs(api): adopt WIRELOG_API on prototypes + smoke test + lint backstop (#782)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ python script.py
 > The generated `wirelog/wirelog-version.h` is also installed but is
 > tracked separately by `check-version-sync.py`.
 
+### Visibility Attribute
+
+New public-API prototypes on installed headers MUST use `WIRELOG_API`
+as the export attribute (defined in `wirelog/wirelog-export.h`).  The
+underlying macro `WIRELOG_PUBLIC` is retained inside
+`wirelog/wirelog-export.h` only as a backward-compatibility alias for
+downstream code that referenced it directly during the v0.40 cycle;
+new declarations on the installed prototype surface must use
+`WIRELOG_API`.  Deprecations use `WIRELOG_DEPRECATED_SINCE(major, minor)`.
+Enforced by `scripts/ci/check-public-api-macro.py`
+(`meson test --suite abi:public_api_macro`).
+
 **Internal headers** (not installed):
 Everything under `wirelog/parser/`, `wirelog/ir/`, `wirelog/backend/`, and `wirelog/backend.h`, `wirelog/session.h`, `wirelog/intern.h`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,56 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Compile-only smoke test for `WIRELOG_DEPRECATED_SINCE`** (#782):
+  `tests/standalone/test_standalone_wirelog_deprecated_macro.c`
+  annotates a static probe function with
+  `WIRELOG_DEPRECATED_SINCE(99, 99)` and references it from `main`,
+  so the macro's cross-compiler expansion path
+  (GCC/Clang `__attribute__((deprecated))`, MSVC
+  `__declspec(deprecated)`, no-op for unknown compilers) is
+  exercised by the build before any real public-API deprecation
+  ships.  Registered as `meson test --suite abi:standalone_include_wirelog_deprecated_macro`;
+  the call-site deprecation diagnostic is suppressed per-target via
+  `cc.get_supported_arguments(['-Wno-deprecated-declarations',
+  '/wd4996'])` so the test does not break `-Werror` CI.
+- **Public-API attribute lint backstop** (#782):
+  `scripts/ci/check-public-api-macro.py` (registered as
+  `meson test --suite abi:public_api_macro`) bans
+  `WIRELOG_PUBLIC` on the 8 prototype headers after the v0.40-cycle
+  adoption sweep to `WIRELOG_API`.  `WIRELOG_PUBLIC` remains valid
+  only inside `wirelog/wirelog-export.h` where the platform `#if`
+  ladder defines it.  Sources its header list by importing
+  `PUBLIC_HEADERS` from the sibling `scripts/ci/check-public-prefix.py`
+  so the surface stays in sync without a second hand-maintained list.
+
 ### Changed
+
+- **Adopt `WIRELOG_API` on every installed public prototype** (#782):
+  76 occurrences of `WIRELOG_PUBLIC` across the 8 prototype headers
+  (`wirelog.h`, `wirelog-types.h`, `wirelog-ir.h`, `wirelog-parser.h`,
+  `wirelog-optimizer.h`, `wirelog-easy.h`, `wirelog-advanced.h`,
+  `wirelog/io/io_adapter.h`) are renamed to `WIRELOG_API`.  The rename
+  is binary-identical: `#define WIRELOG_API WIRELOG_PUBLIC` at
+  `wirelog/wirelog-export.h:34` expands to the same platform-specific
+  attribute (`__attribute__((visibility("default")))` on GCC/Clang,
+  `__declspec(dllexport)` / `__declspec(dllimport)` on Windows,
+  no-op on `WIRELOG_STATIC` or unknown compilers).  The 53-entry
+  allowlist at `abi/libwirelog-1.0.symbols` continues to pass the
+  `abi_symbols` gate unchanged.  `WIRELOG_PUBLIC` is retained as a
+  backward-compat alias for downstream code that referenced it
+  directly during the v0.40 cycle.  Closes the adoption tail of
+  v0.40 epic #680 exit condition 6 (macros were "introduced" at the
+  definition level in v0.40; this commit puts them in use).
+- **Forward-looking documentation of the visibility attribute renamed
+  to `WIRELOG_API`** (#782): `docs/SEMANTICS.md` visibility table,
+  `meson.build` library() comment, `scripts/ci/check-abi-symbols.sh`
+  docstring, and the previously-stale "adoption sweep tracked
+  separately" note in `wirelog/wirelog-export.h:31-33` all updated to
+  reflect the new canonical attribute name.  `AGENTS.md` gains a
+  "Visibility Attribute" subsection mandating `WIRELOG_API` for new
+  public-API declarations.  History in `CHANGELOG.md` and
+  `docs/MIGRATION.md` is left untouched -- those sections describe
+  v0.40 state and should not retroactively change.
 
 ### Deprecated
 

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -120,7 +120,7 @@ reconstruct the reasoning.
 | `wl_intern_t` typedef on `wirelog/wirelog.h` | Renamed to `wirelog_intern_t` (internal `struct wl_intern` tag retained) | #760 |
 | Future-drift prevention | `scripts/ci/check-public-prefix.py` (suite `abi`) refuses any `wl_*` / `WL_*` symbol on a public installed header | #761 |
 | Public-header SSoT 3-way verification | `scripts/ci/check-public-header-surface.py` already shipped at #705; PR #770 added the standalone-include compile matrix that closes Blocker B2 | #689 (B2) |
-| Symbol-visibility default | `gnu_symbol_visibility: 'hidden'`; `WIRELOG_PUBLIC` annotation gates the dynamic-symbol table; SOVERSION=1 decoupled from `project_version` | #733 (K0/K1/K2) |
+| Symbol-visibility default | `gnu_symbol_visibility: 'hidden'`; `WIRELOG_API` annotation gates the dynamic-symbol table (alias of `WIRELOG_PUBLIC`; see `wirelog/wirelog-export.h`); SOVERSION=1 decoupled from `project_version` | #733 (K0/K1/K2), #782 |
 
 ### What remains open
 

--- a/meson.build
+++ b/meson.build
@@ -282,11 +282,11 @@ wirelog_lib = library(
   soversion: '1',
   darwin_versions: ['1', '1.0.0'],
   # Symbol-visibility default: hidden.  Every public-API function on the
-  # 9 installed headers carries WIRELOG_PUBLIC (= visibility("default")
-  # / dllexport) per #733 K0.  Internal symbols (wl_*, col_*, arr_*)
-  # are now hidden from the dynamic-symbol table; consumers who relied
-  # on resolving them through libwirelog.so must rebuild against the
-  # public surface.  See #733.
+  # 9 installed headers carries WIRELOG_API (alias of WIRELOG_PUBLIC =
+  # visibility("default") / dllexport) per #733 K0 + #782.  Internal
+  # symbols (wl_*, col_*, arr_*) are now hidden from the dynamic-symbol
+  # table; consumers who relied on resolving them through libwirelog.so
+  # must rebuild against the public surface.  See #733.
   gnu_symbol_visibility: 'hidden',
 )
 

--- a/scripts/ci/check-abi-symbols.sh
+++ b/scripts/ci/check-abi-symbols.sh
@@ -6,8 +6,9 @@
 # `abi/libwirelog-1.0.symbols`.
 #
 # - The allowlist is the public-API surface frozen for the v1.0
-#   ABI: every name on the list is a `WIRELOG_PUBLIC`-annotated
-#   symbol exported through one of the 9 installed public headers.
+#   ABI: every name on the list is a `WIRELOG_API`-annotated
+#   symbol (alias of `WIRELOG_PUBLIC`; see `wirelog/wirelog-export.h`)
+#   exported through one of the 9 installed public headers.
 # - Any addition of a new public symbol must update the allowlist
 #   in the same PR (the gate fails otherwise).
 # - Any accidental loss of an exported symbol (e.g. an annotation

--- a/scripts/ci/check-public-api-macro.py
+++ b/scripts/ci/check-public-api-macro.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""check-public-api-macro.py - Issue #782 backstop.
+
+Asserts that every public-API prototype on the 8 installed prototype
+headers uses the canonical `WIRELOG_API` attribute macro, not its
+backward-compat alias `WIRELOG_PUBLIC`.  The alias is allowed (and
+required) only inside `wirelog/wirelog-export.h`, where the platform
+`#if` ladder *defines* `WIRELOG_PUBLIC` and `WIRELOG_API` is itself
+defined as `#define WIRELOG_API WIRELOG_PUBLIC`.
+
+Source of truth for the public-headers list
+-------------------------------------------
+
+This lint imports `PUBLIC_HEADERS` from the sibling lint at
+`scripts/ci/check-public-prefix.py` (which authoritatively mirrors
+`wirelog_public_headers` in `meson.build` plus the standalone
+`install_headers('wirelog/io/io_adapter.h', ...)` call).  Any change
+to the installed-header set updates both lints automatically.
+
+Detection (text scan, deliberately conservative)
+------------------------------------------------
+
+Each header is scanned line by line.  Block comments (`/* ... */`)
+and line comments (`//`) are stripped before scanning so that
+docstring references to `WIRELOG_PUBLIC` do not produce false
+positives.  Anything else is searched for `\\bWIRELOG_PUBLIC\\b`.
+Hits anywhere in `wirelog/wirelog-export.h` are exempt (the macro
+itself lives there).  Hits in any other header are violations.
+
+Run as a lint-stage script: no configured build dir required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+
+EXEMPT_HEADER = "wirelog/wirelog-export.h"
+
+VIOLATION_RE = re.compile(r"\bWIRELOG_PUBLIC\b")
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _load_prefix_module():
+    """Load the sibling lint as a module (hyphenated filename
+    requires importlib); reused for `PUBLIC_HEADERS`."""
+    path = SCRIPT_DIR / "check-public-prefix.py"
+    spec = importlib.util.spec_from_file_location("_public_prefix", path)
+    if spec is None or spec.loader is None:
+        print(
+            f"check-public-api-macro: unable to load sibling lint {path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def strip_comments(src: str) -> str:
+    return BLOCK_COMMENT_RE.sub(" ", src)
+
+
+def scan_header(path: pathlib.Path) -> list[tuple[int, str]]:
+    raw = path.read_text(encoding="utf-8")
+    stripped = strip_comments(raw)
+    hits: list[tuple[int, str]] = []
+    for lineno, line in enumerate(stripped.splitlines(), start=1):
+        code = line.split("//", 1)[0]
+        if VIOLATION_RE.search(code):
+            hits.append((lineno, line.rstrip()))
+    return hits
+
+
+def main() -> int:
+    prefix = _load_prefix_module()
+    headers = prefix.PUBLIC_HEADERS
+    violations: list[tuple[str, int, str]] = []
+    for rel in headers:
+        if rel == EXEMPT_HEADER:
+            continue
+        path = REPO_ROOT / rel
+        if not path.exists():
+            print(
+                f"check-public-api-macro: missing public header: {rel}",
+                file=sys.stderr,
+            )
+            return 1
+        for lineno, line in scan_header(path):
+            violations.append((rel, lineno, line))
+
+    if not violations:
+        print(
+            "check-public-api-macro: OK; no WIRELOG_PUBLIC tokens outside "
+            f"{EXEMPT_HEADER} "
+            f"({len(headers) - 1} prototype headers scanned)"
+        )
+        return 0
+
+    print(
+        f"check-public-api-macro: FAIL; {len(violations)} WIRELOG_PUBLIC "
+        f"token(s) on prototype headers (must use WIRELOG_API per "
+        f"AGENTS.md and #782):",
+        file=sys.stderr,
+    )
+    for rel, lineno, line in violations:
+        print(f"  {rel}:{lineno}: {line}", file=sys.stderr)
+    print(
+        "\nPublic prototypes must use WIRELOG_API.  WIRELOG_PUBLIC is "
+        "retained as a backward-compatibility alias only inside "
+        f"{EXEMPT_HEADER}; new code on the installed prototype surface "
+        "must use WIRELOG_API.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -414,6 +414,13 @@ test('public_prefix', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-prefix.py'],
      suite: 'abi')
 
+# Issue #782 backstop: WIRELOG_PUBLIC must not re-appear on the 8
+# prototype headers after the v0.40-cycle adoption sweep to WIRELOG_API.
+# The macro itself lives in wirelog/wirelog-export.h (exempt).
+test('public_api_macro', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-public-api-macro.py'],
+     suite: 'abi')
+
 # Issue #780 / Epic #680 exit gate: every public header must carry
 # `@file` and `@brief` inside a `/** ... */` Doxygen block.  Header
 # list is sourced from `parse_meson_sot` in check-public-header-surface.py

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -490,6 +490,28 @@ foreach hdr : public_standalone_headers
   test('standalone_include_' + hdr[0], exe, suite: 'abi')
 endforeach
 
+# Issue #782: compile-only smoke test for WIRELOG_DEPRECATED_SINCE.
+# The macro is defined in wirelog/wirelog-export.h but has zero
+# in-tree adopters at the time of v0.40.0 release; this stub
+# annotates a static probe function with WIRELOG_DEPRECATED_SINCE(99,99)
+# so the compiler exercises the attribute's expansion path
+# (GCC/Clang __attribute__((deprecated)); MSVC __declspec(deprecated);
+# no-op fallback elsewhere).  The deprecation diagnostic at the call
+# site is suppressed per-target so it does not break -Werror CI.
+deprecated_macro_smoke_warning_flags = cc.get_supported_arguments([
+  '-Wno-deprecated-declarations',
+  '/wd4996',
+])
+test_standalone_wirelog_deprecated_macro_exe = executable(
+  'test_standalone_wirelog_deprecated_macro',
+  files('standalone/test_standalone_wirelog_deprecated_macro.c'),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: deprecated_macro_smoke_warning_flags,
+)
+test('standalone_include_wirelog_deprecated_macro',
+     test_standalone_wirelog_deprecated_macro_exe,
+     suite: 'abi')
+
 test_intern_exe = executable(
   'test_intern',
   files('test_intern.c'),

--- a/tests/standalone/test_standalone_wirelog_deprecated_macro.c
+++ b/tests/standalone/test_standalone_wirelog_deprecated_macro.c
@@ -1,0 +1,37 @@
+/*
+ * test_standalone_wirelog_deprecated_macro.c - Issue #782 smoke test.
+ *
+ * Asserts that the `WIRELOG_DEPRECATED_SINCE(major, minor)` macro
+ * defined at `wirelog/wirelog-export.h:36-47` actually compiles and
+ * attaches its deprecation attribute on the current compiler.  Until
+ * this test landed, the macro had zero in-tree call-sites -- its
+ * cross-compiler expansion (GCC / Clang `__attribute__((deprecated))`,
+ * MSVC `__declspec(deprecated)`, no-op fallback) had never been
+ * exercised before its first real deprecation in v0.42+.
+ *
+ * The test compiles a `static` probe function annotated with
+ * `WIRELOG_DEPRECATED_SINCE(99, 99)` -- a version that will not be
+ * reached in practice -- and references it once from `main`.  The
+ * meson registration passes `-Wno-deprecated-declarations` (or
+ * `/wd4996` under MSVC) so the inevitable deprecation diagnostic at
+ * the call site does not break `-Werror` CI.
+ *
+ * Build success here proves: (a) the macro is syntactically valid
+ * for this compiler, (b) the resulting attribute attaches to a
+ * function declaration without rejection, and (c) the call-site
+ * diagnostic is suppressible via the documented warning flag.
+ */
+
+#include "wirelog/wirelog-export.h"
+
+WIRELOG_DEPRECATED_SINCE(99, 99)
+static int wirelog_deprecated_macro_smoke_probe(void)
+{
+    return 0;
+}
+
+int
+main(void)
+{
+    return wirelog_deprecated_macro_smoke_probe();
+}

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -67,19 +67,19 @@ typedef struct wirelog_io_ctx wirelog_io_ctx_t;
 /* Context Accessors (implemented in #453)                                  */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx);
-WIRELOG_PUBLIC uint32_t
+WIRELOG_API uint32_t
 wirelog_io_ctx_num_cols(const wirelog_io_ctx_t *ctx);
-WIRELOG_PUBLIC wirelog_column_type_t
+WIRELOG_API wirelog_column_type_t
 wirelog_io_ctx_col_type(const wirelog_io_ctx_t *ctx, uint32_t col);
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_io_ctx_param(const wirelog_io_ctx_t *ctx, const char *key);
-WIRELOG_PUBLIC int64_t
+WIRELOG_API int64_t
 wirelog_io_ctx_intern_string(wirelog_io_ctx_t *ctx, const char *utf8);
-WIRELOG_PUBLIC void *
+WIRELOG_API void *
 wirelog_io_ctx_platform(const wirelog_io_ctx_t *ctx);
-WIRELOG_PUBLIC int
+WIRELOG_API int
 wirelog_io_ctx_set_platform(wirelog_io_ctx_t *ctx, void *ptr);
 
 /* ======================================================================== */
@@ -141,16 +141,16 @@ typedef struct wirelog_io_adapter {
  *   wirelog_io_find_adapter        pointer to adapter, or NULL if not found
  */
 
-WIRELOG_PUBLIC int wirelog_io_register_adapter(
+WIRELOG_API int wirelog_io_register_adapter(
     const wirelog_io_adapter_t *adapter) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC int wirelog_io_unregister_adapter(
+WIRELOG_API int wirelog_io_unregister_adapter(
     const char *scheme) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC const wirelog_io_adapter_t *wirelog_io_find_adapter(
+WIRELOG_API const wirelog_io_adapter_t *wirelog_io_find_adapter(
     const char *scheme) WIRELOG_IO_USED;
 
-WIRELOG_PUBLIC const char *wirelog_io_last_error(void);
+WIRELOG_API const char *wirelog_io_last_error(void);
 
 /* ======================================================================== */
 /* Plugin Entry Point (Path B, Issue #461)                                  */

--- a/wirelog/wirelog-advanced.h
+++ b/wirelog/wirelog-advanced.h
@@ -118,7 +118,7 @@ typedef enum {
  * backend selection, WIRELOG_ERR_INVALID_IR on plan generation failure,
  * WIRELOG_ERR_MEMORY on allocation failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_create(wirelog_program_t *program,
     wirelog_backend_kind_t backend, uint32_t num_workers,
     wirelog_session_t **out);
@@ -130,7 +130,7 @@ wirelog_session_create(wirelog_program_t *program,
  * Release the session and its plan.  Does NOT free the program passed
  * to wirelog_session_create(); the caller still owns it.
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_session_destroy(wirelog_session_t *session);
 
 /**
@@ -148,7 +148,7 @@ wirelog_session_destroy(wirelog_session_t *session);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_insert(wirelog_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
@@ -166,7 +166,7 @@ wirelog_session_insert(wirelog_session_t *session, const char *relation,
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure or if
  * the backend does not support retraction.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_remove(wirelog_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
@@ -180,7 +180,7 @@ wirelog_session_remove(wirelog_session_t *session, const char *relation,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_step(wirelog_session_t *session);
 
 /**
@@ -196,7 +196,7 @@ wirelog_session_step(wirelog_session_t *session);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on NULL @session.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_set_delta_cb(wirelog_session_t *session,
     wirelog_on_delta_fn callback, void *user_data);
 
@@ -214,7 +214,7 @@ wirelog_session_set_delta_cb(wirelog_session_t *session,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_snapshot(wirelog_session_t *session,
     wirelog_on_tuple_fn callback,
     void *user_data);
@@ -238,7 +238,7 @@ wirelog_session_snapshot(wirelog_session_t *session,
  * temporarily frozen; WIRELOG_ERR_MEMORY on allocation failure;
  * WIRELOG_ERR_EXEC on invalid arguments or session-side errors.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_session_make_compound(wirelog_session_t *session, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
 

--- a/wirelog/wirelog-easy.h
+++ b/wirelog/wirelog-easy.h
@@ -123,7 +123,7 @@ typedef struct {
  *
  * Returns: WIRELOG_OK on success; *out set to NULL on any error.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_open_opts(const char *dl_src,
     const wirelog_easy_open_opts_t *opts,
     wirelog_easy_session_t **out);
@@ -153,7 +153,7 @@ wirelog_easy_open_opts(const char *dl_src,
  * WIRELOG_ERR_MEMORY on allocation failure, or another wirelog_error_t on
  * other failure modes.  *out is set to NULL on error.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out);
 
 /**
@@ -162,7 +162,7 @@ wirelog_easy_open(const char *dl_src, wirelog_easy_session_t **out);
  *
  * Release the session, plan, program, and intern table in the correct order.
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_easy_close(wirelog_easy_session_t *s);
 
 /**
@@ -180,7 +180,7 @@ wirelog_easy_close(wirelog_easy_session_t *s);
  *
  * Returns: non-negative ID on success, -1 on NULL args or internal error.
  */
-WIRELOG_PUBLIC int64_t
+WIRELOG_API int64_t
 wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym);
 
 /**
@@ -203,7 +203,7 @@ wirelog_easy_intern(wirelog_easy_session_t *s, const char *sym);
  * WIRELOG_ERR_EXEC for invalid arguments, plan/session build failure,
  * side-relation registration failure, or insertion failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args, uint64_t *handle_out);
 
@@ -219,7 +219,7 @@ wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation,
     const int64_t *row,
     uint32_t ncols);
@@ -235,7 +235,7 @@ wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation,
     const int64_t *row,
     uint32_t ncols);
@@ -250,7 +250,7 @@ wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation,
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
@@ -260,7 +260,7 @@ wirelog_easy_insert_sym(wirelog_easy_session_t *s, const char *relation, ...);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...);
 
 /**
@@ -271,7 +271,7 @@ wirelog_easy_remove_sym(wirelog_easy_session_t *s, const char *relation, ...);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_step(wirelog_easy_session_t *s);
 
 /**
@@ -288,7 +288,7 @@ wirelog_easy_step(wirelog_easy_session_t *s);
  * Returns: WIRELOG_OK on success, or a wirelog_error_t describing the
  * plan/session build failure.  A NULL @s returns WIRELOG_ERR_EXEC.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
     void *user_data);
 
@@ -306,7 +306,7 @@ wirelog_easy_set_delta_cb(wirelog_easy_session_t *s, wirelog_on_delta_fn cb,
  * STRING column cannot be reverse-interned, the function calls abort() to
  * prevent silent corruption (NDEBUG-safe — assert() would compile out).
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_easy_print_delta(const char *relation, const int64_t *row,
     uint32_t ncols,
     int32_t diff, void *user_data);
@@ -317,7 +317,7 @@ wirelog_easy_print_delta(const char *relation, const int64_t *row,
  *
  * Print a small "=== @label ===" banner used by examples.
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_easy_banner(const char *label);
 
 /**
@@ -341,7 +341,7 @@ wirelog_easy_banner(const char *label);
  *
  * Returns: WIRELOG_OK on success, WIRELOG_ERR_EXEC on failure.
  */
-WIRELOG_PUBLIC wirelog_error_t
+WIRELOG_API wirelog_error_t
 wirelog_easy_snapshot(wirelog_easy_session_t *s, const char *relation,
     wirelog_on_tuple_fn cb,
     void *user_data);

--- a/wirelog/wirelog-export.h
+++ b/wirelog/wirelog-export.h
@@ -28,9 +28,12 @@
   #define WIRELOG_PUBLIC
 #endif
 
-/* Public-API attribute macro.  Alias of WIRELOG_PUBLIC defined unconditionally
- * above; new code should prefer WIRELOG_API for clarity.  The full
- * adoption sweep across existing prototypes is tracked separately. */
+/* Public-API attribute macro.  WIRELOG_API is the canonical name for
+ * the public-symbol visibility attribute and is the form used on
+ * every prototype in the installed public headers.  The underlying
+ * WIRELOG_PUBLIC macro is retained as a backward-compat alias for
+ * downstream code that referenced it directly during the v0.40 cycle
+ * (see docs/MIGRATION.md 0.30 -> 1.0). */
 #define WIRELOG_API WIRELOG_PUBLIC
 
 /* WIRELOG_DEPRECATED_SINCE(major, minor): annotate APIs scheduled for

--- a/wirelog/wirelog-ir.h
+++ b/wirelog/wirelog-ir.h
@@ -75,7 +75,7 @@ typedef enum {
  *
  * Returns: Node type
  */
-WIRELOG_PUBLIC wirelog_ir_node_type_t
+WIRELOG_API wirelog_ir_node_type_t
 wirelog_ir_node_get_type(const wirelog_ir_node_t *node);
 
 /**
@@ -86,7 +86,7 @@ wirelog_ir_node_get_type(const wirelog_ir_node_t *node);
  *
  * Returns: (transfer none): Relation name string
  */
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_ir_node_get_relation_name(const wirelog_ir_node_t *node);
 
 /**
@@ -97,7 +97,7 @@ wirelog_ir_node_get_relation_name(const wirelog_ir_node_t *node);
  *
  * Returns: Child count (0 for leaf nodes like SCAN)
  */
-WIRELOG_PUBLIC uint32_t
+WIRELOG_API uint32_t
 wirelog_ir_node_get_child_count(const wirelog_ir_node_t *node);
 
 /**
@@ -109,7 +109,7 @@ wirelog_ir_node_get_child_count(const wirelog_ir_node_t *node);
  *
  * Returns: (transfer none): Child node, or NULL if invalid index
  */
-WIRELOG_PUBLIC const wirelog_ir_node_t *
+WIRELOG_API const wirelog_ir_node_t *
 wirelog_ir_node_get_child(const wirelog_ir_node_t *node, uint32_t index);
 
 /* ======================================================================== */
@@ -123,7 +123,7 @@ wirelog_ir_node_get_child(const wirelog_ir_node_t *node, uint32_t index);
  *
  * Print an IR node (for debugging).
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_ir_node_print(const wirelog_ir_node_t *node, uint32_t indent);
 
 /**
@@ -134,7 +134,7 @@ wirelog_ir_node_print(const wirelog_ir_node_t *node, uint32_t indent);
  *
  * Returns: (transfer full): String representation (must be freed)
  */
-WIRELOG_PUBLIC char *
+WIRELOG_API char *
 wirelog_ir_node_to_string(const wirelog_ir_node_t *node);
 
 #ifdef __cplusplus

--- a/wirelog/wirelog-optimizer.h
+++ b/wirelog/wirelog-optimizer.h
@@ -107,7 +107,7 @@ typedef struct {
  *
  * Returns: Default configuration (all optimizations enabled)
  */
-WIRELOG_PUBLIC wirelog_opt_config_t
+WIRELOG_API wirelog_opt_config_t
 wirelog_optimizer_get_default_config(void);
 
 /* Note: wirelog_optimize() lives in wirelog.h — this header adds the
@@ -131,7 +131,7 @@ wirelog_optimizer_get_default_config(void);
  *
  * Returns: true on success, false on error
  */
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_optimize_with_config(wirelog_program_t *program,
     const wirelog_opt_config_t *config,
     wirelog_error_t *error);
@@ -148,7 +148,7 @@ wirelog_optimize_with_config(wirelog_program_t *program,
  *
  * Returns: true on success, false on error
  */
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
     wirelog_error_t *error);
 
@@ -165,7 +165,7 @@ wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
  *
  * Returns: true if stats were collected, false otherwise
  */
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_optimizer_get_stats(const wirelog_program_t *program,
     wirelog_opt_stats_t *stats);
 
@@ -181,7 +181,7 @@ wirelog_optimizer_get_stats(const wirelog_program_t *program,
  * - Cost model decisions
  * - Join ordering rationale
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_optimizer_debug_print(const wirelog_program_t *program);
 
 /**
@@ -192,7 +192,7 @@ wirelog_optimizer_debug_print(const wirelog_program_t *program);
  *
  * Returns: Estimated cost (arbitrary units), or 0 if not available
  */
-WIRELOG_PUBLIC uint64_t
+WIRELOG_API uint64_t
 wirelog_optimizer_cost_estimate(const wirelog_program_t *program);
 
 #ifdef __cplusplus

--- a/wirelog/wirelog-parser.h
+++ b/wirelog/wirelog-parser.h
@@ -70,7 +70,7 @@ typedef struct {
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-WIRELOG_PUBLIC wirelog_program_t *
+WIRELOG_API wirelog_program_t *
 wirelog_parse_with_error_info(const char *filename,
     wirelog_parse_error_t *error_info);
 
@@ -86,7 +86,7 @@ wirelog_parse_with_error_info(const char *filename,
  *
  * Returns: Number of strata (always >= 1)
  */
-WIRELOG_PUBLIC uint32_t
+WIRELOG_API uint32_t
 wirelog_program_get_stratum_count(const wirelog_program_t *program);
 
 /**
@@ -98,7 +98,7 @@ wirelog_program_get_stratum_count(const wirelog_program_t *program);
  *
  * Returns: (transfer none): Stratum info, or NULL if invalid ID
  */
-WIRELOG_PUBLIC const wirelog_stratum_t *
+WIRELOG_API const wirelog_stratum_t *
 wirelog_program_get_stratum(const wirelog_program_t *program,
     uint32_t stratum_id);
 
@@ -110,7 +110,7 @@ wirelog_program_get_stratum(const wirelog_program_t *program,
  *
  * Returns: Total rule count
  */
-WIRELOG_PUBLIC uint32_t
+WIRELOG_API uint32_t
 wirelog_program_get_rule_count(const wirelog_program_t *program);
 
 /**
@@ -122,7 +122,7 @@ wirelog_program_get_rule_count(const wirelog_program_t *program);
  *
  * Returns: (transfer none): Schema info, or NULL if not found
  */
-WIRELOG_PUBLIC const wirelog_schema_t *
+WIRELOG_API const wirelog_schema_t *
 wirelog_program_get_schema(const wirelog_program_t *program,
     const char *relation_name);
 
@@ -134,7 +134,7 @@ wirelog_program_get_schema(const wirelog_program_t *program,
  *
  * Returns: true if stratified, false otherwise
  */
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_program_is_stratified(const wirelog_program_t *program);
 
 /* Note: wirelog_program_free() lives in wirelog.h. */

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -116,11 +116,11 @@ typedef enum {
 /* Operator String Conversion                                               */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_cmp_op_str(wirelog_cmp_op_t op);
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_arith_op_str(wirelog_arith_op_t op);
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_agg_fn_str(wirelog_agg_fn_t fn);
 
 /* ======================================================================== */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -128,7 +128,7 @@ typedef enum {
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-WIRELOG_PUBLIC wirelog_program_t *
+WIRELOG_API wirelog_program_t *
 wirelog_parse(const char *filename, wirelog_error_t *error);
 
 /**
@@ -140,7 +140,7 @@ wirelog_parse(const char *filename, wirelog_error_t *error);
  *
  * Returns: (transfer full): Parsed program, or NULL on error
  */
-WIRELOG_PUBLIC wirelog_program_t *
+WIRELOG_API wirelog_program_t *
 wirelog_parse_string(const char *program_text, wirelog_error_t *error);
 
 /**
@@ -149,7 +149,7 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error);
  *
  * Free a parsed program and all associated resources.
  */
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_program_free(wirelog_program_t *program);
 
 /* ======================================================================== */
@@ -170,7 +170,7 @@ typedef struct wl_intern wirelog_intern_t;
  * @param prog  Compiled program
  * @return Intern table (owned by program, do not free), or NULL
  */
-WIRELOG_PUBLIC const wirelog_intern_t *
+WIRELOG_API const wirelog_intern_t *
 wirelog_program_get_intern(const wirelog_program_t *prog);
 
 /* ======================================================================== */
@@ -190,7 +190,7 @@ wirelog_program_get_intern(const wirelog_program_t *prog);
  * @param num_cols   Output: number of columns per tuple
  * @return 0 on success, -1 on error (unknown relation), 1 if no facts
  */
-WIRELOG_PUBLIC int
+WIRELOG_API int
 wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
     int64_t **data, uint32_t *num_rows,
     uint32_t *num_cols);
@@ -207,7 +207,7 @@ wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
  * @param worker  DD worker handle to load facts into
  * @return 0 on success, -1 on error (NULL args or EDB load failure)
  */
-WIRELOG_PUBLIC int
+WIRELOG_API int
 wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
 
 /**
@@ -221,74 +221,74 @@ wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
  * @param worker  DD worker handle to load facts into
  * @return 0 on success, -1 on error (NULL args, missing file, parse error)
  */
-WIRELOG_PUBLIC int
+WIRELOG_API int
 wirelog_load_input_files(const wirelog_program_t *prog, void *worker);
 
 /* ======================================================================== */
 /* Optimizer API                                                            */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_optimize(wirelog_program_t *program, wirelog_error_t *error);
 
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_optimizer_debug(const wirelog_program_t *program);
 
 /* ======================================================================== */
 /* Executor API                                                             */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC wirelog_executor_t *
+WIRELOG_API wirelog_executor_t *
 wirelog_executor_create(wirelog_program_t *program, wirelog_error_t *error);
 
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_executor_free(wirelog_executor_t *executor);
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_load_facts_from_csv(wirelog_executor_t *executor,
     const char *relation_name, const char *csv_file,
     wirelog_error_t *error);
 
-WIRELOG_PUBLIC wirelog_result_t *
+WIRELOG_API wirelog_result_t *
 wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error);
 
 /* ======================================================================== */
 /* Result API                                                               */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC const void *
+WIRELOG_API const void *
 wirelog_result_get_relation(const wirelog_result_t *result,
     const char *relation_name);
 
-WIRELOG_PUBLIC uint64_t
+WIRELOG_API uint64_t
 wirelog_result_relation_cardinality(const wirelog_result_t *result,
     const char *relation_name);
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_result_write_csv(const wirelog_result_t *result,
     const char *relation_name, const char *output_file,
     wirelog_error_t *error);
 
-WIRELOG_PUBLIC void
+WIRELOG_API void
 wirelog_result_free(wirelog_result_t *result);
 
 /* ======================================================================== */
 /* Utility API                                                              */
 /* ======================================================================== */
 
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_version_string(void);
 
-WIRELOG_PUBLIC const char *
+WIRELOG_API const char *
 wirelog_error_string(wirelog_error_t error);
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_config_embedded(void);
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_config_ipc(void);
 
-WIRELOG_PUBLIC bool
+WIRELOG_API bool
 wirelog_config_threads(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Closes the WIRELOG_API adoption tail carried forward from v0.40 epic #680 exit condition 6.  Lands in 3 atomic commits on `feature/issue-782-wirelog-api-adoption`:

1. **`docs(api): adopt WIRELOG_API on every installed public prototype`** — 76 `WIRELOG_PUBLIC` → `WIRELOG_API` substitutions across the 8 prototype headers (`wirelog.h` 22, `wirelog-easy.h` 14, `io/io_adapter.h` 11, `wirelog-advanced.h` 8, `wirelog-ir.h` 6, `wirelog-parser.h` 6, `wirelog-optimizer.h` 6, `wirelog-types.h` 3).  Binary-identical: `WIRELOG_API` is defined as `#define WIRELOG_API WIRELOG_PUBLIC` at `wirelog/wirelog-export.h:37`, outside the platform `#if` ladder.  `nm -D --defined-only build/libwirelog.so | awk '$2=="T"{print $3}' | sort -u` diff against `abi/libwirelog-1.0.symbols` is empty before and after — the 53-entry allowlist passes unchanged.  `WIRELOG_PUBLIC` macro is retained inside `wirelog/wirelog-export.h` as a backward-compat alias for downstream code that referenced it directly during v0.40.  Forward-looking comment drift in `docs/SEMANTICS.md` row 123 (historical row 119 about `WL_PUBLIC -> WIRELOG_PUBLIC` rename under #759 preserved as v0.40 history), `meson.build:284-289`, and `scripts/ci/check-abi-symbols.sh:5-10` updated.
2. **`tests(abi): compile-only smoke test for WIRELOG_DEPRECATED_SINCE`** — new `tests/standalone/test_standalone_wirelog_deprecated_macro.c` (37 lines) annotates a `static int` probe with `WIRELOG_DEPRECATED_SINCE(99, 99)` and references it from `main`.  Cross-compiler suppression via `cc.get_supported_arguments(['-Wno-deprecated-declarations', '/wd4996'])` so `-Werror` CI does not break.  Until this commit, the macro had zero in-tree call-sites despite being defined at `wirelog/wirelog-export.h:41-50`.
3. **`build(ci): mandate WIRELOG_API on prototypes via AGENTS.md + lint backstop`** — `AGENTS.md` gains a "Visibility Attribute" subsection mandating `WIRELOG_API` for new public-API declarations.  New `scripts/ci/check-public-api-macro.py` (registered as `meson test --suite abi:public_api_macro`) bans `WIRELOG_PUBLIC` token on the 8 prototype headers; the macro stays valid only inside `wirelog/wirelog-export.h`.  Lint sources its header list by importing `PUBLIC_HEADERS` from the sibling `scripts/ci/check-public-prefix.py` (importlib pattern, matches `check-public-doxygen-headers.py`).  `CHANGELOG.md` `[Unreleased]/Added` gains 2 entries (smoke test, lint backstop); `[Unreleased]/Changed` gains 2 entries (rename sweep, forward-looking doc refresh).  Each entry carries `#782`.

## ABI impact

**None.**  `nm -D --defined-only build/libwirelog.so | awk '$2=="T"{print $3}' | sort -u` matches `abi/libwirelog-1.0.symbols` byte-for-byte before and after the rename.  Downstream consumers installed against v0.40.0's `libwirelog.so.1` see identical exports — `WIRELOG_API` and `WIRELOG_PUBLIC` expand to the same `__attribute__((visibility("default")))` on GCC/Clang, the same `__declspec(dllexport)` / `__declspec(dllimport)` on Windows, and the same no-op on `WIRELOG_STATIC` or unknown compilers.

## Verification

- `meson test -C build --suite abi` reports **23/23** at HEAD (up from 21/21 pre-PR; gained `standalone_include_wirelog_deprecated_macro` and `public_api_macro` tests).  Each commit builds and passes its expected count standalone (21/22/23).
- Manual lint: `python3 scripts/ci/check-public-api-macro.py` exits 0 with `no WIRELOG_PUBLIC tokens outside wirelog/wirelog-export.h (8 prototype headers scanned)`.
- Negative-case sanity (off-tree): reintroducing `WIRELOG_PUBLIC` on any prototype line trips the gate to exit 1 with a clear per-header diagnostic; revert restores exit 0.
- `grep -rn '\bWIRELOG_PUBLIC\b' wirelog/wirelog.h wirelog/wirelog-types.h wirelog/wirelog-ir.h wirelog/wirelog-parser.h wirelog/wirelog-optimizer.h wirelog/wirelog-easy.h wirelog/wirelog-advanced.h wirelog/io/io_adapter.h` is empty.

## Out of scope (per issue body)

- Removing the `WIRELOG_PUBLIC` macro — retained as backward-compat alias.
- Internal `wl_*` prototype changes.
- Per-function `@param`/`@return` Doxygen coverage — separate v0.41+ issue.

## Test plan

- [ ] CI `meson test --suite abi` 23/23 on Linux GCC/Clang.
- [ ] CI `meson test --suite abi` on macOS Clang.
- [ ] CI `meson test --suite abi` on Windows MSVC (verify `cc.get_supported_arguments` picks `/wd4996` and the deprecation smoke test compiles).
- [ ] Existing `abi_symbols`, `public_header_surface`, `public_prefix`, `public_doxygen_headers`, `changelog_format`, `release_template` gates continue to pass.
- [ ] New `public_api_macro` and `standalone_include_wirelog_deprecated_macro` tests appear green.

Closes #782.
Refs #681 (v0.41 ABI Infrastructure epic).