### PR TITLE
[codex] Lower side compound body patterns

### DIFF
--- a/docs/COMPOUND_TERMS.md
+++ b/docs/COMPOUND_TERMS.md
@@ -176,8 +176,19 @@ For `inline` compound columns, the pattern `f(a, b)` in a body literal:
 - Binds variables `a` and `b` to the inline physical argument columns.
 - Fails to match rows when the declared functor or arity differs.
 
-Side-relation compound declarations are parsed and exposed in schema metadata,
-but side body-argument binding is not yet lowered into a side-relation join.
+For `side` compound columns, the same body pattern lowers to a parent relation
+scan joined with the generated side relation:
+
+```
+rel(..., f(a, b), ...)  ->  rel(...) JOIN __compound_f_2(handle, arg0, arg1)
+```
+
+The join key is the parent handle column equals the side relation `handle`
+column. Variables, constants, and duplicate variables inside the pattern are
+then handled by the existing JOIN, FILTER, and PROJECT machinery. This is
+structural body-pattern binding for declared compound columns, not general
+Prolog unification: it does not construct new compounds in rule heads, search
+alternative functors, or recursively destructure arbitrary nested side handles.
 
 ### Example: projecting a compound argument
 
@@ -197,18 +208,20 @@ x_values(id, x) :- event(id, point(x, _)).
 hot_items(key) :- item(key, tag(category, priority)), priority > 10.
 ```
 
-### Current limitation: side-relation body binding
+### Side-relation body binding
 
-Side declarations are accepted:
+Side declarations can bind body fields:
 
 ```
-.decl event(id: int64, meta: metadata/4)
-.decl event_side(id: int64, meta: metadata/4 side)
+.decl event(id: int64, tenant: symbol, meta: metadata/4 side)
+.decl hot(id: int64, host: symbol)
+
+hot(ID, Host) :- event(ID, _, metadata(Level, Ts, Host, Risk)), Risk > 80.
 ```
 
-The public execution path currently binds compound body variables for inline
-columns only. Support for lowering side patterns through
-`__compound_<functor>_<arity>` side-relation joins is tracked separately.
+At execution time the `metadata(...)` pattern reads rows from
+`__compound_metadata_4(handle, arg0, arg1, arg2, arg3)` by joining
+`event.meta == __compound_metadata_4.handle`.
 
 ### Parser limitation: compound terms in rule heads
 
@@ -250,11 +263,15 @@ For a nested compound like `scope(metadata(t, ts, loc, risk))`:
 3. Main relation column: holds `handle_scope`.
 
 Nested side-tier storage metadata follows the same nesting. Rule-body binding
-for nested side terms is not lowered yet:
+for a flat declared side pattern is supported, but nested body destructuring is
+not recursive. A nested body pattern such as the following does not match by
+recursively opening `metadata(...)`:
 
 ```
 .decl record(id: int64, scope_col: scope/1)
-.decl record(id: int64, scope_col: scope/1)
+.decl seen(id: int64)
+
+seen(ID) :- record(ID, scope(metadata(Level, Ts, Host, Risk))).
 ```
 
 ---
@@ -282,6 +299,7 @@ When in doubt, omit the hint. The default (`side`) is always correct.
 | Nesting > 64 levels                      | Parse error: "compound term nesting too deep"         |
 | `inline` hint with arity > 4            | Parse error |
 | `inline` hint with depth > 1            | Schema-apply error; `WL_LOG=COMPOUND:2` emits `error=depth_overflow` |
+| Negated side compound body pattern       | IR conversion error; negated side-join lowering is not yet supported |
 | Handle from session A used in session B  | `arena_lookup` returns NULL (session seed mismatch)   |
 | Handle after arena saturation (epoch 4095)| `arena_alloc` returns `WL_COMPOUND_HANDLE_NULL`      |
 
@@ -305,8 +323,10 @@ sum_rel(id, x + y) :- pair_rel(id, pair(x, y)).
 .decl message(msg_id: int64, envelope: envelope/2)
 ```
 
-The declaration is accepted and exposed in schema metadata. Binding nested side
-arguments in rule bodies requires the future side-relation lowering path.
+The declaration is accepted and exposed in schema metadata. A rule can bind the
+outer `envelope/2` arguments through its generated side relation; recursively
+destructuring a nested child handle inside the same body term is not part of the
+current binding model.
 
 ---
 

