### PR TITLE
chore(#735): anchor Phase 2B TODOs to public sub-issues

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1108,7 +1108,7 @@ col_idb_consolidate(col_rel_t *r, wl_col_session_t *sess)
  *   4. Fire delta_cb(+1) for each row in new state not found in prev state
  *   5. Free snapshots
  *
- * TODO(Phase 2B): Replace step 2 with semi-naive ΔR propagation.
+ * TODO(#809): Replace step 2 with semi-naive ΔR propagation.
  */
 
 /* Forward declaration for col_stratum_step_with_delta (defined below) */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2017,7 +2017,7 @@ next_del_incr:;
  *   - Delta path: col_stratum_step_with_delta (snapshot + eval + set diff)
  * Arena is reset after each stratum to reclaim temporary evaluation data.
  *
- * TODO(Phase 2B): Replace set-diff delta with semi-naive ΔR propagation.
+ * TODO(#810): Replace set-diff delta with semi-naive ΔR propagation.
  *
  * @param session: wl_session_t* (cast to wl_col_session_t* internally)
  * @return 0 on success, non-zero on evaluation error
@@ -2145,7 +2145,7 @@ col_session_step(wl_session_t *session)
  * Implements wl_compute_backend_t.session_set_delta_cb vtable slot.
  * The callback is invoked with diff=+1 for new tuples during col_session_step.
  *
- * TODO(Phase 2B): Also fire diff=-1 for retracted tuples when semi-naive
+ * TODO(#810): Also fire diff=-1 for retracted tuples when semi-naive
  * delta propagation tracks removed tuples explicitly.
  *
  * @param session:   wl_session_t* (cast to wl_col_session_t* internally)
@@ -2174,7 +2174,7 @@ col_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
  *
  * Complexity: O(S * R * N) where S=strata, R=relations per stratum, N=rows
  *
- * TODO(Phase 2B): Snapshot should read from stable R (not recompute);
+ * TODO(#811): Snapshot should read from stable R (not recompute);
  * currently re-evaluates on every call which is O(input) per snapshot.
  *
  * @param session:   wl_session_t* (cast to wl_col_session_t* internally)


### PR DESCRIPTION
## Summary

- Per CLAUDE.md global rule, internal phase labels must not appear in source without a public issue cross-reference.
- Updates the four `Phase 2B` TODO comments in `wirelog/columnar/eval.c` and `wirelog/columnar/session.c` to reference the newly-filed public sub-issues #809, #810, #811.
- Comment-only change. No behavior or test surface modified.

## Mapping

| Site | Old label | New anchor |
|------|-----------|------------|
| `eval.c:1111` | `Phase 2B` | `#809` |
| `session.c:2020` | `Phase 2B` | `#810` |
| `session.c:2148` | `Phase 2B` | `#810` (paired retract path) |
| `session.c:2177` | `Phase 2B` | `#811` |

Closes #735.

## Test plan

- [x] CI builds + lint (`lint-pr`, `ci-pr`).
- [x] No functional code touched -- existing test suite remains valid.