### PR TITLE
feat(#786): libabigail .abi.json manifest gate + abidiff CI test

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -32,6 +32,18 @@ when a published release exists for the tag at HEAD; it SKIPs
 cleanly on PR builds and on tags whose release does not yet
 exist.
 
+### ABI manifest update
+
+The libabigail-backed `abi/libwirelog-1.0.abi.json` baseline pins struct
+layouts, function signatures, and visibility attributes that the
+`abi/libwirelog-1.0.symbols` allowlist cannot see (Issue #786 /
+`meson test --suite abi:abi_manifest`).  On a release PR that
+deliberately reshapes the ABI, regenerate the baseline with
+`scripts/release/regenerate-abi-manifest.sh build` and commit the diff
+alongside the API change.  The gate SKIPs cleanly when libabigail is
+not installed or when the baseline is absent — first-time seeding only
+requires running the regeneration script once on a Linux/x86_64 host.
+
 ### Template (Markdown)
 
 ```md

--- a/scripts/ci/check-abi-manifest.sh
+++ b/scripts/ci/check-abi-manifest.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# check-abi-manifest.sh - Issue #786 (cross-link #690 libabigail half).
+#
+# Asserts that the just-built libwirelog shared library is ABI-compatible
+# with the committed baseline `abi/libwirelog-1.0.abi.json`.  Where the
+# `.symbols` allowlist (#733 K2 / `check-abi-symbols.sh`) only checks
+# the dynamic-symbol *set*, this gate uses libabigail's `abidiff` to
+# catch the richer surface that `nm -D` alone cannot see:
+#
+#   - struct member offsets and padding,
+#   - function signature changes (parameter or return-type),
+#   - visibility / linkage attribute drift,
+#   - typedef target changes.
+#
+# Any incompatible-change finding from `abidiff` fails the gate; the
+# operator must either:
+#
+#   (a) revert the offending change, or
+#   (b) deliberately bump SOVERSION (out-of-scope for v1.0.x), or
+#   (c) regenerate the baseline via
+#       `scripts/release/regenerate-abi-manifest.sh` and commit the diff
+#       alongside the API-changing PR.
+#
+# Usage (typically wired through meson, but also runnable standalone):
+#
+#   scripts/ci/check-abi-manifest.sh <build_root>
+#
+# Where <build_root> contains `libwirelog.so` (or a SOVERSION-qualified
+# link).
+#
+# Exit codes:
+#
+#   0   - manifest matches baseline (or SKIPped gracefully).
+#   1   - incompatible-change finding (or missing baseline / inputs).
+#
+# SKIP conditions (exit 0 with diagnostic):
+#
+#   - `libwirelog.so` absent (Windows, static-only, cross builds).
+#   - `abidiff` not on PATH (libabigail not installed).
+#   - Baseline `abi/libwirelog-1.0.abi.json` absent (first-time setup;
+#     run `scripts/release/regenerate-abi-manifest.sh` to seed).
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <build_root>" >&2
+    exit 1
+fi
+
+build_root="$1"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+baseline="$repo_root/abi/libwirelog-1.0.abi.json"
+suppr="$repo_root/abi/libwirelog-1.0.suppr"
+
+lib=""
+for candidate in \
+    "$build_root/libwirelog.so" \
+    "$build_root/libwirelog.so.1" ; do
+    if [ -e "$candidate" ]; then
+        lib="$candidate"
+        break
+    fi
+done
+
+if [ -z "$lib" ]; then
+    echo "check-abi-manifest: SKIP: libwirelog.so not found in $build_root" >&2
+    echo "  (expected on Windows / static-only / cross builds)" >&2
+    exit 0
+fi
+
+if ! command -v abidiff >/dev/null 2>&1; then
+    echo "check-abi-manifest: SKIP: abidiff not on PATH" >&2
+    echo "  install libabigail (Ubuntu: apt-get install -y libabigail-tools)" >&2
+    exit 0
+fi
+
+if [ ! -f "$baseline" ]; then
+    echo "check-abi-manifest: SKIP: baseline missing: $baseline" >&2
+    echo "  first-time setup: run scripts/release/regenerate-abi-manifest.sh" >&2
+    echo "  and commit the resulting abi/libwirelog-1.0.abi.json." >&2
+    exit 0
+fi
+
+# `--suppr` is optional; pass it only if the suppression file exists so
+# the gate stays usable for the v1.0 frozen-ABI case where no
+# suppressions are needed.
+abidiff_args=()
+if [ -f "$suppr" ]; then
+    abidiff_args+=(--suppr "$suppr")
+fi
+
+# abidiff exit codes (libabigail >= 1.8):
+#   0  - no diff or compatible-only diff.
+#   1  - tool error (bad inputs, parse failure).
+#   2  - leaf-changes only (compatible).
+#   3  - ABI changes (mix of compatible + incompatible).
+#   4  - ABI incompatible changes (the case we fail on).
+#   5  - ABI changes carrying both leaf and ABI bits.
+#
+# Bit 2 (decimal 4) is the "incompatible" flag.  We fail if it's set.
+set +e
+abidiff "${abidiff_args[@]}" "$baseline" "$lib" 2>&1
+rc=$?
+set -e
+
+if [ $rc -eq 0 ] || [ $rc -eq 2 ]; then
+    echo "check-abi-manifest: OK; libabigail reports no incompatible changes (rc=$rc)"
+    exit 0
+fi
+
+# Bit 2 (incompatible) set → fail.  Other bits (3, 5, 7) include it.
+if [ $((rc & 4)) -ne 0 ]; then
+    echo "check-abi-manifest: FAIL: incompatible ABI changes (abidiff rc=$rc)" >&2
+    echo "" >&2
+    echo "If the change is deliberate (SOVERSION bump or new v-line)," >&2
+    echo "regenerate the baseline:" >&2
+    echo "" >&2
+    echo "  scripts/release/regenerate-abi-manifest.sh $build_root" >&2
+    echo "" >&2
+    echo "and commit abi/libwirelog-1.0.abi.json alongside the API change." >&2
+    exit 1
+fi
+
+# Other non-zero (e.g. tool error rc=1): surface to the operator.
+echo "check-abi-manifest: FAIL: abidiff returned rc=$rc" >&2
+exit 1

--- a/scripts/release/regenerate-abi-manifest.sh
+++ b/scripts/release/regenerate-abi-manifest.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# regenerate-abi-manifest.sh - Issue #786 (cross-link #690 libabigail half).
+#
+# Regenerates the committed `abi/libwirelog-1.0.abi.json` baseline used
+# by the `meson test --suite abi:abi_manifest` gate.  Run this whenever
+# a deliberate ABI-impacting change lands (new public function, changed
+# struct layout, etc.) and commit the diff alongside the PR.
+#
+# Output flags (chosen to keep the manifest source-controllable):
+#
+#   --no-show-locs        Drop file/line locations (changes per build).
+#   --no-elf-needed       Drop the NEEDED entries (libc soname differs
+#                         across distros).
+#   --type-id-style hash  Stable hash-based type IDs (vs the default
+#                         incremental numbering which renumbers on
+#                         every regeneration).
+#
+# Usage:
+#
+#   meson setup build
+#   meson compile -C build
+#   scripts/release/regenerate-abi-manifest.sh [build_root]
+#
+# `build_root` defaults to `build` if not provided.  Exits non-zero if
+# `abidw` is missing or the build is incomplete.
+#
+# Companion: `scripts/ci/check-abi-manifest.sh` consumes the file this
+# script writes.  See `docs/RELEASE_PROCESS.md` §1 for the operator
+# procedure.
+
+set -euo pipefail
+
+build_root="${1:-build}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+baseline="$repo_root/abi/libwirelog-1.0.abi.json"
+
+if ! command -v abidw >/dev/null 2>&1; then
+    echo "regenerate-abi-manifest: FAIL: abidw not on PATH" >&2
+    echo "  install libabigail (Ubuntu: apt-get install -y libabigail-tools)" >&2
+    exit 1
+fi
+
+lib=""
+for candidate in \
+    "$repo_root/$build_root/libwirelog.so" \
+    "$repo_root/$build_root/libwirelog.so.1" ; do
+    if [ -e "$candidate" ]; then
+        lib="$candidate"
+        break
+    fi
+done
+
+if [ -z "$lib" ]; then
+    echo "regenerate-abi-manifest: FAIL: libwirelog.so not found under $build_root" >&2
+    echo "  expected: $repo_root/$build_root/libwirelog.so[.1]" >&2
+    echo "  did you run \`meson compile -C $build_root\`?" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$baseline")"
+
+abidw \
+    --no-show-locs \
+    --no-elf-needed \
+    --type-id-style hash \
+    --out-file "$baseline" \
+    "$lib"
+
+n=$(wc -l < "$baseline" | tr -d ' ')
+echo "regenerate-abi-manifest: wrote $baseline ($n lines)"
+echo "  review with: git diff -- $baseline"
+echo "  commit alongside the API-changing PR."

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -478,6 +478,20 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #786 (cross-link #690 libabigail half): libabigail manifest gate.
+# Where abi_symbols only checks the dynamic-symbol set, abi_manifest uses
+# `abidiff` to catch struct member offsets, function signature changes,
+# and visibility/linkage drift that nm -D cannot see.  Linux/ELF-focused;
+# SKIPs cleanly when libwirelog.so is missing (Windows, static-only),
+# when abidiff is not on PATH, or when the baseline has not been seeded
+# yet (run scripts/release/regenerate-abi-manifest.sh to seed).
+if sh.found()
+  test('abi_manifest', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-abi-manifest.sh',
+              meson.project_build_root()],
+       suite: 'abi')
+endif
+
 # Issue #689 / Blocker B2: standalone-include compile matrix for the
 # public-headers SSoT.  One executable per public header, each
 # compiled in isolation against tests/standalone/test_standalone_<H>.c


### PR DESCRIPTION
Closes #786.

## Summary

Adds the libabigail half of the v0.41 ABI golden-file infrastructure (parent #690).  The `.symbols` allowlist half landed via #733 K2; this PR adds the richer manifest layer that captures struct member offsets, function signature changes, and visibility attributes that `nm -D` alone cannot see.

* `scripts/release/regenerate-abi-manifest.sh` — operator-side regeneration via `abidw --no-show-locs --no-elf-needed --type-id-style hash`.  Flag set chosen to keep the manifest reproducible across distros and abidw invocations.
* `scripts/ci/check-abi-manifest.sh` — CI gate that runs `abidiff` between the committed baseline and the just-built `libwirelog.so`.  Decodes the abidiff bit-flag exit code; fails only on bit 2 (incompatible ABI changes), passes on no-diff or leaf-only diffs.  Mirrors the SKIP semantics of `check-abi-symbols.sh` (#733 K2).
* `tests/meson.build` registers the gate as `meson test --suite abi:abi_manifest` alongside `abi_symbols`.
* `docs/RELEASE_PROCESS.md` §1 gains an "ABI manifest update" subsection pointing operators at the regeneration script.

## Baseline seeding — first-time setup follow-up

The baseline `abi/libwirelog-1.0.abi.json` itself is **not in this PR**: generating it requires libabigail on a Linux/x86_64 host, which is the project's pinned ABI platform (#690 B3 scope).  Until the baseline is committed, the new gate SKIPs cleanly on every platform with a clear diagnostic.

First-time seeding is one command on Ubuntu:

```
sudo apt-get install -y libabigail-tools
meson setup build && meson compile -C build
scripts/release/regenerate-abi-manifest.sh build
git add abi/libwirelog-1.0.abi.json
```

This is an intentional split: the infrastructure (this PR) and the baseline are separable concerns, and the baseline must be authored on a Linux box.  Once the baseline lands the gate transitions from SKIP → PASS in CI.

## SKIP conditions

The gate exits 0 with a diagnostic in three cases:

1. `libwirelog.so` not found (Windows, static-only, cross builds) — matches `abi_symbols` semantics.
2. `abidiff` not on PATH (libabigail not installed).
3. Baseline `abi/libwirelog-1.0.abi.json` not yet committed (first-time setup case).

## Test plan

- [x] Bash syntax validation (`bash -n`) for both scripts.
- [x] Local SKIP-path verified on Windows: `check-abi-manifest build-bench` exits 0 with "libwirelog.so not found" diagnostic.
- [x] uncrustify / editorconfig: only shell + docs + meson changes, no `.c`/`.h` touched.
- [ ] CI Linux build: gate SKIPs with "baseline missing" diagnostic until the baseline is committed.
- [ ] Acceptance test (deferred to baseline-seeding PR): intentionally add a public function, re-run gate, confirm abidiff reports incompatible-change and exits 1.

## References

- Parent: #681 v0.41 ABI Infrastructure epic.
- Predecessor: #690 (this PR + the seeding PR together replace its libabigail half).
- Allowlist sibling: #733 K2 (`abi_symbols` gate + `check-abi-symbols.sh`) — same pattern.
- libabigail manual: https://sourceware.org/libabigail/manual/