### PR TITLE
abi(#803): harmonize 'libwirelog not built' diagnostic + document plan soft-mirror

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -10,6 +10,21 @@ It is the operational counterpart of:
 - `docs/SECURITY_MODEL.md` — vulnerability-disclosure policy.
 - `stable-release-plan.md` — long-form roadmap to v1.0 GA.
 
+> **Note on `stable-release-plan.md`.**  Unlike the other documents
+> listed above, the long-form release plan is intentionally **not**
+> tracked in the source tree — it is a working planning artifact that
+> maintainers keep locally during release preparation.  The public-
+> header SoT gate `scripts/ci/check-public-header-surface.py` knows
+> this: its `parse_plan_section()` helper returns `None` when the
+> file is absent, which is the case in every CI checkout and clean
+> clone today.  The §3.1 cross-check therefore activates only for
+> contributors who keep a working copy of the plan locally; drift
+> errors against that copy (e.g. a public-header rename that the
+> local plan has not yet picked up) are local-developer noise and do
+> not gate CI.  If the team later decides to track the plan in-tree,
+> the existing gate immediately becomes a hard mirror for §3.1 with
+> no script change required.
+
 It is the deliverable for issue **#772** (release-note template +
 publication procedure) and is referenced by **#687** (v1.0.0 GA
 epic) which lists "CHANGELOG `[1.0.0]` section merged" as an exit

--- a/scripts/ci/check-log-erasure.sh
+++ b/scripts/ci/check-log-erasure.sh
@@ -58,7 +58,7 @@ for candidate in "${BUILD_DIR}/libwirelog.so" \
     if [[ -f "${candidate}" ]]; then LIB="${candidate}"; break; fi
 done
 if [[ -z "${LIB}" ]]; then
-    echo "ERROR: libwirelog artifact not found under ${BUILD_DIR}" >&2
+    echo "ERROR: libwirelog not built under ${BUILD_DIR}; run 'meson compile -C ${BUILD_DIR}' first" >&2
     exit 2
 fi
 

--- a/scripts/ci/check-no-testhook-in-libwirelog.sh
+++ b/scripts/ci/check-no-testhook-in-libwirelog.sh
@@ -13,7 +13,7 @@ for candidate in "$BUILD_DIR/libwirelog.so" "$BUILD_DIR"/libwirelog.so.* \
     if [[ -f "$candidate" ]]; then LIB="$candidate"; break; fi
 done
 if [[ -z "$LIB" ]]; then
-    echo "ERROR: libwirelog artifact not found under $BUILD_DIR" >&2
+    echo "ERROR: libwirelog not built under $BUILD_DIR; run 'meson compile -C $BUILD_DIR' first" >&2
     exit 2
 fi
 

--- a/scripts/ci/check-wl-easy-opts-symbol.sh
+++ b/scripts/ci/check-wl-easy-opts-symbol.sh
@@ -9,7 +9,7 @@ for candidate in "$BUILD_DIR/libwirelog.so" "$BUILD_DIR"/libwirelog.so.* \
     if [[ -f "$candidate" ]]; then LIB="$candidate"; break; fi
 done
 if [[ -z "$LIB" ]]; then
-    echo "ERROR: libwirelog shared artifact not found under $BUILD_DIR" >&2
+    echo "ERROR: libwirelog shared library not built under $BUILD_DIR; run 'meson compile -C $BUILD_DIR' first" >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Summary

Resolves the three abi-suite findings reported in #803:

- **Findings 2 & 3** (build-state diagnostic) — three sibling CI scripts (`check-no-testhook-in-libwirelog.sh`, `check-wl-easy-opts-symbol.sh`, `check-log-erasure.sh`) all use the same hand-copied "for candidate in ... libwirelog ... done; [[ -f ]]" probe and previously emitted "ERROR: libwirelog [shared] artifact not found under \$BUILD_DIR". Replace with a harmonized message that names the actual precondition:

  ```
  ERROR: libwirelog[ shared library] not built under <DIR>; run
         'meson compile -C <DIR>' first
  ```

  Behavior is otherwise unchanged: still `exit 2` (FAIL), same `[[ -f ]]` existence test, same candidate-glob loop. The positive path (library present, ABI invariants enforced) is byte-identical.

- **Finding 1** (plan soft-mirror) — the gate `scripts/ci/check-public-header-surface.py` cross-checks `meson.build`'s SoT against several mirrors, one of which is the §3.1 table inside `stable-release-plan.md`. The plan is **intentionally not tracked in `origin/main`**; the gate's `parse_plan_section()` already returns `None` when the file is absent, so CI never sees drift here. Locally, however, a contributor who keeps a working copy of the plan can hit hard-FAIL against drift in that local copy (e.g. the post-rename `wirelog/wirelog-easy.h` vs the plan still referencing pre-rename `wirelog/wl_easy.h`). The asymmetry was undocumented outside the script's own docstring; add a paragraph to `docs/RELEASE_PROCESS.md` explaining the untracked status and the soft-mirror contract so future local-only failure reports have a documented answer.

No code change to `scripts/ci/check-public-header-surface.py`. No change to `stable-release-plan.md` (which remains untracked). No public-API or ABI impact. No build-system change.

Closes #803

## Test plan

- [x] `meson compile -C build wirelog`
- [x] `meson test -C build log_abi_no_testhook_in_libwirelog wirelog_easy_abi_opts_symbol log_abi_compile_erasure` -> 3/3 OK
- [x] Negative path verified on `/tmp/no-such-dir`: each of the three scripts emits the new diagnostic and exits 2
- [x] Each commit passes the suite standalone (atomic-commit gate)
- [ ] CI green on PR