### PR TITLE
ci(#742): gate Status: Future entries in docs/SEMANTICS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,25 @@ This is the source-comment counterpart to the rule (recorded in
 project-wide assistant config) that forbids internal phase labels in
 commit messages and PR descriptions.
 
+### `Status: Future` entries in docs/SEMANTICS.md
+
+`docs/SEMANTICS.md` is the canonical reference for semantic-model
+decisions and labels each entry `Status: Current` or `Status: Future`.
+A 1.0 stable contract that says "this is Future" with no schedule is
+an unbounded liability; external embedders cannot estimate when a
+Future entry becomes Current.
+
+The rule:
+
+* Every `Status: Future` heading in `docs/SEMANTICS.md` MUST cite a
+  milestone or issue reference within the 8-line window starting at
+  the heading. Acceptable anchors are `#NNN`, `Milestone vX.Y`, or
+  `Target: milestone vX.Y`.
+* The gate `meson test --suite abi:semantics_future` /
+  `scripts/ci/check-semantics-future.sh` enforces this. It exits 0
+  cleanly when there are no Future entries (i.e. when the doc is
+  fully Current).
+
 ## General Styleguides
 
 * Write clear, self-documenting code.

--- a/scripts/ci/check-semantics-future.sh
+++ b/scripts/ci/check-semantics-future.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# scripts/ci/check-semantics-future.sh - Issue #742.
+#
+# Asserts that every `Status: Future` entry in `docs/SEMANTICS.md`
+# is anchored to a public milestone or issue.  A `Status: Future`
+# declaration without a schedule is an unbounded liability for the
+# 1.0 stable contract: external embedders cannot estimate when the
+# Future entry becomes Current.
+#
+# Rule:
+#   Within an 8-line window starting at each `Status: Future` heading,
+#   the document MUST cite at least one of:
+#     - a GitHub issue reference (`#NNN`)
+#     - a milestone marker (`milestone:` / `Milestone:` / `Milestone NNN`
+#       / `v0.NN` / `v1.0.NN`)
+#
+#   The 8-line window is wide enough to span "## Heading (Status: Future)"
+#   followed by a "Tracked under #NNN" or "Target: milestone v0.42" line.
+#
+# Exit codes:
+#   0 - every Future entry has an anchor, or no Future entries exist
+#   1 - at least one Future entry is unanchored
+#   1 - docs/SEMANTICS.md is missing
+#
+# Intended to register under `meson test --suite abi:semantics_future`.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+doc="$repo_root/docs/SEMANTICS.md"
+
+if [ ! -f "$doc" ]; then
+    echo "check-semantics-future: FAIL: $doc is missing" >&2
+    exit 1
+fi
+
+# Find each Status: Future heading and capture its line number.
+future_lines=$(grep -nE 'Status: *Future' "$doc" || true)
+
+if [ -z "$future_lines" ]; then
+    echo "check-semantics-future: OK (no Status: Future entries)"
+    exit 0
+fi
+
+fail=0
+while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    line=$(echo "$match" | cut -d: -f1)
+    text=$(echo "$match" | cut -d: -f2-)
+
+    # Read the 8-line window starting at the heading line.
+    start=$line
+    end=$((line + 7))
+    window=$(sed -n "${start},${end}p" "$doc")
+
+    # Require an issue reference or a milestone marker within the window.
+    if ! echo "$window" \
+            | grep -qE '#[0-9]+|[mM]ilestone[: ]|v[0-9]+\.[0-9]+'; then
+        if [ "$fail" -eq 0 ]; then
+            echo "check-semantics-future: FAIL: unanchored Status: Future entry/entries detected" >&2
+            echo "" >&2
+            echo "Each Status: Future entry MUST cite a milestone or issue link" >&2
+            echo "within the 8-line window starting at the heading.  Use either:" >&2
+            echo "  - 'Tracked under #NNN' / '(see #NNN)'" >&2
+            echo "  - 'Milestone v0.NN' / 'Target: milestone v0.NN'" >&2
+            echo "" >&2
+            echo "Unanchored entries:" >&2
+        fi
+        echo "  $doc:$line: $text" >&2
+        fail=1
+    fi
+done <<< "$future_lines"
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+count=$(echo "$future_lines" | wc -l | tr -d ' ')
+echo "check-semantics-future: OK ($count Status: Future entr$([ "$count" -eq 1 ] && echo y || echo ies), all anchored)"
+exit 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -486,6 +486,16 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #742: every `Status: Future` entry in docs/SEMANTICS.md must
+# cite a milestone or issue link within an 8-line window of the
+# heading.  Prevents the doc from accruing unbounded "Future" entries
+# with no schedule.  Static text scan; no build-tree input required.
+if sh.found()
+  test('semantics_future', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-semantics-future.sh'],
+       suite: 'abi')
+endif
+
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss


### PR DESCRIPTION
## Summary

- Adds `scripts/ci/check-semantics-future.sh` and a meson abi-suite test (`semantics_future`).
- Enforces that every `Status: Future` heading in `docs/SEMANTICS.md` has a milestone or issue reference (`#NNN`, `Milestone vX.Y`, `vX.Y`) within an 8-line window starting at the heading.
- Documents the rule under `CONTRIBUTING.md` -> "`Status: Future` entries in docs/SEMANTICS.md".

Closes #742.

## Why this matters

A `Status: Future` declaration without a schedule is an unbounded liability for the 1.0 stable contract; external embedders cannot estimate when the Future entry becomes Current.

Today `docs/SEMANTICS.md` has zero `Status: Future` entries (all three sections are Current). The gate exits 0 cleanly when there are no Future entries, so it imposes no current burden and only fires when a Future entry is introduced.

## Test plan

- [x] `bash scripts/ci/check-semantics-future.sh` exits 0 on current main (no Future entries).
- [x] Synthetic test confirms the gate FAILs on a Future heading without an anchor and PASSes when `Tracked under #NNN` is added.
- [x] CI `ci-pr`, `lint-pr` will run.