### PR TITLE
ci(abi): enroll Linux arm64 in PR Build matrix + fix dead ci-main check (#787)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -81,10 +81,18 @@ jobs:
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
-          # ARM64 specific: verify NEON support
-          if [ "${{ matrix.os }}" = "arm64" ]; then
-            echo "ARM64 runner detected. Verifying NEON support..."
-            [ -f /proc/cpuinfo ] && grep -q "neon" /proc/cpuinfo && echo "NEON support verified" || echo "Warning: NEON support not detected"
+          # ARM64 specific: verify NEON / aarch64 SIMD support.  The
+          # historical check matched against `matrix.os == 'arm64'`,
+          # which never matched the actual runner label
+          # `ubuntu-24.04-arm` and silently no-op'd.  The corrected
+          # comparison runs on every arm64 matrix entry (#787).
+          if [ "${{ matrix.os }}" = "ubuntu-24.04-arm" ]; then
+            echo "ARM64 runner detected. Verifying ASIMD / NEON support..."
+            if [ -f /proc/cpuinfo ] && grep -qE 'asimd|neon' /proc/cpuinfo; then
+              echo "ARM64 SIMD (asimd / NEON) support verified"
+            else
+              echo "Warning: ARM64 SIMD support not detected in /proc/cpuinfo"
+            fi
           fi
 
       - name: Install dependencies (macOS)

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -60,6 +60,19 @@ jobs:
             compiler: msvc
             cc: cl
 
+          # ARM64 - GCC (GitHub-hosted runner, #787)
+          # Mirrors the leg in ci-main.yml; required by the v0.41 ABI
+          # Infrastructure milestone (#681) to ensure the abi suite
+          # (abi_symbols, public_header_surface, public_prefix,
+          # public_doxygen_headers, public_api_macro, test_parity,
+          # threading_doc, version_sync, changelog_format,
+          # release_template, and the standalone-include compile
+          # tests) passes on the second supported architecture before
+          # v1.0 ABI freeze.
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            cc: gcc
+
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,26 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **CI: enroll Linux arm64 (`ubuntu-24.04-arm`) GCC build in the PR
+  gate matrix** (#787): mirrors the arm64 leg already present in
+  `.github/workflows/ci-main.yml` so the abi suite (`abi_symbols`,
+  `public_header_surface`, `public_prefix`,
+  `public_doxygen_headers`, `public_api_macro`, `test_parity`,
+  `threading_doc`, `version_sync`, `changelog_format`,
+  `release_template`, and the standalone-include compile tests)
+  exercises the second supported architecture on every PR before
+  merge.  Same-source-of-truth allowlist
+  (`abi/libwirelog-1.0.symbols`) is intentionally arch-agnostic --
+  `gnu_symbol_visibility: 'hidden'` plus `WIRELOG_API`-only export
+  keeps SIMD/NEON wrappers internal so the 53-symbol set is
+  identical across x86_64 and arm64.  Also fixes a stale matrix
+  comparison in `ci-main.yml:84-95` that compared against the
+  unused literal `'arm64'` instead of the actual runner label
+  `'ubuntu-24.04-arm'`, so the SIMD-capability verification block
+  now runs on the arm64 leg as intended.  Required-check
+  promotion is a follow-up repo-admin action (branch protection),
+  not part of this PR; the libabigail `.abi.json` half of the
+  cross-arch ABI gate lands under #786 once that issue ships.
 - **Adopt `WIRELOG_API` on every installed public prototype** (#782):
   76 occurrences of `WIRELOG_PUBLIC` across the 8 prototype headers
   (`wirelog.h`, `wirelog-types.h`, `wirelog-ir.h`, `wirelog-parser.h`,


### PR DESCRIPTION
## Summary

Closes the arm64 leg of v0.41 epic #681's ABI Infrastructure exit conditions.  Adds `Build / ubuntu-24.04-arm / gcc` to the PR gate matrix and fixes a stale comparison in `ci-main.yml` that silently no-op'd the SIMD-verification block.

## Scope correction (synthesized from architect+critic deliberation)

The issue body said "enroll Linux arm64 runner."  The actual state is:

- `ci-main.yml:66-71` **already has** `ubuntu-24.04-arm` / gcc in the Build matrix (advisory via `continue-on-error: true`).
- `ci-pr.yml` (where required-gate enforcement lives) had **no arm64 entry**.
- `ci-main.yml:85` compared `matrix.os == 'arm64'` (dead code — actual label is `ubuntu-24.04-arm`).

This PR delivers the actually-missing pieces:

1. **`ci-pr.yml`**: new `ubuntu-24.04-arm` / gcc Build matrix entry.  Mirrors the four existing entries (linux-gcc, linux-clang, macos-clang, windows-msvc).
2. **`ci-main.yml`**: corrected SIMD verification check now matches the actual runner label and inspects `/proc/cpuinfo` for `asimd` or `neon`.

## ABI surface consistency

`abi/libwirelog-1.0.symbols` is intentionally arch-agnostic; the 53-symbol allowlist applies to both x86_64 and arm64 because:

- `gnu_symbol_visibility: 'hidden'` (`meson.build:290`, #733 K1) hides every non-`WIRELOG_API`-annotated symbol.
- The v0.40 sweep (#782) ensured every public prototype on the 8 installed headers carries `WIRELOG_API`.
- SIMD / NEON wrappers in `wirelog/columnar/{ops,relation,frontier}.c` are file-local — none carry the export annotation.

→ The dynamic-symbol table from `nm -D --defined-only` is bit-identical across arches; no per-arch allowlist split is required.

## Out of scope (explicitly deferred)

- **`abi_manifest` arm64 leg**: depends on #786 (libabigail `.abi.json`).  Acceptance criterion 2 of #787 ("struct-layout breakage trips on both legs") will be testable once #786 ships.
- **Required-check promotion** (branch-protection rule): repo-admin action via `gh api /repos/.../branches/main/protection`, not a PR-side change.  This PR lands the leg so PR authors see it run; flipping required-mode is a follow-up admin step.
- **Clang on arm64**: mirroring x86_64's GCC+Clang pair would double the runner cost.  Defer to v0.43 platform packaging.
- **Sanitizers / TSan on arm64**: separate concern, tracked under #708 C5.
- **macOS arm64** (Apple Silicon): out of scope per the issue body; tracked under v0.43.
- **5-consecutive-green-merges soak**: post-merge tracking, not a PR-time gate.  #787 stays open as a soak tracker until the count is reached.

## Verification

- YAML syntax: both files parse clean; matrix entry shape matches the four existing entries.
- `git diff` shows only YAML + a single CHANGELOG `[Unreleased]/Changed` entry referencing `#787`.
- CI must produce a new `Build / ubuntu-24.04-arm / gcc` status check on this PR.

## Test plan

- [ ] CI matrix shows the new `Build / ubuntu-24.04-arm / gcc` job in PR checks.
- [ ] The arm64 leg compiles cleanly (NEON code in columnar SIMD paths exercised for the first time in PR CI).
- [ ] `meson test` on the arm64 leg passes (default suite + all `--suite abi` gates).
- [ ] `abi_symbols` allowlist diff is empty on arm64 (the 53-symbol claim).
- [ ] Existing x86_64 / macOS / Windows legs remain green (no regression).
- [ ] CHANGELOG `changelog_format` gate accepts the new entry.

Closes #787 conditionally on the soak-time criterion (≥5 consecutive green main merges after this lands).
Refs #681, #786 (libabigail half), #733 K1, #782.