### PR TITLE
feat(#801): cli -- add --version/-v option and surface version in --help

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3851,6 +3851,22 @@ test('baseline_tab_nodes',
 )
 
 # ============================================================================
+# CLI Version / Help Surface Test (Issue #801)
+# Reuses baseline_py3 (already resolved above) to invoke the executable.
+# ============================================================================
+
+test('cli_version',
+  baseline_py3,
+  args: [
+    files('test_cli_version.py')[0],
+    wirelog_cli.full_path(),
+    meson.project_version(),
+  ],
+  depends: wirelog_cli,
+  suite: 'cli',
+)
+
+# ============================================================================
 # I/O Adapter Registry Tests (#450)
 # ============================================================================
 

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# test_cli_version.py - Regression test for wirelog_cli --version / -v.
+#
+# Copyright (C) CleverPlant
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Usage: test_cli_version.py <wirelog_cli_executable> <project_version_string>
+#
+# Asserts (issue #801 acceptance criteria):
+#   * --version       exits 0 and stdout contains <version> tagged with
+#                     "wirelog_cli"; stderr is empty.
+#   * -v              same contract as --version.
+#   * --version  and  -v produce byte-identical stdout.
+#   * --help          exits 0 and surfaces the version somewhere in its
+#                     output (stdout or stderr; --help currently goes to
+#                     stderr — that pre-existing behavior is preserved).
+#   * --version short-circuits ahead of --workers / file-required checks:
+#     "wirelog_cli --version --workers 4 nonexistent.dl" exits 0 with no
+#     file read, no plugin load.
+#   * Unknown options still fail non-zero with empty stdout (regression
+#     guard: the new branch must not turn into a permissive catch-all).
+#
+# Line endings are normalized to LF so the test passes on Windows runners.
+
+import subprocess
+import sys
+
+
+def _normalize(s: str) -> str:
+    return s.replace("\r\n", "\n")
+
+
+def _run(exe, *args):
+    # timeout=30 fails closed if a future regression makes a flag stop
+    # short-circuiting and instead block on stdin (e.g. via watch mode).
+    return subprocess.run(
+        [exe, *args], capture_output=True, text=True, timeout=30)
+
+
+def _fail(msg):
+    sys.stderr.write(msg if msg.endswith("\n") else msg + "\n")
+    return 1
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        return _fail(
+            "usage: test_cli_version.py <executable> <project_version>")
+
+    exe, version = sys.argv[1], sys.argv[2]
+    version_outputs = {}
+
+    for flag in ("--version", "-v"):
+        r = _run(exe, flag)
+        if r.returncode != 0:
+            return _fail(
+                "%s: exit %d (expected 0); stderr=%r"
+                % (flag, r.returncode, r.stderr))
+        stdout = _normalize(r.stdout)
+        if "wirelog_cli" not in stdout:
+            return _fail(
+                "%s: stdout missing 'wirelog_cli' tag; got %r"
+                % (flag, stdout))
+        if version not in stdout:
+            return _fail(
+                "%s: stdout missing version %r; got %r"
+                % (flag, version, stdout))
+        if r.stderr.strip() != "":
+            return _fail(
+                "%s: stderr should be empty; got %r" % (flag, r.stderr))
+        version_outputs[flag] = stdout
+
+    if version_outputs["--version"] != version_outputs["-v"]:
+        return _fail(
+            "--version and -v produced different stdout:\n"
+            "  --version: %r\n"
+            "  -v:        %r"
+            % (version_outputs["--version"], version_outputs["-v"]))
+
+    # --help must surface the version too (acceptance criterion #3).
+    r = _run(exe, "--help")
+    if r.returncode != 0:
+        return _fail("--help: exit %d (expected 0)" % r.returncode)
+    help_out = _normalize(r.stdout) + _normalize(r.stderr)
+    if version not in help_out:
+        return _fail(
+            "--help: version %r not found in output; "
+            "stdout=%r stderr=%r"
+            % (version, r.stdout, r.stderr))
+
+    # --version must short-circuit before file-required / --workers checks.
+    r = _run(exe, "--version", "--workers", "4", "nonexistent-file.dl")
+    if r.returncode != 0:
+        return _fail(
+            "--version with extra args: exit %d (expected 0); stderr=%r"
+            % (r.returncode, r.stderr))
+    if version not in _normalize(r.stdout):
+        return _fail(
+            "--version with extra args: stdout missing version; got %r"
+            % r.stdout)
+
+    # Unknown options must still fail non-zero with empty stdout.
+    r = _run(exe, "--definitely-not-a-real-flag")
+    if r.returncode == 0:
+        return _fail(
+            "unknown option: expected non-zero exit, got 0; stdout=%r"
+            % r.stdout)
+    if r.stdout.strip() != "":
+        return _fail(
+            "unknown option: stdout should be empty, got %r" % r.stdout)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirelog/cli/main.c
+++ b/wirelog/cli/main.c
@@ -12,6 +12,7 @@
  *   --watch [interval]         Watch mode: re-evaluate on stdin input
  *   --load-adapter PATH        Load adapter plugin (repeatable, requires
  *                              -Dio_plugin_dlopen=enabled)
+ *   --version, -v              Print version and exit
  *   --help                     Show usage information
  */
 
@@ -20,6 +21,9 @@
 #ifdef WL_HAVE_PLUGIN_LOADER
 #include "plugin_loader.h"
 #endif
+
+/* WIRELOG_VERSION_STRING; generated header, see wirelog-version.h.in. */
+#include "wirelog/wirelog-version.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -31,6 +35,7 @@
 static void
 print_usage(const char *progname)
 {
+    fprintf(stderr, "wirelog_cli %s\n\n", WIRELOG_VERSION_STRING);
     fprintf(stderr, "Usage: %s [options] <file.dl>\n", progname);
     fprintf(stderr, "\nOptions:\n");
     fprintf(stderr, "  --workers N          Number of worker threads "
@@ -46,7 +51,8 @@ print_usage(const char *progname)
         ", disabled in this build"
 #endif
         ")\n");
-    fprintf(stderr, "  --help               Show this help message\n");
+    fprintf(stderr, "  --version, -v        Print version and exit\n");
+    fprintf(stderr, "  --help, -h           Show this help message\n");
 }
 
 int
@@ -63,6 +69,11 @@ main(int argc, char *argv[])
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             print_usage(argv[0]);
+            return 0;
+        }
+        if (strcmp(argv[i], "--version") == 0
+            || strcmp(argv[i], "-v") == 0) {
+            printf("wirelog_cli %s\n", WIRELOG_VERSION_STRING);
             return 0;
         }
         if (strcmp(argv[i], "--delta") == 0) {


### PR DESCRIPTION
## Summary

- Add `--version` / `-v` to `wirelog_cli`; both print `wirelog_cli <WIRELOG_VERSION_STRING>` to stdout and exit 0, short-circuiting identically to `--help` (no file required, no plugin load, no `--workers` validation).
- Surface the version in `--help` output: a banner at the top of `print_usage()` plus an explicit `--version, -v` row in the Options block.
- New regression test `tests/test_cli_version.py` (suite `cli`) registered in `tests/meson.build`.

Unknown options retain the previous behavior (non-zero exit, usage on stderr). No public API or ABI change — the CLI executable is not part of `libwirelog`, and this commit only consumes an already-installed public macro.

Closes #801

## Test plan

- [x] `meson compile -C build wirelog_cli` clean
- [x] `./build/wirelog_cli --version` -> `wirelog_cli 0.40.99` on stdout, exit 0
- [x] `./build/wirelog_cli -v` -> identical
- [x] `./build/wirelog_cli --help` -> includes the version banner, exit 0
- [x] `./build/wirelog_cli --bogus` -> non-zero, usage on stderr, stdout empty
- [x] `meson test -C build cli_version cli cli_watch cli_delta` -> 4/4 OK
- [x] `meson test -C build --suite baseline` -> 3/3 OK
- [ ] CI green on PR

Pre-existing ABI-suite failures on `main` (`public_header_surface`, `wirelog_easy_abi_opts_symbol`, `log_abi_no_testhook_in_libwirelog`) are unrelated to this change; they concern drift between `stable-release-plan.md` and the public-header list, not the CLI.