### PR TITLE
fix(#791): DOOP silent abort at stratum 54 + cardinality cap bump

### DIFF
--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2198,6 +2198,31 @@ col_join_output_limit_reached(wl_col_session_t *sess, const col_rel_t *out)
     return out && out->nrows >= limit;
 }
 
+/*
+ * col_join_inloop_backpressure: in-loop soft backpressure check.
+ *
+ * The RELATION-subsystem 80% threshold is a SOFT signal intended for the
+ * multi-worker TDD path, where col_eval_stratum_tdd recovers via EAGAIN
+ * (retry with fewer workers).  Coordinator and single-session evaluators
+ * have no fallback — propagating EOVERFLOW from this signal turns a soft
+ * advisory into an unrecoverable, silent abort (Issue #791: DOOP fails at
+ * stratum 54 SubtypeOf eff_iter=1 when RELATION usage crosses 4.7 GB on a
+ * 16 GB host even though absolute memory is fine and the cardinality cap
+ * is far away).  Restrict this check to worker sessions; the hard
+ * cardinality cap (col_join_output_limit_reached) remains the universal
+ * safety net.  The pre-join coordinator-side BP check still applies and
+ * degrades gracefully to an empty result (Issue #404 design).
+ */
+static inline bool
+col_join_inloop_backpressure(wl_col_session_t *sess, const col_rel_t *out)
+{
+    if (!sess || !sess->coordinator)
+        return false;
+    return out && out->nrows > 0 && out->nrows % 10000 == 0
+           && wl_mem_ledger_should_backpressure(
+        &sess->mem_ledger, WL_MEM_SUBSYS_RELATION, 80);
+}
+
 static int
 col_join_reserve_exact(col_rel_t *rel, uint32_t nrows)
 {
@@ -3041,9 +3066,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                     break;
                 }
                 if (col_join_output_limit_reached(sess, out)
-                    || (out->nrows % 10000 == 0 && out->nrows > 0
-                    && wl_mem_ledger_should_backpressure(
-                        &sess->mem_ledger, WL_MEM_SUBSYS_RELATION, 80))) {
+                    || col_join_inloop_backpressure(sess, out)) {
                     fprintf(stderr,
                         "join output limit reached: %u rows "
                         "(limit=%llu)\n",
@@ -3197,10 +3220,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                                 break;
                             }
                             if (col_join_output_limit_reached(sess, out)
-                                || (out->nrows % 10000 == 0 && out->nrows > 0
-                                && wl_mem_ledger_should_backpressure(
-                                    &sess->mem_ledger, WL_MEM_SUBSYS_RELATION,
-                                    80))) {
+                                || col_join_inloop_backpressure(sess, out)) {
                                 fprintf(
                                     stderr,
                                     "join output limit reached: %u rows "
@@ -3233,10 +3253,7 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                             break;
                         }
                         if (col_join_output_limit_reached(sess, out)
-                            || (out->nrows % 10000 == 0 && out->nrows > 0
-                            && wl_mem_ledger_should_backpressure(
-                                &sess->mem_ledger, WL_MEM_SUBSYS_RELATION,
-                                80))) {
+                            || col_join_inloop_backpressure(sess, out)) {
                             fprintf(stderr,
                                 "join output limit reached: %u rows "
                                 "(limit=%llu)\n",
@@ -6832,9 +6849,12 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 if (join_rc != 0)
                     break;
                 if (col_join_output_limit_reached(sess, out)
-                    || (out->nrows % 10000 == 0 && out->nrows > 0
-                    && wl_mem_ledger_should_backpressure(
-                        &sess->mem_ledger, WL_MEM_SUBSYS_RELATION, 80))) {
+                    || col_join_inloop_backpressure(sess, out)) {
+                    fprintf(stderr,
+                        "join output limit reached (diff): %u rows "
+                        "(limit=%llu)\n",
+                        out->nrows,
+                        (unsigned long long)sess->join_output_limit);
                     join_rc = EOVERFLOW;
                     break;
                 }
@@ -6890,9 +6910,12 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
                 if (join_rc != 0)
                     break;
                 if (col_join_output_limit_reached(sess, out)
-                    || (out->nrows % 10000 == 0 && out->nrows > 0
-                    && wl_mem_ledger_should_backpressure(
-                        &sess->mem_ledger, WL_MEM_SUBSYS_RELATION, 80))) {
+                    || col_join_inloop_backpressure(sess, out)) {
+                    fprintf(stderr,
+                        "join output limit reached (diff): %u rows "
+                        "(limit=%llu)\n",
+                        out->nrows,
+                        (unsigned long long)sess->join_output_limit);
                     join_rc = EOVERFLOW;
                     break;
                 }

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1011,13 +1011,22 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         if (!env_valid) {
             uint64_t phys = col_detect_physical_memory();
             if (phys > 0) {
-                /* Global per-join cap: 25% of RAM / (8 bytes * 5 avg cols).
+                /* Global per-join cap: 25% of RAM / (8 bytes * 3 avg cols).
                  * Each K-fusion worker processes a 1/K data partition, so
                  * per-partition join output does NOT scale with K.  Dividing
                  * by num_workers here was a regression (commit 6929689) that
                  * caused silent data loss in multi-worker mode (Issue #404).
-                 * Dynamic mem_ledger backpressure handles runtime coordination. */
-                sess->join_output_limit = (phys / 4) / 40ULL;
+                 * Dynamic mem_ledger backpressure handles runtime coordination.
+                 *
+                 * Avg-col assumption was 5 (Issue #221, /40), but DOOP-class
+                 * points-to analyses dominate the recursive recursive-join
+                 * cost on 2-3 column intermediates (SubtypeOf, MethodLookup,
+                 * VarPointsTo, CallGraphEdge); /40 was conservatively low and
+                 * caused DOOP to hit the cap at ~105M intermediate rows on
+                 * 16 GB hosts (Issue #791).  /24 is a 67 % headroom bump that
+                 * preserves the 25 % RAM safety margin and matches the
+                 * narrow-join workloads that dominate the v0.43 portfolio. */
+                sess->join_output_limit = (phys / 4) / 24ULL;
             } else {
                 sess->join_output_limit = COL_JOIN_OUTPUT_LIMIT_DEFAULT;
             }


### PR DESCRIPTION
Closes #791.

## Summary

- Gate the in-loop RELATION-subsystem 80 % backpressure check (`col_op_join` + `col_op_join_diff`) to worker sessions only.  Coordinator / single-session evaluators have no recovery path for `EOVERFLOW` from this soft signal — the helper `col_join_inloop_backpressure` short-circuits to `false` when `sess->coordinator == NULL`.  The hard cardinality cap (`col_join_output_limit_reached`) remains the universal safety net.
- Add the missing `fprintf` diagnostic at the two `col_op_join_diff` in-loop sites so a real cardinality-cap hit is visible at any log level.
- Bump the narrow-join avg-col assumption in the dynamic cardinality cap formula from 5 to 3.  Same 25 % RAM safety margin; 67 % more headroom for DOOP-class workloads (16 GB host: 100 M → 166 M; 28 GB Linux: 175 M → 291 M).

## Root cause

DOOP failed silently at stratum 54 `SubtypeOf` `eff_iter=1` on a 16 GB Windows host (regression vs the 2026-04-20 baseline in #512).  Two contributing factors:

1. The in-loop BP check returned `EOVERFLOW` regardless of session type.  Multi-worker TDD recovers via EAGAIN.  Coordinator / single-session has no recovery — the function returned with no `[ERROR]` log, the bench harness reported `FAIL` after ~10 s.
2. Two of the five in-loop sites (`col_op_join_diff` lines 6838, 6896 before the diff) were missing the `fprintf` that the three `col_op_join` sites emit, so even at `WL_LOG=*:1` there was no diagnostic.
3. The cardinality cap formula `(phys / 4) / (5 avg cols * 8 B)` was tuned for wider intermediate relations; DOOP-class points-to analyses dominate on 2–3 column intermediates and produced ~105 M rows on this hardware, just above the 100 M cap.

Once the BP-gate fix exposed the cap hit with a clear `fprintf`, the cap value adjustment landed as the second commit.

The pre-join coordinator-side BP check (Issue #404 design — degrade coordinator joins to empty results gracefully) and the static `COL_JOIN_OUTPUT_LIMIT_DEFAULT = 50M` fallback are untouched.

## Test plan

- [x] Build under MSVC 19.50 (clean rebuild, release mode, no warnings introduced).
- [x] DOOP (zxing) on Windows / MSVC, no `WIRELOG_JOIN_OUTPUT_LIMIT` override: 61.4 s wall, 6,276,657 output tuples (drifts from 2026-04-20 6,275,739 toward Linux 6,276,338 baseline, within the documented hash-iteration-order tolerance band), 9.1 GB peak RSS, 28 iterations.  Status: OK.
- [x] All 14 non-DOOP workloads return **identical** tuple counts to the 2026-04-20 baseline.  TC 4950, Reach 100, Andersen 155, Dyck 2120, CSPA 20381, CSDA 2986, Galen 5568, Polonius 1807, DDISASM 531, CRDT 1301914.
- [ ] Linux side of the portfolio re-run at HEAD (separate task; not blocking this PR).
- [ ] Full `meson test -C build` suite (unit + ASan + threads where applicable) — to run prior to merge.

## Risk

- The gate makes coordinator / single-session joins run unbounded with respect to the soft 80 % RELATION threshold.  Mitigations: (1) hard cardinality cap still applies, (2) `WIRELOG_JOIN_OUTPUT_LIMIT` env override remains the user-side escape valve, (3) pre-join coordinator BP still triggers the graceful empty-result degrade for cases where the join hasn't started yet.
- The cap bump from /40 to /24 raises the cardinality ceiling by 67 %.  On memory-constrained hosts a particularly wide-intermediate join (5+ cols) could now allocate closer to the 25 % RAM budget before tripping.  The avg-cols assumption is still conservative for the workload portfolio dominated by 2–3 col intermediates.

## References

- #791 — investigation and resolution thread
- #512 — Windows/MSVC measurement baseline (head-to-head with Linux)
- Issue #404 — coordinator-side pre-join BP design
- Issue #221 — original join_output_limit + the conservative avg-cols=5 choice