--- a/examples/13-daemon-style/README.md
+++ b/examples/13-daemon-style/README.md
@@ -27,12 +27,14 @@ pulse(ID) :- pulse(ID).
 hot_event(ID, Tenant) :- event(ID, Tenant, Risk, _), Risk > 80.
 ```
 
-The `risk` scalar drives the rule because side-compound body destructuring is a
-larger compiler feature tracked separately. The payload still uses the real
-session-local compound arena, so rotations are triggered by arena saturation
-rather than by a caller-owned event watermark. The synthetic empty `pulse`
-recursion forces deterministic epoch advancement for the demo workload; it does
-not change the emitted `hot_event` results.
+The demo keeps `risk` as a scalar so the hot-event rule stays readable, but a
+declared side payload can also be bound in rule bodies, for example
+`event(ID, Tenant, _, metadata(Level, Ts, Host, Risk))`. That binding is a
+handle join against `__compound_metadata_4`, not general Prolog unification.
+The payload uses the real session-local compound arena, so rotations are
+triggered by arena saturation rather than by a caller-owned event watermark.
+The synthetic empty `pulse` recursion forces deterministic epoch advancement
+for the demo workload; it does not change the emitted `hot_event` results.
 The EDB log stores source-level event values rather than encoded Wirelog rows,
 so each fresh session re-interns symbols and rebuilds rows with its own public
 API state.

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -135,6 +135,29 @@ parse_or_die(const char *src, const char *what)
     return prog;
 }
 
+static wirelog_error_t
+make_compound4(wirelog_session_t *s, const char *functor, int64_t a0,
+    int64_t a1, int64_t a2, int64_t a3, uint64_t *handle)
+{
+    wirelog_compound_arg_t args[4] = {
+        { WIRELOG_TYPE_INT64, a0 },
+        { WIRELOG_TYPE_INT64, a1 },
+        { WIRELOG_TYPE_INT64, a2 },
+        { WIRELOG_TYPE_INT64, a3 },
+    };
+    return wirelog_session_make_compound(s, functor, 4, args, handle);
+}
+
+static wirelog_error_t
+make_compound1(wirelog_session_t *s, const char *functor, int64_t a0,
+    uint64_t *handle)
+{
+    wirelog_compound_arg_t args[1] = {
+        { WIRELOG_TYPE_INT64, a0 },
+    };
+    return wirelog_session_make_compound(s, functor, 1, args, handle);
+}
+
 /* T1: create / destroy with default backend; program ownership stays
  *     with the caller (destroy must not free it). */
 static int
@@ -759,6 +782,319 @@ out:
     return rc;
 }
 
+/* Parity (#785): mirrors test_side_compound_body_field_binding. */
+static int
+test_side_compound_body_field_binding(void)
+{
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl host_hit(id: int64, host: symbol)\n"
+        "host_hit(ID, Host) :- event(ID, Tenant, "
+        "metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
+    wirelog_program_t *prog = parse_or_die(src, "T17");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int64_t tenant = wl_intern_put(intern, "acme");
+    int64_t host_a = wl_intern_put(intern, "edge-a");
+    int64_t host_b = wl_intern_put(intern, "edge-b");
+    uint64_t hot_handle = 0;
+    uint64_t cold_handle = 0;
+    int rc = 0;
+    if (tenant < 0 || host_a < 0 || host_b < 0
+        || make_compound4(s, "metadata", 1, 100, host_a, 90,
+        &hot_handle) != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 101, host_b, 40,
+        &cold_handle) != WIRELOG_OK) {
+        fprintf(stderr, "T17 compound allocation failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    int64_t hot_row[3] = { 7, tenant, (int64_t)hot_handle };
+    int64_t cold_row[3] = { 8, tenant, (int64_t)cold_handle };
+    if (wirelog_session_insert(s, "event", hot_row, 1, 3) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", cold_row, 1, 3)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T17 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter f = { .target_relation = "host_hit" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T17 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.ncols[0] != 2 || f.rows[0][0] != 7
+        || f.rows[0][1] != host_a) {
+        fprintf(stderr, "T17: expected only host_hit(7, edge-a)\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_side_compound_constant_child_filters. */
+static int
+test_side_compound_constant_child_filters(void)
+{
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, _, metadata(_, _, _, 90)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T18");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    uint64_t hot_handle = 0;
+    uint64_t cold_handle = 0;
+    int rc = 0;
+    if (make_compound4(s, "metadata", 1, 100, 3, 90, &hot_handle)
+        != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 101, 3, 40, &cold_handle)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T18 compound allocation failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    int64_t hot_row[3] = { 7, 1, (int64_t)hot_handle };
+    int64_t cold_row[3] = { 8, 1, (int64_t)cold_handle };
+    if (wirelog_session_insert(s, "event", hot_row, 1, 3) != WIRELOG_OK
+        || wirelog_session_insert(s, "event", cold_row, 1, 3)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T18 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter f = { .target_relation = "hot" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T18 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.ncols[0] != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr, "T18: expected only hot(7)\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_side_compound_duplicate_child_variables_filter. */
+static int
+test_side_compound_duplicate_child_variables_filter(void)
+{
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl same(id: int64)\n"
+        "same(ID) :- event(ID, _, metadata(X, X, _, _)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T19");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    uint64_t matched_handle = 0;
+    uint64_t unmatched_handle = 0;
+    int rc = 0;
+    if (make_compound4(s, "metadata", 4, 4, 3, 90, &matched_handle)
+        != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 2, 3, 90,
+        &unmatched_handle) != WIRELOG_OK) {
+        fprintf(stderr, "T19 compound allocation failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    int64_t matched_row[3] = { 7, 1, (int64_t)matched_handle };
+    int64_t unmatched_row[3] = { 8, 1, (int64_t)unmatched_handle };
+    if (wirelog_session_insert(s, "event", matched_row, 1, 3)
+        != WIRELOG_OK
+        || wirelog_session_insert(s, "event", unmatched_row, 1, 3)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T19 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter f = { .target_relation = "same" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T19 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 1 || f.ncols[0] != 1 || f.rows[0][0] != 7) {
+        fprintf(stderr, "T19: expected only same(7)\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_side_compound_wrong_functor_handle_no_match. */
+static int
+test_side_compound_wrong_functor_handle_no_match(void)
+{
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl seen(id: int64)\n"
+        "seen(ID) :- event(ID, _, metadata(_, _, _, _)).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T20");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    uint64_t wrong_handle = 0;
+    int rc = 0;
+    if (make_compound4(s, "other", 1, 2, 3, 4, &wrong_handle)
+        != WIRELOG_OK) {
+        fprintf(stderr, "T20 compound allocation failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    int64_t row[3] = { 7, 1, (int64_t)wrong_handle };
+    if (wirelog_session_insert(s, "event", row, 1, 3) != WIRELOG_OK) {
+        fprintf(stderr, "T20 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter f = { .target_relation = "seen" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T20 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 0) {
+        fprintf(stderr, "T20: wrong functor handle derived rows\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_side_compound_nested_child_no_match. */
+static int
+test_side_compound_nested_child_no_match(void)
+{
+    const char *src
+        = ".decl record(id: int64, scope_col: scope/1 side)\n"
+        ".decl seen(id: int64)\n"
+        "seen(ID) :- record(ID, scope(metadata(Level, Ts, Host, Risk))).\n";
+    wirelog_program_t *prog = parse_or_die(src, "T21");
+    if (!prog)
+        return 1;
+
+    wirelog_session_t *s = NULL;
+    if (wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s)
+        != WIRELOG_OK || !s) {
+        wirelog_program_free(prog);
+        return 1;
+    }
+
+    uint64_t metadata_handle = 0;
+    uint64_t scope_handle = 0;
+    int rc = 0;
+    if (make_compound4(s, "metadata", 1, 100, 3, 90, &metadata_handle)
+        != WIRELOG_OK
+        || make_compound1(s, "scope", (int64_t)metadata_handle,
+        &scope_handle) != WIRELOG_OK) {
+        fprintf(stderr, "T21 compound allocation failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    int64_t row[2] = { 7, (int64_t)scope_handle };
+    if (wirelog_session_insert(s, "record", row, 1, 2) != WIRELOG_OK) {
+        fprintf(stderr, "T21 insert failed\n");
+        rc = 1;
+        goto out;
+    }
+
+    struct tuple_filter f = { .target_relation = "seen" };
+    if (wirelog_session_snapshot(s, filter_tuples, &f) != WIRELOG_OK) {
+        fprintf(stderr, "T21 snapshot failed\n");
+        rc = 1;
+        goto out;
+    }
+    if (f.count != 0) {
+        fprintf(stderr, "T21: nested side body destructuring matched\n");
+        rc = 1;
+    }
+out:
+    wirelog_session_destroy(s);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* Parity (#785): mirrors test_negated_side_compound_body_pattern_rejected. */
+static int
+test_negated_side_compound_body_pattern_rejected(void)
+{
+    const char *src
+        = ".decl all_events(id: int64)\n"
+        ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl clean(id: int64)\n"
+        "clean(ID) :- all_events(ID), !event(ID, metadata(_, _, _, 90)).\n";
+    wirelog_error_t parse_err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &parse_err);
+    if (!prog)
+        return parse_err == WIRELOG_OK ? 1 : 0;
+
+    wirelog_session_t *s = NULL;
+    wirelog_error_t err
+        = wirelog_session_create(prog, WIRELOG_BACKEND_DEFAULT, 1, &s);
+    int rc = 0;
+    if (err != WIRELOG_ERR_INVALID_IR || s) {
+        fprintf(stderr,
+            "T22: expected invalid IR for negated side compound, got %d\n",
+            err);
+        wirelog_session_destroy(s);
+        rc = 1;
+    }
+    wirelog_program_free(prog);
+    return rc;
+}
+
 /* Parity (#785): mirrors test_wirelog_easy.c::test_intern_returns_same_id.
  * Interning the same string twice through wl_intern_put must return
  * the same int64 id; the advanced API exposes the intern table via
@@ -1019,6 +1355,12 @@ main(void)
     failures += test_inline_compound_constant_child_filters();
     failures += test_inline_compound_duplicate_child_variables_filter();
     failures += test_side_compound_public_allocation_saturates();
+    failures += test_side_compound_body_field_binding();
+    failures += test_side_compound_constant_child_filters();
+    failures += test_side_compound_duplicate_child_variables_filter();
+    failures += test_side_compound_wrong_functor_handle_no_match();
+    failures += test_side_compound_nested_child_no_match();
+    failures += test_negated_side_compound_body_pattern_rejected();
     failures += test_intern_returns_same_id();
     failures += test_snapshot_filter();
     failures += test_cleanup_order_no_use_after_free();

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -758,6 +758,323 @@ test_inline_compound_duplicate_child_variables_filter(void)
     PASS();
 }
 
+static wirelog_error_t
+make_compound4(wirelog_easy_session_t *s, const char *functor, int64_t a0,
+    int64_t a1, int64_t a2, int64_t a3, uint64_t *handle)
+{
+    wirelog_compound_arg_t args[4] = {
+        { WIRELOG_TYPE_INT64, a0 },
+        { WIRELOG_TYPE_INT64, a1 },
+        { WIRELOG_TYPE_INT64, a2 },
+        { WIRELOG_TYPE_INT64, a3 },
+    };
+    return wirelog_easy_make_compound(s, functor, 4, args, handle);
+}
+
+static wirelog_error_t
+make_compound1(wirelog_easy_session_t *s, const char *functor, int64_t a0,
+    uint64_t *handle)
+{
+    wirelog_compound_arg_t args[1] = {
+        { WIRELOG_TYPE_INT64, a0 },
+    };
+    return wirelog_easy_make_compound(s, functor, 1, args, handle);
+}
+
+static void
+test_side_compound_body_field_binding(void)
+{
+    TEST("side compound body pattern binds fields through side join");
+
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl host_hit(id: int64, host: symbol)\n"
+        "host_hit(ID, Host) :- event(ID, Tenant, "
+        "metadata(Level, Ts, Host, Risk)), Risk > 80.\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t tenant = wirelog_easy_intern(s, "acme");
+    int64_t host_a = wirelog_easy_intern(s, "edge-a");
+    int64_t host_b = wirelog_easy_intern(s, "edge-b");
+    uint64_t hot_handle = 0;
+    uint64_t cold_handle = 0;
+    if (tenant < 0 || host_a < 0 || host_b < 0
+        || make_compound4(s, "metadata", 1, 100, host_a, 90,
+        &hot_handle) != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 101, host_b, 40,
+        &cold_handle) != WIRELOG_OK) {
+        FAIL("compound allocation failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t hot_row[3] = { 7, tenant, (int64_t)hot_handle };
+    int64_t cold_row[3] = { 8, tenant, (int64_t)cold_handle };
+    if (wirelog_easy_insert(s, "event", hot_row, 3) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", cold_row, 3) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t host_hit;
+    memset(&host_hit, 0, sizeof(host_hit));
+    if (wirelog_easy_snapshot(s, "host_hit", collect_tuple, &host_hit)
+        != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    wirelog_easy_close(s);
+
+    if (host_hit.count != 1 || host_hit.ncols[0] != 2
+        || host_hit.rows[0][0] != 7 || host_hit.rows[0][1] != host_a) {
+        FAIL("expected only host_hit(7, edge-a)");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_side_compound_constant_child_filters(void)
+{
+    TEST("side compound constant child filters rows");
+
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl hot(id: int64)\n"
+        "hot(ID) :- event(ID, _, metadata(_, _, _, 90)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t tenant = wirelog_easy_intern(s, "acme");
+    uint64_t hot_handle = 0;
+    uint64_t cold_handle = 0;
+    if (tenant < 0
+        || make_compound4(s, "metadata", 1, 100, 3, 90,
+        &hot_handle) != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 101, 3, 40,
+        &cold_handle) != WIRELOG_OK) {
+        FAIL("compound allocation failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t hot_row[3] = { 7, tenant, (int64_t)hot_handle };
+    int64_t cold_row[3] = { 8, tenant, (int64_t)cold_handle };
+    if (wirelog_easy_insert(s, "event", hot_row, 3) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", cold_row, 3) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t hot;
+    memset(&hot, 0, sizeof(hot));
+    if (wirelog_easy_snapshot(s, "hot", collect_tuple, &hot) != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    wirelog_easy_close(s);
+
+    if (hot.count != 1 || hot.ncols[0] != 1 || hot.rows[0][0] != 7) {
+        FAIL("expected only side row with constant child value 90");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_side_compound_duplicate_child_variables_filter(void)
+{
+    TEST("side compound duplicate child variables filter rows");
+
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl same(id: int64)\n"
+        "same(ID) :- event(ID, _, metadata(X, X, _, _)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t tenant = wirelog_easy_intern(s, "acme");
+    uint64_t matched_handle = 0;
+    uint64_t unmatched_handle = 0;
+    if (tenant < 0
+        || make_compound4(s, "metadata", 4, 4, 3, 90,
+        &matched_handle) != WIRELOG_OK
+        || make_compound4(s, "metadata", 1, 2, 3, 90,
+        &unmatched_handle) != WIRELOG_OK) {
+        FAIL("compound allocation failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t matched_row[3] = { 7, tenant, (int64_t)matched_handle };
+    int64_t unmatched_row[3] = { 8, tenant, (int64_t)unmatched_handle };
+    if (wirelog_easy_insert(s, "event", matched_row, 3) != WIRELOG_OK
+        || wirelog_easy_insert(s, "event", unmatched_row, 3) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t same;
+    memset(&same, 0, sizeof(same));
+    if (wirelog_easy_snapshot(s, "same", collect_tuple, &same)
+        != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    wirelog_easy_close(s);
+
+    if (same.count != 1 || same.ncols[0] != 1 || same.rows[0][0] != 7) {
+        FAIL("expected only side row with equal duplicate child variables");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_side_compound_wrong_functor_handle_no_match(void)
+{
+    TEST("side compound wrong functor handle does not match metadata pattern");
+
+    const char *src
+        = ".decl event(id: int64, tenant: symbol, payload: metadata/4 side)\n"
+        ".decl seen(id: int64)\n"
+        "seen(ID) :- event(ID, _, metadata(_, _, _, _)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    int64_t tenant = wirelog_easy_intern(s, "acme");
+    uint64_t wrong_handle = 0;
+    if (tenant < 0
+        || make_compound4(s, "other", 1, 2, 3, 4,
+        &wrong_handle) != WIRELOG_OK) {
+        FAIL("compound allocation failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t row[3] = { 7, tenant, (int64_t)wrong_handle };
+    if (wirelog_easy_insert(s, "event", row, 3) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t seen;
+    memset(&seen, 0, sizeof(seen));
+    if (wirelog_easy_snapshot(s, "seen", collect_tuple, &seen)
+        != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    wirelog_easy_close(s);
+
+    if (seen.count != 0) {
+        FAIL("wrong functor handle should not join metadata side relation");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_side_compound_nested_child_no_match(void)
+{
+    TEST("side compound nested child pattern is not recursive");
+
+    const char *src
+        = ".decl record(id: int64, scope_col: scope/1 side)\n"
+        ".decl seen(id: int64)\n"
+        "seen(ID) :- record(ID, scope(metadata(Level, Ts, Host, Risk))).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    uint64_t metadata_handle = 0;
+    uint64_t scope_handle = 0;
+    if (make_compound4(s, "metadata", 1, 100, 3, 90, &metadata_handle)
+        != WIRELOG_OK
+        || make_compound1(s, "scope", (int64_t)metadata_handle,
+        &scope_handle) != WIRELOG_OK) {
+        FAIL("compound allocation failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t row[2] = { 7, (int64_t)scope_handle };
+    if (wirelog_easy_insert(s, "record", row, 2) != WIRELOG_OK) {
+        FAIL("insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t seen;
+    memset(&seen, 0, sizeof(seen));
+    if (wirelog_easy_snapshot(s, "seen", collect_tuple, &seen)
+        != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    wirelog_easy_close(s);
+
+    if (seen.count != 0) {
+        FAIL("nested side body destructuring should not match");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_negated_side_compound_body_pattern_rejected(void)
+{
+    TEST("negated side compound body pattern is rejected");
+
+    const char *src
+        = ".decl all_events(id: int64)\n"
+        ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl clean(id: int64)\n"
+        "clean(ID) :- all_events(ID), !event(ID, metadata(_, _, _, 90)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) == WIRELOG_OK || s) {
+        wirelog_easy_close(s);
+        FAIL("negated side compound pattern should fail open");
+        return;
+    }
+    PASS();
+}
+
 static void
 test_side_compound_public_allocation_saturates(void)
 {
@@ -1467,6 +1784,12 @@ main(void)
     test_inline_compound_functor_mismatch_is_empty();
     test_inline_compound_constant_child_filters();
     test_inline_compound_duplicate_child_variables_filter();
+    test_side_compound_body_field_binding();
+    test_side_compound_constant_child_filters();
+    test_side_compound_duplicate_child_variables_filter();
+    test_side_compound_wrong_functor_handle_no_match();
+    test_side_compound_nested_child_no_match();
+    test_negated_side_compound_body_pattern_rejected();
     test_side_compound_public_allocation_saturates();
     test_insert_sym_variadic();
     test_remove_sym();

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -22,6 +22,7 @@
 
 #define INITIAL_CAPACITY 8
 #define WL_IR_COMPOUND_INLINE_MAX_ARITY 4u
+#define WL_IR_COMPOUND_SIDE_NAME_MAX 96u
 
 /* ======================================================================== */
 /* Column Type Mapping                                                      */
@@ -1091,6 +1092,217 @@ wrap_column_cmp_filter(wirelog_ir_node_t *child, uint32_t left_col,
 }
 
 static wirelog_ir_node_t *
+wrap_duplicate_var_filters(wirelog_ir_node_t *child, char **var_names,
+    uint32_t var_count)
+{
+    wirelog_ir_node_t *result = child;
+    if (!result || !var_names)
+        return result;
+
+    for (uint32_t i = 0; i < var_count; i++) {
+        if (!var_names[i])
+            continue;
+        for (uint32_t j = i + 1; j < var_count; j++) {
+            if (!var_names[j])
+                continue;
+            if (strcmp(var_names[i], var_names[j]) != 0)
+                continue;
+
+            wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
+            if (!f)
+                continue;
+
+            wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
+            if (cmp) {
+                cmp->cmp_op = WIRELOG_CMP_EQ;
+                wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
+                if (lhs) {
+                    char col[32];
+                    snprintf(col, sizeof(col), "col%u", i);
+                    lhs->var_name = strdup_safe(col);
+                }
+                wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
+                if (rhs) {
+                    char col[32];
+                    snprintf(col, sizeof(col), "col%u", j);
+                    rhs->var_name = strdup_safe(col);
+                }
+                wl_ir_expr_add_child(cmp, lhs);
+                wl_ir_expr_add_child(cmp, rhs);
+            }
+            f->filter_expr = cmp;
+            wl_ir_node_add_child(f, result);
+            result = f;
+        }
+    }
+
+    return result;
+}
+
+typedef struct {
+    const wl_parser_ast_node_t *arg;
+    char *handle_var;
+} side_compound_binding_t;
+
+static char *
+make_side_handle_var(const wl_parser_ast_node_t *atom, uint32_t col_idx)
+{
+    char buf[96];
+    snprintf(buf, sizeof(buf), "$compound_handle_%p_%u",
+        (const void *)atom, col_idx);
+    return strdup_safe(buf);
+}
+
+static char *
+make_side_relation_name(const char *functor, uint32_t arity)
+{
+    if (!functor || arity == 0)
+        return NULL;
+    char buf[WL_IR_COMPOUND_SIDE_NAME_MAX];
+    int n = snprintf(buf, sizeof(buf), "__compound_%s_%u", functor, arity);
+    if (n < 0 || (size_t)n >= sizeof(buf))
+        return NULL;
+    return strdup_safe(buf);
+}
+
+static char **
+concat_var_names_positional(char **left, uint32_t left_count, char **right,
+    uint32_t right_count, uint32_t *out_count)
+{
+    uint32_t total = left_count + right_count;
+    char **merged = (char **)calloc(total > 0 ? total : 1, sizeof(char *));
+    if (!merged) {
+        *out_count = 0;
+        return NULL;
+    }
+
+    for (uint32_t i = 0; i < left_count; i++)
+        merged[i] = strdup_safe(left ? left[i] : NULL);
+    for (uint32_t i = 0; i < right_count; i++)
+        merged[left_count + i] = strdup_safe(right ? right[i] : NULL);
+
+    *out_count = total;
+    return merged;
+}
+
+static int
+set_single_join_key(wirelog_ir_node_t *join, const char *key)
+{
+    if (!join || !key)
+        return -1;
+
+    join->join_left_keys = (char **)calloc(1, sizeof(char *));
+    join->join_right_keys = (char **)calloc(1, sizeof(char *));
+    if (!join->join_left_keys || !join->join_right_keys)
+        return -1;
+
+    join->join_key_count = 1;
+    join->join_left_keys[0] = strdup_safe(key);
+    join->join_right_keys[0] = strdup_safe(key);
+    if (!join->join_left_keys[0] || !join->join_right_keys[0])
+        return -1;
+
+    return 0;
+}
+
+static wirelog_ir_node_t *
+build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
+    const char *handle_var, char ***out_var_names, uint32_t *out_var_count)
+{
+    if (out_var_names)
+        *out_var_names = NULL;
+    if (out_var_count)
+        *out_var_count = 0;
+    if (!compound_arg || !compound_arg->name || !handle_var || !out_var_names
+        || !out_var_count)
+        return NULL;
+
+    char *side_name = make_side_relation_name(compound_arg->name,
+            compound_arg->child_count);
+    if (!side_name)
+        return NULL;
+
+    wirelog_ir_node_t *scan = wl_ir_node_create(WIRELOG_IR_SCAN);
+    if (!scan) {
+        free(side_name);
+        return NULL;
+    }
+    wl_ir_node_set_relation(scan, side_name);
+    free(side_name);
+
+    uint32_t count = compound_arg->child_count + 1u;
+    scan->column_names = (char **)calloc(count, sizeof(char *));
+    char **var_names = (char **)calloc(count, sizeof(char *));
+    if (!scan->column_names || !var_names) {
+        free_var_names(var_names, count);
+        wl_ir_node_free(scan);
+        return NULL;
+    }
+    scan->column_count = count;
+
+    scan->column_names[0] = strdup_safe(handle_var);
+    var_names[0] = strdup_safe(handle_var);
+    for (uint32_t i = 0; i < compound_arg->child_count; i++) {
+        const wl_parser_ast_node_t *child = compound_arg->children[i];
+        if (child && child->type == WL_PARSER_AST_NODE_VARIABLE) {
+            scan->column_names[i + 1u] = strdup_safe(child->name);
+            var_names[i + 1u] = strdup_safe(child->name);
+        }
+    }
+
+    wirelog_ir_node_t *result = scan;
+    bool unsupported_nested_pattern = false;
+    for (uint32_t i = 0; i < compound_arg->child_count; i++) {
+        const wl_parser_ast_node_t *child = compound_arg->children[i];
+        if (!child)
+            continue;
+        if (child->type == WL_PARSER_AST_NODE_INTEGER) {
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
+            if (rhs) {
+                rhs->int_value = child->int_value;
+                result = wrap_column_cmp_filter(result, i + 1u, rhs);
+            }
+        } else if (child->type == WL_PARSER_AST_NODE_STRING) {
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
+            if (rhs) {
+                rhs->str_value = strdup_safe(child->str_value);
+                result = wrap_column_cmp_filter(result, i + 1u, rhs);
+            }
+        } else if (child->type == WL_PARSER_AST_NODE_COMPOUND_TERM) {
+            unsupported_nested_pattern = true;
+        }
+    }
+    if (unsupported_nested_pattern)
+        result = wrap_false_filter(result);
+
+    *out_var_names = var_names;
+    *out_var_count = count;
+    return result;
+}
+
+static bool
+atom_has_declared_side_compound_pattern(const wl_parser_ast_node_t *atom,
+    const struct wirelog_program *prog)
+{
+    if (!atom || !prog)
+        return false;
+
+    wl_ir_relation_info_t *rel_info = find_relation_info(prog, atom->name);
+    if (!rel_info || !rel_info->columns)
+        return false;
+
+    for (uint32_t i = 0; i < atom->child_count && i < rel_info->column_count;
+        i++) {
+        const wl_parser_ast_node_t *arg = atom->children[i];
+        const wirelog_column_t *col = &rel_info->columns[i];
+        if (arg && arg->type == WL_PARSER_AST_NODE_COMPOUND_TERM
+            && col->compound_kind == WIRELOG_COMPOUND_KIND_SIDE)
+            return true;
+    }
+    return false;
+}
+
+static wirelog_ir_node_t *
 build_atom_scan(const wl_parser_ast_node_t *atom,
     const struct wirelog_program *prog, char ***out_var_names,
     uint32_t *out_var_count)
@@ -1143,7 +1355,12 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         = (const wl_parser_ast_node_t **)calloc(
             physical_count > 0 ? physical_count : 1,
             sizeof(wl_parser_ast_node_t *));
-    if (!scan->column_names || !var_names || !physical_args) {
+    side_compound_binding_t *side_bindings
+        = (side_compound_binding_t *)calloc(
+            arg_count > 0 ? arg_count : 1, sizeof(side_compound_binding_t));
+    if (!scan->column_names || !var_names || !physical_args
+        || !side_bindings) {
+        free(side_bindings);
         free(physical_args);
         free(var_names);
         wl_ir_node_free(scan);
@@ -1152,6 +1369,7 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
 
     /* Collect column names from atom arguments */
     uint32_t phys_idx = 0;
+    uint32_t side_binding_count = 0;
     for (uint32_t i = 0; i < arg_count; i++) {
         const wl_parser_ast_node_t *arg = atom->children[i];
         if (arg->type == WL_PARSER_AST_NODE_VARIABLE) {
@@ -1175,6 +1393,20 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                 }
                 phys_idx++;
             }
+        } else if (rel_info && i < rel_info->column_count
+            && rel_info->columns[i].compound_kind
+            == WIRELOG_COMPOUND_KIND_SIDE
+            && compound_arg_functor_matches(arg, &rel_info->columns[i], prog)) {
+            char *handle_var = make_side_handle_var(atom, i);
+            physical_args[phys_idx] = arg;
+            if (handle_var) {
+                scan->column_names[phys_idx] = strdup_safe(handle_var);
+                var_names[phys_idx] = strdup_safe(handle_var);
+                side_bindings[side_binding_count].arg = arg;
+                side_bindings[side_binding_count].handle_var = handle_var;
+                side_binding_count++;
+            }
+            phys_idx++;
         } else {
             /* Wildcard, integer, string -> NULL (anonymous position) */
             physical_args[phys_idx] = arg;
@@ -1280,41 +1512,7 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         result = wrap_false_filter(result);
 
     /* Step 1a: Intra-atom FILTER for duplicate variables */
-    for (uint32_t i = 0; i < physical_count; i++) {
-        if (!var_names[i])
-            continue;
-        for (uint32_t j = i + 1; j < physical_count; j++) {
-            if (!var_names[j])
-                continue;
-            if (strcmp(var_names[i], var_names[j]) == 0) {
-                wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-                if (!f)
-                    continue;
-
-                wl_ir_expr_t *cmp = wl_ir_expr_create(WL_IR_EXPR_CMP);
-                if (cmp) {
-                    cmp->cmp_op = WIRELOG_CMP_EQ;
-                    wl_ir_expr_t *lhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                    if (lhs) {
-                        char col[32];
-                        snprintf(col, sizeof(col), "col%u", i);
-                        lhs->var_name = strdup_safe(col);
-                    }
-                    wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_VAR);
-                    if (rhs) {
-                        char col[32];
-                        snprintf(col, sizeof(col), "col%u", j);
-                        rhs->var_name = strdup_safe(col);
-                    }
-                    wl_ir_expr_add_child(cmp, lhs);
-                    wl_ir_expr_add_child(cmp, rhs);
-                }
-                f->filter_expr = cmp;
-                wl_ir_node_add_child(f, result);
-                result = f;
-            }
-        }
-    }
+    result = wrap_duplicate_var_filters(result, var_names, physical_count);
 
     /* Step 1b: Intra-atom FILTER for constants */
     for (uint32_t i = 0; i < physical_count; i++) {
@@ -1334,9 +1532,52 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         }
     }
 
+    char **result_vars = var_names;
+    uint32_t result_vcount = physical_count;
+
+    for (uint32_t i = 0; i < side_binding_count; i++) {
+        char **side_vars = NULL;
+        uint32_t side_vcount = 0;
+        wirelog_ir_node_t *side_scan = build_side_compound_scan(
+            side_bindings[i].arg, side_bindings[i].handle_var,
+            &side_vars, &side_vcount);
+        wirelog_ir_node_t *join = wl_ir_node_create(WIRELOG_IR_JOIN);
+        if (!side_scan || !join
+            || set_single_join_key(join, side_bindings[i].handle_var) != 0) {
+            wl_ir_node_free(side_scan);
+            wl_ir_node_free(join);
+            free_var_names(side_vars, side_vcount);
+            result = wrap_false_filter(result);
+            continue;
+        }
+
+        wl_ir_node_add_child(join, result);
+        wl_ir_node_add_child(join, side_scan);
+        result = join;
+
+        uint32_t combined_count = 0;
+        char **combined = concat_var_names_positional(result_vars,
+                result_vcount, side_vars, side_vcount, &combined_count);
+        free_var_names(result_vars, result_vcount);
+        free_var_names(side_vars, side_vcount);
+        if (!combined) {
+            result_vars = NULL;
+            result_vcount = 0;
+            result = wrap_false_filter(result);
+            continue;
+        }
+        result_vars = combined;
+        result_vcount = combined_count;
+        result = wrap_duplicate_var_filters(result, result_vars,
+                result_vcount);
+    }
+
+    for (uint32_t i = 0; i < side_binding_count; i++)
+        free(side_bindings[i].handle_var);
+    free(side_bindings);
     free(physical_args);
-    *out_var_names = var_names;
-    *out_var_count = physical_count;
+    *out_var_names = result_vars;
+    *out_var_count = result_vcount;
     return result;
 }
 
@@ -1577,6 +1818,21 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             const wl_parser_ast_node_t *neg_atom = b->children[0];
             if (neg_atom->type != WL_PARSER_AST_NODE_ATOM)
                 continue;
+            if (atom_has_declared_side_compound_pattern(neg_atom, prog)) {
+                WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
+                    "negated side compound body pattern is unsupported "
+                    "for relation=%s",
+                    neg_atom->name ? neg_atom->name : "?");
+                for (uint32_t s = 0; s < scan_count; s++)
+                    free_var_names(scan_vars[s], scan_vcounts[s]);
+                if (cur_vars_is_merged)
+                    free_var_names(cur_vars, cur_vcount);
+                wl_ir_node_free(current);
+                free(scans);
+                free(scan_vars);
+                free(scan_vcounts);
+                return NULL;
+            }
 
             char **neg_vars = NULL;
             uint32_t neg_vcount = 0;


### PR DESCRIPTION
## Summary

- Lower declared side compound body patterns into parent-handle joins against generated __compound_<functor>_<arity> relations.
- Bind side payload fields through existing JOIN/FILTER/PROJECT paths, including constants and duplicate variable equality.
- Add public wirelog_easy_make_compound() E2E coverage and update compound docs/example notes.

Fixes #648

## Validation

- meson test -C build wirelog_easy inline_compound_wiring compound_side_relation public_api_macro --print-errorlogs
- meson compile -C build
- git diff --check