### PR TITLE
tests(parity): cross-facade test-parity audit (7 -> 21 advanced tests + CI gate) (#785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Cross-facade test-parity audit + CI gate** (#785):
+  `tests/test_wirelog_advanced.c` grows from 7 to 21 test
+  functions, mirroring `tests/test_wirelog_easy.c` invariants
+  through the public `wirelog_session_*` surface.  14 new
+  advanced tests cover parse errors, num_workers explicit
+  values, intern stability (twice -- before and after first
+  step), snapshot relation filtering, repeated open/use/close
+  ordering, recursive multi-round delta callbacks, and the full
+  inline-compound + side-compound parity sweep (5 inline-compound
+  binding patterns + 1 side-compound saturation).  Every
+  easy-side test is either paired with a same-named advanced
+  test or carries a `/* PARITY: ... */` block-comment on its
+  declaration line naming the structural reason no advanced
+  analogue exists (12 facade-only annotations covering opts
+  struct, `*_sym` variadics, `wirelog_easy_print_delta`, plus 2
+  deferred-annotations for the #665 partial-conjunction tests
+  whose easy-side test helper is not yet ported to advanced).
+  New gate `scripts/ci/check-test-parity.py` (registered as
+  `meson test --suite abi:test_parity`) enforces the rule
+  per-test, not as a numeric ratio, so future additions on
+  either side cannot silently regress parity.  Result at this
+  commit: 15 paired + 14 annotated = 29 easy tests covered.
 - **`scripts/ci/check-threading-doc.sh`** (#734): static gate
   registered as `meson test --suite abi:threading_doc` that counts
   `atomic_*` call sites in `wirelog/` production sources and asserts
@@ -77,6 +99,14 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+- **`docs/SEMANTICS.md` cross-facade parity audit subsection**
+  (#785, under epic #681): the existing "Cross-facade parity
+  (Status: Current)" block gains a new sub-block recording the
+  per-test paired-or-annotated rule, the lint backstop, and the
+  intentional reverse-parity asymmetry (backend selection is
+  advanced-only by design).  Future maintainers reading the
+  semantic model now see why some `test_create_*` tests are
+  one-sided.
 - **`docs/THREADING.md`** (#734, under epic #681): new canonical
   document covering wirelog's threading model -- backend selection
   (C11 `<threads.h>` > Win32 > POSIX, with `-Dthreads=posix` forcing

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -89,6 +89,31 @@ advanced API exposes backend selection through the
 `wirelog_backend_kind_t` enum (`DEFAULT`, `COLUMNAR`); new backends
 will appear as additive enum values in future minor releases.
 
+#### Parity audit (v0.41 / #785)
+
+The cross-facade contract is mechanically pinned by a per-test
+parity rule: every `test_*` function in
+`tests/test_wirelog_easy.c` is either (a) **paired** with a
+same-named function in `tests/test_wirelog_advanced.c` or
+(b) **annotated** with a `/* PARITY: ... */` block-comment on the
+line(s) immediately preceding the declaration, naming the
+structural reason no advanced analogue exists (typically the
+easy facade carries a convenience surface -- `*_sym` variadics,
+`wirelog_easy_open_opts_t`, `wirelog_easy_print_delta` -- that
+has no `wirelog_session_*` counterpart).  Enforced by
+`scripts/ci/check-test-parity.py` (`meson test --suite abi:test_parity`).
+
+The rule is per-test, not a numeric ratio: future additions on
+either side cannot silently regress parity.  Either pair the new
+test or annotate the easy declaration with the structural reason.
+
+**Reverse parity is intentionally asymmetric.**  Advanced-only
+tests (`test_create_columnar`, `test_create_invalid_backend`,
+`test_null_safety` for backend selection) do not back-port to the
+easy facade -- the easy surface hides backend selection by
+design.  The asymmetry is recorded here so future maintainers do
+not assume symmetric coverage.
+
 ### References
 
 - `wirelog/wirelog-easy.c` — `ensure_plan_built` performs the seed.

--- a/scripts/ci/check-test-parity.py
+++ b/scripts/ci/check-test-parity.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""check-test-parity.py - Issue #785 cross-facade test-parity gate.
+
+Asserts that every `test_*` function in `tests/test_wirelog_easy.c`
+is either:
+
+  (a) **Paired** -- a function with the same name exists in
+      `tests/test_wirelog_advanced.c`, OR
+  (b) **Annotated** -- the immediately-preceding line(s) carry a
+      `/* PARITY: ... */` block-comment naming the reason no
+      advanced analogue exists (typically because the easy facade
+      surface has no advanced counterpart -- `*_sym` variadics,
+      `WIRELOG_EASY_OPEN_OPTS_INIT`, `wirelog_easy_print_delta`,
+      etc.).
+
+The rule is per-test (no ratio threshold) so future easy-side
+additions cannot silently regress parity coverage; either pair the
+new test on the advanced side, or annotate the easy declaration
+with the structural reason.
+
+Source-of-truth comments:
+
+  - Easy test file: `tests/test_wirelog_easy.c`.
+  - Advanced test file: `tests/test_wirelog_advanced.c`.
+  - PARITY-annotation format: `/* PARITY: <text> */` on the line
+    immediately preceding `static void test_X(void)`.
+
+Exit codes:
+
+  0 -- every easy test is paired or annotated.
+  1 -- at least one easy test is unpaired and unannotated.
+
+Run as a lint-stage script under `meson test --suite abi:test_parity`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+EASY = REPO_ROOT / "tests" / "test_wirelog_easy.c"
+ADVANCED = REPO_ROOT / "tests" / "test_wirelog_advanced.c"
+
+NAME_RE = re.compile(r"^test_([A-Za-z0-9_]+)\(void\)$")
+PARITY_RE = re.compile(r"/\*\s*PARITY\s*:")
+
+
+def die(msg: str) -> None:
+    print(f"check-test-parity: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def collect_test_names(path: pathlib.Path) -> dict[str, int]:
+    """Return {test_name: 1-based_line_no} for every `test_*(void)`
+    in the file."""
+    out: dict[str, int] = {}
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        m = NAME_RE.match(line)
+        if m:
+            out[f"test_{m.group(1)}"] = lineno
+    return out
+
+
+def has_parity_annotation(lines: list[str], decl_lineno: int) -> bool:
+    """Check whether the lines immediately preceding the `test_X(void)`
+    declaration at decl_lineno (1-based) carry a PARITY annotation.
+    The annotation can sit either on the line above the declaration
+    or on the line above `static void` (the previous line).  Look
+    back up to 5 lines."""
+    start = max(0, decl_lineno - 6)
+    window = "\n".join(lines[start : decl_lineno - 1])
+    return bool(PARITY_RE.search(window))
+
+
+def main() -> int:
+    for p in (EASY, ADVANCED):
+        if not p.is_file():
+            die(f"missing test file: {p}")
+
+    easy_names = collect_test_names(EASY)
+    advanced_names = set(collect_test_names(ADVANCED).keys())
+    easy_lines = EASY.read_text().splitlines()
+
+    missing: list[tuple[str, int]] = []
+    for name, lineno in easy_names.items():
+        if name in advanced_names:
+            continue
+        if has_parity_annotation(easy_lines, lineno):
+            continue
+        missing.append((name, lineno))
+
+    if missing:
+        print(
+            f"check-test-parity: FAIL: {len(missing)} easy test(s) "
+            f"unpaired AND unannotated:",
+            file=sys.stderr,
+        )
+        for name, lineno in missing:
+            rel = EASY.relative_to(REPO_ROOT)
+            print(f"  {rel}:{lineno}: {name}", file=sys.stderr)
+        print(
+            "",
+            "Fix one of:",
+            "  (a) Add the same-named function to "
+            "tests/test_wirelog_advanced.c, OR",
+            "  (b) Prepend a `/* PARITY: facade-only -- <reason> */`",
+            "      block-comment on the line(s) immediately above the",
+            "      `static void test_X(void)` declaration in easy.",
+            sep="\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    paired = sum(1 for n in easy_names if n in advanced_names)
+    annotated = len(easy_names) - paired - len(missing)
+    print(
+        f"check-test-parity: OK; {paired} paired, {annotated} annotated "
+        f"({len(easy_names)} easy test(s) total; "
+        f"{len(advanced_names)} advanced test(s))"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-test-parity.py
+++ b/scripts/ci/check-test-parity.py
@@ -54,12 +54,18 @@ def die(msg: str) -> None:
 
 def collect_test_names(path: pathlib.Path) -> dict[str, int]:
     """Return {test_name: 1-based_line_no} for every `test_*(void)`
-    in the file."""
+    in the file.  Duplicate names fail loudly (a C linker would
+    reject them anyway, but the lint catches them earlier with a
+    clearer diagnostic)."""
     out: dict[str, int] = {}
     for lineno, line in enumerate(path.read_text().splitlines(), start=1):
         m = NAME_RE.match(line)
         if m:
-            out[f"test_{m.group(1)}"] = lineno
+            name = f"test_{m.group(1)}"
+            if name in out:
+                die(f"duplicate test name {name} at {path.name}:{lineno} "
+                    f"(also at line {out[name]})")
+            out[name] = lineno
     return out
 
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -421,6 +421,15 @@ test('public_api_macro', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-api-macro.py'],
      suite: 'abi')
 
+# Issue #785: cross-facade test parity.  Every test_* function in
+# tests/test_wirelog_easy.c must either pair with a same-named
+# function in tests/test_wirelog_advanced.c or carry a
+# `/* PARITY: ... */` annotation on the line(s) above its
+# declaration.  Static text scan.
+test('test_parity', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-test-parity.py'],
+     suite: 'abi')
+
 # Issue #780 / Epic #680 exit gate: every public header must carry
 # `@file` and `@brief` inside a `/** ... */` Doxygen block.  Header
 # list is sourced from `parse_meson_sot` in check-public-header-surface.py

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -9,12 +9,19 @@
  * facades cannot drift apart silently.
  */
 
+/* setenv / unsetenv are POSIX (used by the side-compound saturation
+ * parity test).  The Windows variants used by test_wirelog_easy.c live
+ * under _WIN32 and are out of scope for the v0.40 sweep. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "wirelog/wirelog-advanced.h"
 #include "wirelog/wirelog.h"
 #include "wirelog/intern.h"
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static const char *PROG_SRC =
     ".decl edge(a:symbol,b:symbol)\n"
@@ -64,6 +71,34 @@ count_deltas(const char *relation, const int64_t *row, uint32_t ncols,
         st->inserts++;
     else if (diff < 0)
         st->removes++;
+}
+
+/* Per-relation tuple collector used by inline-compound parity tests
+ * (#785).  wirelog_session_snapshot has no relation filter (the easy
+ * counterpart does), so we filter inside the callback. */
+#define WL_FILTER_MAX_ROWS 8
+#define WL_FILTER_MAX_COLS 8
+
+struct tuple_filter {
+    const char *target_relation;
+    int count;
+    uint32_t ncols[WL_FILTER_MAX_ROWS];
+    int64_t rows[WL_FILTER_MAX_ROWS][WL_FILTER_MAX_COLS];
+};
+
+static void
+filter_tuples(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    struct tuple_filter *f = (struct tuple_filter *)user_data;
+    if (strcmp(relation, f->target_relation) != 0)
+        return;
+    if (f->count >= WL_FILTER_MAX_ROWS)
+        return;
+    int idx = f->count++;
+    f->ncols[idx] = ncols;
+    for (uint32_t i = 0; i < ncols && i < WL_FILTER_MAX_COLS; i++)
+        f->rows[idx][i] = row[i];
 }
 
 static wirelog_program_t *
@@ -383,6 +418,325 @@ test_num_workers_explicit_four(void)
     return rc;
 }
 
+/* Parity (#785): mirrors test_wirelog_easy.c::test_inline_compound_body_binding.
+ * Asserts the inline-compound body pattern `metadata(L,T,H,R)` binds
+ * the four child variables so the head condition `R > 80` filters
+ * rows correctly. */
+static int
+test_inline_compound_body_binding(void)
+{
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)),"
+        " Risk > 80.\n";
+    wirelog_program_t *prog = parse_or_die(src, "T11");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
+    int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
+    int rc = 0;
+    if (wirelog_session_insert(s, "event", hot_row, 1, 5) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", cold_row, 1, 5) != WIRELOG_OK) {
+        fprintf(stderr, "T11 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+    struct tuple_filter f = { .target_relation = "hot" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T11 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.ncols[0] != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr,
+            "T11: expected only hot(7), got count=%d row0[0]=%lld\n",
+            f.count, (long long)f.rows[0][0]);
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_inline_compound_body_join_binding.
+ * Verifies that body variables from the inline compound participate
+ * in joins (here: Risk joins threshold). */
+static int
+test_inline_compound_body_join_binding(void)
+{
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl threshold(risk: int64)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(Level, Ts, Host, Risk)),"
+        " threshold(Risk).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T12");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int64_t matched[5] = { 7, 1, 2, 3, 90 };
+    int64_t unmatched[5] = { 8, 1, 2, 3, 40 };
+    int64_t threshold_row[1] = { 90 };
+    int rc = 0;
+    if (wirelog_session_insert(s, "event", matched, 1, 5) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", unmatched, 1, 5) != WIRELOG_OK
+        || wirelog_session_insert(s, "threshold", threshold_row, 1, 1)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T12 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+    struct tuple_filter f = { .target_relation = "hot" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T12 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr, "T12: expected join to derive only hot(7)\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_inline_compound_functor_mismatch_is_empty.
+ * A body using a different functor name does not match. */
+static int
+test_inline_compound_functor_mismatch_is_empty(void)
+{
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl bad(id: int64)\n"
+        "bad(ID) :- event(ID, other(Level, Ts, Host, Risk)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T13");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int64_t row[5] = { 7, 1, 2, 3, 90 };
+    int rc = 0;
+    if (wirelog_session_insert(s, "event", row, 1, 5) != WIRELOG_OK) {
+        fprintf(stderr, "T13 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+    struct tuple_filter f = { .target_relation = "bad" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T13 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 0) {
+        fprintf(stderr,
+            "T13: mismatched functor should derive no rows, got %d\n",
+            f.count);
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_inline_compound_constant_child_filters.
+ * A constant in a child slot filters rows that do not match the
+ * literal value. */
+static int
+test_inline_compound_constant_child_filters(void)
+{
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, metadata(_, _, _, 90)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T14");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int64_t hot_row[5] = { 7, 1, 2, 3, 90 };
+    int64_t cold_row[5] = { 8, 1, 2, 3, 40 };
+    int rc = 0;
+    if (wirelog_session_insert(s, "event", hot_row, 1, 5) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", cold_row, 1, 5) != WIRELOG_OK) {
+        fprintf(stderr, "T14 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+    struct tuple_filter f = { .target_relation = "hot" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T14 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr,
+            "T14: expected only row with constant child 90\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_inline_compound_duplicate_child_variables_filter.
+ * Repeating a child variable in a compound pattern filters rows where
+ * the two slots are unequal. */
+static int
+test_inline_compound_duplicate_child_variables_filter(void)
+{
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 inline)\n"
+        ".decl same(id: int64)\n"
+        "same(ID) :- event(ID, metadata(X, X, _, _)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T15");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int64_t matched[5] = { 7, 4, 4, 3, 90 };
+    int64_t unmatched[5] = { 8, 1, 2, 3, 90 };
+    int rc = 0;
+    if (wirelog_session_insert(s, "event", matched, 1, 5) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", unmatched, 1, 5) != WIRELOG_OK) {
+        fprintf(stderr, "T15 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+    struct tuple_filter f = { .target_relation = "same" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T15 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr,
+            "T15: expected only row with equal duplicate variables\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_side_compound_public_allocation_saturates.
+ * With WIRELOG_COMPOUND_MAX_EPOCHS=2, the second compound allocation
+ * across two epochs reports WIRELOG_ERR_COMPOUND_SATURATED and the
+ * out-handle is cleared to WIRELOG_COMPOUND_HANDLE_NULL. */
+static int
+test_side_compound_public_allocation_saturates(void)
+{
+    if (setenv("WIRELOG_COMPOUND_MAX_EPOCHS", "2", 1) != 0)
+        return 1;
+
+    const char *src
+        = ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl seen(id: int64)\n"
+        ".decl edge(x: int64, y: int64)\n"
+        ".decl tc(x: int64, y: int64)\n"
+        "seen(ID) :- event(ID, _).\n"
+        "tc(X, Y) :- edge(X, Y).\n"
+        "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T16");
+    if (!prog) {
+        unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+        return 1;
+    }
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+        return 1;
+    }
+
+    wirelog_compound_arg_t args[4] = {
+        { WIRELOG_TYPE_INT64, 1 },
+        { WIRELOG_TYPE_INT64, 2 },
+        { WIRELOG_TYPE_INT64, 3 },
+        { WIRELOG_TYPE_INT64, 4 },
+    };
+    uint64_t handle = 0;
+    int rc = 0;
+    wirelog_error_t mc_rc
+        = wirelog_session_make_compound(s, "metadata", 4, args, &handle);
+    if (mc_rc != WIRELOG_OK || handle == WIRELOG_COMPOUND_HANDLE_NULL) {
+        fprintf(stderr,
+            "T16: first make_compound failed rc=%d handle=%llu\n",
+            mc_rc, (unsigned long long)handle);
+        rc = 1;
+        goto out;
+    }
+    int64_t event_row[2] = { 1, (int64_t)handle };
+    int64_t edge_12[2] = { 1, 2 };
+    int64_t edge_23[2] = { 2, 3 };
+    int64_t edge_34[2] = { 3, 4 };
+    if (wirelog_session_insert(s, "event", event_row, 1, 2) != WIRELOG_OK
+        || wirelog_session_insert(s, "edge", edge_12, 1, 2) != WIRELOG_OK
+        || wirelog_session_insert(s, "edge", edge_23, 1, 2) != WIRELOG_OK
+        || wirelog_session_insert(s, "edge", edge_34, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T16 first insert/step failed\n");
+        rc = 1;
+        goto out;
+    }
+    handle = 123;
+    mc_rc = wirelog_session_make_compound(s, "metadata", 4, args, &handle);
+    if (mc_rc != WIRELOG_ERR_COMPOUND_SATURATED
+        || handle != WIRELOG_COMPOUND_HANDLE_NULL) {
+        fprintf(stderr,
+            "T16: expected SATURATED + cleared handle, got rc=%d "
+            "handle=%llu\n",
+            mc_rc, (unsigned long long)handle);
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    unsetenv("WIRELOG_COMPOUND_MAX_EPOCHS");
+    return rc;
+}
+
 int
 main(void)
 {
@@ -397,6 +751,12 @@ main(void)
     failures += test_open_parse_error();
     failures += test_num_workers_default_is_one();
     failures += test_num_workers_explicit_four();
+    failures += test_inline_compound_body_binding();
+    failures += test_inline_compound_body_join_binding();
+    failures += test_inline_compound_functor_mismatch_is_empty();
+    failures += test_inline_compound_constant_child_filters();
+    failures += test_inline_compound_duplicate_child_variables_filter();
+    failures += test_side_compound_public_allocation_saturates();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");
     else

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -302,6 +302,87 @@ test_null_safety(void)
     return rc;
 }
 
+/* Parity (#785): mirrors test_wirelog_easy.c::test_open_parse_error.
+ * On the advanced side, parsing happens explicitly via
+ * wirelog_parse_string; the test asserts that malformed Datalog
+ * returns NULL and sets the error indicator. */
+static int
+test_open_parse_error(void)
+{
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog
+        = wirelog_parse_string("this is not datalog ::: !!!", &err);
+    int rc = 0;
+    if (prog) {
+        fprintf(stderr, "T8: parse should have failed, got prog=%p\n",
+            (void *)prog);
+        wirelog_program_free(prog);
+        rc = 1;
+    }
+    if (err == WIRELOG_OK) {
+        fprintf(stderr, "T8: parse failed but err == WIRELOG_OK\n");
+        rc = 1;
+    }
+    return rc;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_num_workers_default_is_one.
+ * Where the easy facade reads num_workers from an opts struct and
+ * defaults to 1 when unspecified, the advanced API takes num_workers
+ * as an explicit constructor argument; this test verifies that
+ * passing 1 is accepted and the resulting session is usable. */
+static int
+test_num_workers_default_is_one(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T9");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s);
+    int rc = 0;
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T9 create num_workers=1 err=%d\n", err);
+        rc = 1;
+    } else if (wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T9 step failed with num_workers=1\n");
+        rc = 1;
+    }
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_num_workers_explicit_four.
+ * Pass num_workers=4 explicitly and verify session_create accepts the
+ * value and the resulting session can evaluate a step.  The easy-side
+ * test captures the log line to verify the value reached the runtime;
+ * on the advanced side num_workers IS the parameter, so behavioural
+ * verification (step succeeds) is sufficient. */
+static int
+test_num_workers_explicit_four(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T10");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 4, &s);
+    int rc = 0;
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T10 create num_workers=4 err=%d\n", err);
+        rc = 1;
+    } else if (wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T10 step failed with num_workers=4\n");
+        rc = 1;
+    }
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
 int
 main(void)
 {
@@ -313,6 +394,9 @@ main(void)
     failures += test_insert_step_delta();
     failures += test_insert_remove_roundtrip();
     failures += test_null_safety();
+    failures += test_open_parse_error();
+    failures += test_num_workers_default_is_one();
+    failures += test_num_workers_explicit_four();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");
     else

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -737,6 +737,246 @@ out:
     return rc;
 }
 
+/* Parity (#785): mirrors test_wirelog_easy.c::test_intern_returns_same_id.
+ * Interning the same string twice through wl_intern_put must return
+ * the same int64 id; the advanced API exposes the intern table via
+ * wirelog_program_get_intern. */
+static int
+test_intern_returns_same_id(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T17");
+    if (!prog)
+        return 1;
+
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t a = wl_intern_put(intern, "alice");
+    int64_t b = wl_intern_put(intern, "alice");
+    int rc = 0;
+    if (a < 0 || b < 0 || a != b) {
+        fprintf(stderr,
+            "T17: intern inconsistent a=%lld b=%lld\n",
+            (long long)a, (long long)b);
+        rc = 1;
+    }
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_snapshot_filter.
+ * wirelog_session_snapshot itself does not filter by relation, but
+ * the per-tuple callback can.  Insert into two relations (edge and
+ * derived path), then verify the filter callback collects only the
+ * targeted relation's rows. */
+static int
+test_snapshot_filter(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T18");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t a = wl_intern_put(intern, "a");
+    int64_t b = wl_intern_put(intern, "b");
+    int64_t c = wl_intern_put(intern, "c");
+    int rc = 0;
+    int64_t e_ab[2] = { a, b };
+    int64_t e_bc[2] = { b, c };
+    if (wirelog_session_insert(s, "edge", e_ab, 1, 2) != WIRELOG_OK
+        || wirelog_session_insert(s, "edge", e_bc, 1, 2) != WIRELOG_OK) {
+        fprintf(stderr, "T18 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter path_filter = { .target_relation = "path" };
+    if (wirelog_session_snapshot(s, filter_tuples, &path_filter)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T18 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    /* path is transitive closure over edge: expect path(a,b), path(b,c),
+     * path(a,c) -> 3 rows. */
+    if (path_filter.count != 3) {
+        fprintf(stderr,
+            "T18: expected 3 path tuples after filter, got %d\n",
+            path_filter.count);
+        rc = 1;
+    }
+    /* All filtered rows must be from the "path" relation. */
+    for (int i = 0; i < path_filter.count; i++) {
+        if (path_filter.ncols[i] != 2) {
+            fprintf(stderr, "T18: path row %d ncols=%u\n",
+                i, path_filter.ncols[i]);
+            rc = 1;
+        }
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_cleanup_order_no_use_after_free.
+ * Repeated open/use/close cycles must not leak or use-after-free under
+ * ASAN.  Mirrors easy by running two iterations through a tiny insert
+ * + step cycle. */
+static int
+test_cleanup_order_no_use_after_free(void)
+{
+    for (int iter = 0; iter < 2; iter++) {
+        wirelog_program_t *prog = parse_or_die(PROG_SRC, "T19");
+        if (!prog)
+            return 1;
+
+        wirelog_session_t *s = NULL;
+        if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+            != WIRELOG_OK || !s) {
+            wirelog_program_free(prog);
+            return 1;
+        }
+
+        wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+        int64_t a = wl_intern_put(intern, "a");
+        int64_t b = wl_intern_put(intern, "b");
+        int64_t row[2] = { a, b };
+        int rc = 0;
+        if (wirelog_session_insert(s, "edge", row, 1, 2) != WIRELOG_OK
+            || wirelog_session_step(s) != WIRELOG_OK) {
+            fprintf(stderr, "T19 iter=%d insert/step failed\n", iter);
+            rc = 1;
+        }
+        wirelog_session_destroy(s);
+        wirelog_program_free(prog);
+        if (rc)
+            return rc;
+    }
+    return 0;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_intern_after_step_succeeds.
+ * Interning a brand new symbol after the plan has been built and
+ * stepped must still succeed; the new id must be usable for a
+ * subsequent insert+step. */
+static int
+test_intern_after_step_succeeds(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T20");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t a = wl_intern_put(intern, "a");
+    int64_t b = wl_intern_put(intern, "b");
+    int rc = 0;
+    int64_t row[2] = { a, b };
+    if (wirelog_session_insert(s, "edge", row, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T20 first insert/step failed\n");
+        rc = 1;
+        goto out;
+    }
+    /* Intern a brand new symbol after the first step. */
+    int64_t late = wl_intern_put(intern, "late_symbol");
+    if (late < 0) {
+        fprintf(stderr, "T20 late intern failed\n");
+        rc = 1;
+        goto out;
+    }
+    int64_t late_row[2] = { late, b };
+    if (wirelog_session_insert(s, "edge", late_row, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T20 late insert/step failed\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_wirelog_easy.c::test_delta_cb_multi_round_recursive_insert.
+ * Issue #662 invariant: a delta callback installed before two
+ * insert+step rounds on a recursive stratum must observe deltas in
+ * BOTH rounds.  Without the symmetric arrangement-cache invalidation
+ * the second round either drops deltas or trips on stale joins. */
+static int
+test_delta_cb_multi_round_recursive_insert(void)
+{
+    static const char *RECURSIVE_REACH_SRC
+        = ".decl edge(a: int64, b: int64)\n"
+        ".decl reach(a: int64, b: int64)\n"
+        "reach(A, B) :- edge(A, B).\n"
+        "reach(A, C) :- reach(A, B), edge(B, C).\n";
+
+    wirelog_program_t *prog = parse_or_die(RECURSIVE_REACH_SRC, "T21");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    struct delta_state st = { 0, 0 };
+    if (wirelog_session_set_delta_cb(s, count_deltas, &st) != WIRELOG_OK) {
+        wirelog_session_destroy(s);
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    int rc = 0;
+    int64_t e12[2] = { 1, 2 };
+    if (wirelog_session_insert(s, "edge", e12, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T21 round 1 insert/step failed\n");
+        rc = 1;
+        goto out;
+    }
+    uint32_t first_round_inserts = st.inserts;
+    if (first_round_inserts == 0) {
+        fprintf(stderr, "T21 round 1: no inserts surfaced\n");
+        rc = 1;
+        goto out;
+    }
+
+    /* Second insert/step round must also surface deltas on the
+     * recursive stratum. */
+    int64_t e23[2] = { 2, 3 };
+    if (wirelog_session_insert(s, "edge", e23, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(s) != WIRELOG_OK) {
+        fprintf(stderr, "T21 round 2 insert/step failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (st.inserts <= first_round_inserts) {
+        fprintf(stderr,
+            "T21 round 2: expected more inserts than round 1=%u, got %u\n",
+            first_round_inserts, st.inserts);
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
 int
 main(void)
 {
@@ -757,6 +997,11 @@ main(void)
     failures += test_inline_compound_constant_child_filters();
     failures += test_inline_compound_duplicate_child_variables_filter();
     failures += test_side_compound_public_allocation_saturates();
+    failures += test_intern_returns_same_id();
+    failures += test_snapshot_filter();
+    failures += test_cleanup_order_no_use_after_free();
+    failures += test_intern_after_step_succeeds();
+    failures += test_delta_cb_multi_round_recursive_insert();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");
     else

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -23,6 +23,28 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+/* MSVC's CRT lacks POSIX setenv / unsetenv; route through _putenv_s.
+ * Mirrors the same shim block in tests/test_wirelog_easy.c so the
+ * cross-facade saturation parity test (T16) compiles cleanly under
+ * the Windows MSVC CI leg. */
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#endif
+
 static const char *PROG_SRC =
     ".decl edge(a:symbol,b:symbol)\n"
     ".decl path(a:symbol,b:symbol)\n"

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -257,6 +257,7 @@ capture_num_workers_log(const wirelog_easy_open_opts_t *opts, uint32_t expected)
 /* Tests                                                                    */
 /* ======================================================================== */
 
+/* PARITY: paired -- mirrored by test_null_safety on the advanced side (#785). */
 static void
 test_open_close_null_safe(void)
 {
@@ -824,6 +825,7 @@ test_side_compound_public_allocation_saturates(void)
     PASS();
 }
 
+/* PARITY: facade-only -- no wirelog_session_insert_sym variadic on advanced (#785). */
 static void
 test_insert_sym_variadic(void)
 {
@@ -866,6 +868,7 @@ test_insert_sym_variadic(void)
     PASS();
 }
 
+/* PARITY: facade-only -- no wirelog_session_remove_sym; row-form remove paired by test_insert_remove_roundtrip (#785). */
 static void
 test_remove_sym(void)
 {
@@ -986,6 +989,7 @@ test_snapshot_filter(void)
     PASS();
 }
 
+/* PARITY: facade-only -- wirelog_easy_print_delta is a stdout helper; no advanced equivalent (#785). */
 static void
 test_print_delta_integer_column(void)
 {
@@ -1015,6 +1019,7 @@ test_print_delta_integer_column(void)
     PASS();
 }
 
+/* PARITY: facade-only -- wirelog_easy_print_delta is a stdout helper; no advanced equivalent (#785). */
 static void
 test_print_delta_unknown_relation_integer_fallback(void)
 {
@@ -1061,6 +1066,7 @@ test_print_delta_unknown_relation_integer_fallback(void)
 #endif
 }
 
+/* PARITY: facade-only -- wirelog_easy_print_delta is a stdout helper; no advanced equivalent (#785). */
 static void
 test_print_delta_abort_on_missed_symbol(void)
 {
@@ -1384,6 +1390,7 @@ drive_issue_665_partial_conjunction(wirelog_easy_session_t *s)
     return matched;
 }
 
+/* PARITY: deferred -- #665 partial-conjunction regression scenario relies on the easy-specific drive_issue_665_partial_conjunction helper; advanced-side port tracked separately (#785 follow-up). */
 static void
 test_issue_665_partial_conjunction_default_workers(void)
 {
@@ -1403,6 +1410,7 @@ test_issue_665_partial_conjunction_default_workers(void)
     PASS();
 }
 
+/* PARITY: deferred -- multi-worker opts-path variant of the #665 scenario; advanced exposes num_workers via constructor (test_num_workers_explicit_four), but the full #665 helper port is the v0.41+ follow-up above. */
 static void
 test_issue_665_partial_conjunction_multi_worker(void)
 {

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -231,7 +231,8 @@ capture_num_workers_log(const wirelog_easy_open_opts_t *opts, uint32_t expected)
     close(log_fd);
 
     wirelog_easy_session_t *s = NULL;
-    wirelog_error_t open_rc = wirelog_easy_open_opts(ACCESS_CONTROL_SRC, opts, &s);
+    wirelog_error_t open_rc = wirelog_easy_open_opts(ACCESS_CONTROL_SRC, opts,
+            &s);
     wirelog_error_t build_rc = WIRELOG_ERR_EXEC;
     if (open_rc == WIRELOG_OK && s)
         build_rc = wirelog_easy_set_delta_cb(s, NULL, NULL);
@@ -293,13 +294,15 @@ test_open_parse_error(void)
     PASS();
 }
 
+/* PARITY: facade-only -- wirelog_session_create has no opts struct (#785). */
 static void
 test_open_opts_null_equiv_to_open(void)
 {
     TEST("open_opts NULL opts equivalent to open");
 
     wirelog_easy_session_t *s = NULL;
-    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, NULL, &s) != WIRELOG_OK || !s) {
+    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, NULL,
+        &s) != WIRELOG_OK || !s) {
         FAIL("open_opts failed");
         return;
     }
@@ -312,6 +315,7 @@ test_open_opts_null_equiv_to_open(void)
     PASS();
 }
 
+/* PARITY: facade-only -- advanced API has no opts struct to size-validate (#785). */
 static void
 test_open_opts_zero_size_rejected(void)
 {
@@ -331,6 +335,7 @@ test_open_opts_zero_size_rejected(void)
     PASS();
 }
 
+/* PARITY: facade-only -- no _reserved field on the advanced API surface (#785). */
 static void
 test_open_opts_reserved_rejected(void)
 {
@@ -352,6 +357,7 @@ test_open_opts_reserved_rejected(void)
     PASS();
 }
 
+/* PARITY: facade-only -- WIRELOG_EASY_OPEN_OPTS_INIT is a facade convenience macro (#785). */
 static void
 test_open_opts_init_macro(void)
 {
@@ -377,6 +383,7 @@ test_open_opts_init_macro(void)
     PASS();
 }
 
+/* PARITY: facade-only -- advanced wirelog_session_create is always eager; no eager_build flag (#785). */
 static void
 test_open_opts_eager_build_ok(void)
 {
@@ -385,7 +392,8 @@ test_open_opts_eager_build_ok(void)
     wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
     opts.eager_build = true;
     wirelog_easy_session_t *s = NULL;
-    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, &opts, &s) != WIRELOG_OK || !s) {
+    if (wirelog_easy_open_opts(ACCESS_CONTROL_SRC, &opts,
+        &s) != WIRELOG_OK || !s) {
         FAIL("open_opts eager_build failed");
         return;
     }
@@ -404,6 +412,7 @@ test_open_opts_eager_build_ok(void)
  * parse-error path (per the architect+critic synthesis plan, scope-narrow per
  * Critic MAJOR #6).
  */
+/* PARITY: facade-only -- advanced parse error is covered by test_open_parse_error (#785). */
 static void
 test_open_opts_eager_build_propagates_parse_error(void)
 {
@@ -599,7 +608,8 @@ test_inline_compound_body_join_binding(void)
     int64_t threshold_row[1] = { 90 };
     if (wirelog_easy_insert(s, "event", matched_row, 5) != WIRELOG_OK
         || wirelog_easy_insert(s, "event", unmatched_row, 5) != WIRELOG_OK
-        || wirelog_easy_insert(s, "threshold", threshold_row, 1) != WIRELOG_OK) {
+        || wirelog_easy_insert(s, "threshold", threshold_row,
+        1) != WIRELOG_OK) {
         FAIL("insert failed");
         wirelog_easy_close(s);
         return;
@@ -1106,7 +1116,8 @@ test_cleanup_order_no_use_after_free(void)
             FAIL("open failed");
             return;
         }
-        if (wirelog_easy_insert_sym(s, "can", "alice", "read", (const char *)NULL)
+        if (wirelog_easy_insert_sym(s, "can", "alice", "read",
+            (const char *)NULL)
             != WIRELOG_OK) {
             FAIL("insert_sym failed");
             wirelog_easy_close(s);
@@ -1321,7 +1332,8 @@ drive_issue_665_partial_conjunction(wirelog_easy_session_t *s)
 
     /* Step 3: session_state(S, ST) — still missing session_active and
      * perm_state, so the join body is unsatisfied. */
-    if (wirelog_easy_insert_sym(s, "session_state", "s", "st", (const char *)NULL)
+    if (wirelog_easy_insert_sym(s, "session_state", "s", "st",
+        (const char *)NULL)
         != WIRELOG_OK)
         return false;
     if (wirelog_easy_step(s) != WIRELOG_OK)


### PR DESCRIPTION
## Summary

Closes the cross-facade test-parity exit condition under v0.41 epic #681.  `tests/test_wirelog_advanced.c` grows from **7 to 21 test functions** (3 commits), every easy-side test is either paired by exact name or annotated with a structural `/* PARITY: ... */` reason, and a new CI gate (`scripts/ci/check-test-parity.py` under `meson test --suite abi:test_parity`) prevents future drift.

## Atomic commit series (4)

1. **C1 `76ce94e`** — `parse_error + num_workers` parity (3 new advanced tests) + 6 facade-only annotations on opts tests (no advanced opts struct).
2. **C2 `932e448`** — inline-compound + side-compound parity (6 new advanced tests).  Adds shared `filter_tuples` helper since `wirelog_session_snapshot` has no relation filter (the easy counterpart does); `_POSIX_C_SOURCE 200809L` for `setenv`/`unsetenv` in the saturation test.
3. **C3 `5f947a2`** — remaining 5 parity pairs (intern stability, snapshot filter, cleanup ordering, intern-after-step, recursive multi-round delta callback) + 6 more annotations (1 PAIRED for `test_null_safety` mirror, 5 facade-only for `*_sym` variadics and `print_delta` helpers, 2 deferred for #665 partial-conjunction tests whose easy-side helper port is out of scope) + new lint + `docs/SEMANTICS.md` "Parity audit" sub-block + CHANGELOG entries.
4. **Fixup `b9a2317`** — meta-review-flagged defensive guard: lint now `die()`s with a clear diagnostic if a `test_X(void)` declaration appears twice in either file.  C linker would reject the duplicate anyway, but the lint pre-empts at lint time.

## Parity outcome

| Metric | Before | After |
|---|---:|---:|
| advanced test functions | 7 | **21** |
| easy test functions | 29 | 29 |
| paired by exact name | 2 | **15** |
| annotated `/* PARITY: ... */` | 0 | **14** |
| coverage (paired + annotated) | 2/29 (7%) | **29/29 (100%)** |

## CI gate

`meson test --suite abi:test_parity` now has 25 tests (up from 24), with the new `test_parity` gate enforcing per-test paired-or-annotated rule:

```
check-test-parity: OK; 15 paired, 14 annotated
(29 easy test(s) total; 21 advanced test(s))
```

The gate is **per-test** not **per-ratio** — future easy-side additions cannot silently regress parity; they must either pair on advanced or carry a `/* PARITY: ... */` annotation naming the structural reason.

## Reverse-parity asymmetry

`docs/SEMANTICS.md` "Cross-facade parity" subsection gains a "Parity audit (v0.41 / #785)" sub-block documenting:

- The per-test rule.
- The lint backstop and where to run it.
- The intentional reverse-parity asymmetry: advanced-only tests (`test_create_columnar`, `test_create_invalid_backend`, `test_null_safety` for backend selection) do NOT back-port to the easy facade because the easy surface hides backend selection by design.

## Verification

- `meson test -C build --suite abi` -> **25/25 OK** (gained `test_parity`).
- `meson test -C build wirelog_advanced wirelog_easy` -> **2/2 OK**.
- `python3 scripts/ci/check-test-parity.py` -> exit 0; "15 paired, 14 annotated".
- Negative-case (off-tree): synthetic unpaired easy test trips gate to exit 1; restore -> exit 0.  Duplicate test name in either file -> `die()` with clear `at file:LINE (also at line ORIG)` diagnostic.
- API discipline: `grep -c 'wirelog_session_' tests/test_wirelog_advanced.c` = 113; `wirelog_easy_` = 0.

## Out of scope (explicitly disclaimed)

- The #665 partial-conjunction easy-side helper (`drive_issue_665_partial_conjunction`) is not ported to advanced; both #665 tests carry a "PARITY: deferred" annotation noting the gap is tracked under the v0.41 epic #681.
- Backwards `easy <- advanced` parity for backend-selection tests (e.g. `test_create_columnar`) is intentionally absent per the SEMANTICS asymmetry note.
- The `filter_tuples` helper has fixed-size 8x8 arrays; current parity tests fit comfortably (max 3 path rows).

## Test plan

- [ ] CI `meson test --suite abi` 25/25 on Linux GCC/Clang.
- [ ] CI on macOS Clang.
- [ ] CI on Windows MSVC (verifies POSIX-conditional `setenv` path compiles + skips correctly; the `_POSIX_C_SOURCE` guard makes the symbols visible only where they exist).
- [ ] `test_parity` gate appears in test output green.
- [ ] Existing `wirelog_advanced`, `wirelog_easy`, `wirelog_easy_inline_facts` tests continue to pass.

Closes #785.
Refs #681, #717, #662, #665.