### PR TITLE
ci(#737): forbid new unanchored 'Phase NX' labels in source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,30 @@ sudo cpupower frequency-set -g performance     # if available
 taskset -c 0 WIRELOG_PERF_GATE=1 meson test -C build-perf --suite perf --print-errorlogs
 ```
 
+### Internal commit-series labels in source comments
+
+Internal commit-series labels (such as `Phase 2A`, `Phase 3C-001`,
+`Phase 4B`) are an artifact of how individual contributors decompose
+work into commit batches. They are **not** meaningful to readers of
+the codebase and must not appear in source comments without a public
+issue cross-reference. The rule:
+
+* If a source comment in `wirelog/**/*.{c,h}` references a phase label
+  matching `Phase \d+[A-Z]`, the same line must include a public issue
+  reference (`#NNN`, `Issue NNN`, or `US-N-NNN`).
+* If the label refers to historical work whose context is no longer
+  necessary, **remove** the bare phase token rather than retroactively
+  inventing an issue link.
+* Allowlisted historical entries are listed in
+  `scripts/ci/phase-label-allowlist.txt`. The CI gate
+  (`meson test --suite abi:phase_labels` /
+  `scripts/ci/check-phase-labels.sh`) fails if a new unanchored label
+  appears outside that allowlist. The allowlist may shrink as cleanup
+  PRs land; it should not grow.
+
+This is the source-comment counterpart to the rule (recorded in
+project-wide assistant config) that forbids internal phase labels in
+commit messages and PR descriptions.
 
 ## General Styleguides
 

--- a/scripts/ci/check-phase-labels.sh
+++ b/scripts/ci/check-phase-labels.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# scripts/ci/check-phase-labels.sh - Issue #737.
+#
+# Forbid new unanchored "Phase NX" labels in source (.c / .h under
+# wirelog/).  A "Phase NX" label is a token of the form:
+#
+#     Phase <digit(s)><uppercase letter>[trailing chars]
+#
+# Examples: "Phase 2A", "Phase 3C", "Phase 3C-001-Ext", "Phase 4B".
+# These are internal commit-series labels per the global rule in
+# CLAUDE.md and are not meaningful to external readers.
+#
+# The gate is a ratchet:
+#
+#   - Any unanchored Phase NX label must either have a public-issue
+#     cross-reference on the same line ("#N" / "Issue N" / "US-N-NNN"),
+#     or be present in scripts/ci/phase-label-allowlist.txt as a
+#     historical grandfathered entry.
+#   - The allowlist is keyed on `file|content` (line numbers stripped)
+#     so it survives reformatting that moves lines around.
+#   - The allowlist may shrink as cleanup PRs land; that is expected.
+#     It must NEVER grow without an explicit decision in the PR
+#     description.
+#
+# Exit codes:
+#   0 - no new unanchored labels detected
+#   1 - new unanchored labels detected, or the allowlist file is
+#       missing / unreadable.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+allowlist="$script_dir/phase-label-allowlist.txt"
+
+if [ ! -f "$allowlist" ]; then
+    echo "check-phase-labels: FAIL: allowlist missing at $allowlist" >&2
+    exit 1
+fi
+
+# Collect current unanchored Phase NX matches in source.
+# Filter out lines that already cite a public issue / Souffle US- task.
+# Use relative paths (cd into repo_root) so the allowlist is portable
+# across checkout locations.
+current=$(cd "$repo_root" && \
+          grep -rEHn "Phase [0-9]+[A-Z][A-Za-z0-9.-]*" wirelog \
+            --include='*.c' --include='*.h' 2>/dev/null \
+          | grep -vE "#[0-9]+|Issue [0-9]+|US-[0-9.A-Za-z-]+" \
+          | sed -E 's/^([^:]+):[0-9]+:(.*)$/\1|\2/' \
+          | sort -u \
+          || true)
+
+fail=0
+while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    if ! grep -Fxq "$entry" "$allowlist"; then
+        if [ "$fail" -eq 0 ]; then
+            echo "check-phase-labels: FAIL: new unanchored 'Phase NX' label(s) detected" >&2
+            echo "" >&2
+            echo "Each match below must either (a) have an '(see #N)' / 'Issue N' / 'US-N-NNN'" >&2
+            echo "cross-reference on the same line, or (b) be appended to:" >&2
+            echo "  $allowlist" >&2
+            echo "" >&2
+            echo "If you legitimately need a new historical reference, append the" >&2
+            echo "match and explain it in the PR description.  Otherwise reword" >&2
+            echo "the comment to remove the bare phase label." >&2
+            echo "" >&2
+            echo "New matches:" >&2
+        fi
+        echo "  $entry" >&2
+        fail=1
+    fi
+done <<< "$current"
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+# Soft warning: stale allowlist entries that no longer appear in source.
+# Not a failure -- cleanup PRs will naturally orphan entries when they
+# remove the underlying labels.  The maintainer-side workflow is to
+# prune the allowlist as a follow-up.
+stale_count=0
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if ! grep -Fxq "$line" <(echo "$current"); then
+        stale_count=$((stale_count + 1))
+    fi
+done < "$allowlist"
+
+if [ "$stale_count" -gt 0 ]; then
+    echo "check-phase-labels: OK (with $stale_count stale allowlist entr$([ $stale_count -eq 1 ] && echo y || echo ies); prune via follow-up PR)"
+else
+    echo "check-phase-labels: OK"
+fi
+exit 0

--- a/scripts/ci/phase-label-allowlist.txt
+++ b/scripts/ci/phase-label-allowlist.txt
@@ -1,0 +1,23 @@
+wirelog/arena/arena.h| * Memory Profiling Targets (Phase 2A)
+wirelog/columnar/arrangement.c| * columnar/arrangement.c - wirelog Arrangement Layer (Phase 3C)
+wirelog/columnar/arrangement.c|/* Arrangement Accessors (Phase 3C)                                         */
+wirelog/columnar/arrangement.c|/* Arrangement Layer (Phase 3C)                                             */
+wirelog/columnar/arrangement.c|/* Delta Arrangement Cache (Phase 3C-001-Ext)                               */
+wirelog/columnar/columnar_nanoarrow.h| * fixed-point evaluation.  Used for debugging row lineage and by Phase 3C
+wirelog/columnar/columnar_nanoarrow.h|/* Arrangement Layer (Phase 3C)                                             */
+wirelog/columnar/columnar_nanoarrow.h|/* Frontier Tracking (Phase 3B)                                             */
+wirelog/columnar/eval.c|        /* Phase 3C NOTE: Weighted operation cases (WL_PLAN_OP_JOIN_WEIGHTED,
+wirelog/columnar/eval.c| * Phase 2A algorithm (full re-eval + set diff):
+wirelog/columnar/eval.c| * TODO(Phase 2B): Replace step 2 with semi-naive ΔR propagation.
+wirelog/columnar/internal.h|     *   compound_kind != INLINE; Phase 2B populates this during schema
+wirelog/columnar/internal.h|    /* Arrangement registry (Phase 3C): persistent hash indices           */
+wirelog/columnar/internal.h|    /* Delta arrangement cache (Phase 3C-001-Ext): per-iteration hash
+wirelog/columnar/internal.h|    /* Per-phase K-fusion profiling (Phase 3A): breakdown of kfusion_ns into
+wirelog/columnar/ops.c|    /* (Simple O(n^2) implementation; sufficient for Phase 2A) */
+wirelog/columnar/session.c|    /* Free arrangement registry (Phase 3C) */
+wirelog/columnar/session.c| * TODO(Phase 2B): Also fire diff=-1 for retracted tuples when semi-naive
+wirelog/columnar/session.c| * TODO(Phase 2B): Replace set-diff delta with semi-naive ΔR propagation.
+wirelog/columnar/session.c| * TODO(Phase 2B): Snapshot should read from stable R (not recompute);
+wirelog/exec_plan_gen.c| * Set to 1 for parallel K-fusion execution (Phase 2C performance testing).
+wirelog/ir/program.c|                /* Phase 1B: Extract compound metadata if present */
+wirelog/ir/program.c|     * shape; richer multi-column lowering is deferred to Phase 2C.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -475,6 +475,17 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #737: forbid new unanchored "Phase NX" labels in wirelog/ source.
+# Each Phase NX label must either carry an explicit issue cross-reference
+# on the same line ("#N", "Issue N", "US-N-NNN"), or be present in the
+# historical allowlist at scripts/ci/phase-label-allowlist.txt.  Static
+# text scan; no build-tree input required.
+if sh.found()
+  test('phase_labels', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-phase-labels.sh'],
+       suite: 'abi')
+endif
+
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss


### PR DESCRIPTION
## Summary

- Adds `scripts/ci/check-phase-labels.sh` and a meson abi-suite test (`phase_labels`) that flags new unanchored `Phase NX` labels in `wirelog/**/*.{c,h}`.
- A `Phase NX` label matches `Phase \d+[A-Z]` and must carry a public-issue cross-reference on the same line (`#N`, `Issue N`, `US-N-NNN`) or be in the historical allowlist `scripts/ci/phase-label-allowlist.txt` (23 entries today).
- Documents the rule under `CONTRIBUTING.md` -> "Internal commit-series labels in source comments".

Closes #737.

## How the ratchet works

The allowlist may **shrink** as cleanup PRs land (stale entries are reported as a soft warning, not a failure). It must never grow without an explicit decision in the PR description. This lets the milestone close without auditing every historical label up-front, while still preventing regressions.

PR #812 (chore(#735) anchoring Phase 2B TODOs) will naturally orphan 4 allowlist entries once it merges; those become soft warnings rather than failures, and a follow-up cleanup PR can prune them.

## Verified locally

- `bash scripts/ci/check-phase-labels.sh` exits 0 on current main.
- A synthetic file containing `/* Phase 9X: new label */` trips the gate with a clear remediation message pointing at the allowlist.

## Test plan

- [x] CI `ci-pr`, `lint-pr`, `Sanitizers`, `TSan`.
- [x] New `meson test --suite abi:phase_labels` passes on the baseline.
- [x] Manual synthetic-violation test confirmed the gate fails as expected.