### PR TITLE
docs(#692): define residue, slip recursive aggregation closure to v0.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,24 @@ All notable changes to wirelog are documented in this file.
   current 5-trial medians; the +26% CSPA W=1 delta (1.55s -> 1.95s) is
   a measurement-methodology change, not a runtime regression, and 1.95s
   is the honest baseline.  Closes #736.
+- **`docs/SEMANTICS.md` recursive aggregation residue definition + v0.43
+  slip** (#692): adds a new "Recursive aggregation residue (Status:
+  Future)" section defining "residue" operationally as the count of
+  `'not yet implemented'` markers and disabled conformance tests in
+  `tests/test_recursive_agg*.c` that block CC-min, SSSP-max, and
+  count-stratified programs from producing correct output at workers in
+  {1, 4, 8, 16}.  Records the current state (harness disabled at
+  `tests/meson.build:184-198, 2190-2194`; `col_op_reduce` IS wired
+  (`WL_PLAN_OP_REDUCE` case at `eval.c:267-269`) but conformance cannot
+  run because the harness is disabled; `col_op_reduce_weighted` built
+  but NOT dispatched (no `WL_PLAN_OP_REDUCE_WEIGHTED:` case) in the
+  recursive dispatch switch at `wirelog/columnar/eval.c:241-288`;
+  count-stratified
+  scope asymmetry) and the path to residue = 0: Phase 2B prerequisite
+  (#735, #809/#810/#811) then v0.43 harness re-port.  Narrows the v0.42
+  exit criterion to "non-agg recursion residue = 0" via Phase 2B;
+  recursive aggregation residue = 0 slips to v0.43 per architect+critic
+  synthesis on 2026-05-18.
 
 - **`docs/SEMANTICS.md` cross-facade parity audit subsection**
   (#785, under epic #681): the existing "Cross-facade parity

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -123,6 +123,62 @@ not assume symmetric coverage.
 - `CHANGELOG.md` — entry for #718.
 - `stable-release-plan.md` §3, §7 — public-surface and conformance plans.
 
+## Recursive aggregation residue (Status: Future)
+
+Tracked under #692.  Target: residue = 0 in Milestone v0.43.
+
+### Definition
+
+Residue is the count of `'not yet implemented'` markers and disabled
+conformance tests in `tests/test_recursive_agg*.c` that prevent
+recursive aggregation programs (CC-min, SSSP-max, count-stratified)
+from producing semantically correct output at workers in {1, 4, 8, 16}.
+
+### Current state (as of v0.42)
+
+- **Conformance harness disabled**: `tests/test_recursive_agg.c`,
+  `tests/test_recursive_agg_cc_min.c`, and
+  `tests/test_recursive_agg_sssp_max.c` are disabled in
+  `tests/meson.build:184-198, 2190-2194`.  The harness depended on the
+  DD/Rust FFI backend, which has been removed.  No replacement fixtures
+  have been ported to the columnar backend.
+- **Columnar dispatch state** at `wirelog/columnar/eval.c:241-288`:
+  - `col_op_reduce` (`wirelog/columnar/ops.c:6090`) IS wired into the
+    recursive dispatch switch (`WL_PLAN_OP_REDUCE` case at
+    `eval.c:267-269`).  Conformance for recursive monotone aggregation
+    (MIN/MAX) cannot run today only because the harness in
+    `tests/test_recursive_agg*.c` is disabled.
+  - `col_op_reduce_weighted` (`wirelog/columnar/ops.c:6200`) is built
+    but NOT dispatched (no `WL_PLAN_OP_REDUCE_WEIGHTED:` case in the
+    switch).  Weighted reductions inside `iterate()` cannot execute.
+- **count-stratified scope asymmetry**: count-stratified aggregation
+  appears in the #692 issue body but is absent from the acceptance
+  criteria, and no test fixtures exist.
+
+### Path to residue = 0
+
+1. **Phase 2B prerequisite**: semi-naive Delta-R for non-aggregation
+   recursion (#735, #809, #810, #811) must land first.  Phase 2B covers
+   non-agg recursion; REDUCE-inside-iterate is a separate concern.
+2. **v0.43 work**: re-enable the conformance harness against the
+   columnar backend; add a `WL_PLAN_OP_REDUCE_WEIGHTED:` case to wire
+   `col_op_reduce_weighted` into the recursive dispatch switch; add
+   count-stratified fixtures.
+
+v0.42 narrowed exit criterion: "non-agg recursion residue = 0" via
+Phase 2B sub-issues (#809/#810/#811).  Recursive aggregation residue = 0
+carries to v0.43 under #692.
+
+### References
+
+- Issue #692 — Blocker B5: Recursive aggregation residue = 0.
+- Phase 2B: #735, #809, #810, #811.
+- `wirelog/columnar/ops.c` — `col_op_reduce`, `col_op_reduce_weighted`.
+- `wirelog/columnar/eval.c:241-288` — recursive dispatch switch.
+- `tests/meson.build:184-198, 2190-2194` — disabled harness entries.
+
+---
+
 ## v0.40 API audit closure (Status: Current)
 
 The v0.40 API audit (epic #680, Risk-C and Blocker-B series catalogued


### PR DESCRIPTION
## Summary

Implements the milestone-administrative resolution for issue #692 ("Blocker B5: Recursive aggregation residue = 0").

- Slips #692 to **v0.43 Platform Packaging** milestone (already done via `gh issue edit`).
- Defines "residue" operationally in `docs/SEMANTICS.md` (it was undefined in any tracked file).
- Narrows v0.42 exit to "non-agg recursion residue = 0" via Phase 2B sub-issues #809/#810/#811.
- CHANGELOG bullet under `[Unreleased] ### Documentation`.

## Why the slip

Architect + critic both analyzed #692 and converged on a multi-week scope:

- **Test harness disabled**: `tests/meson.build:184-198, 2190-2194` lists `test_recursive_agg{,_cc_min,_sssp_max}.c` as deferred / DD-backend-deleted. None of these tests currently run; the acceptance ("worker in {1,4,8,16}") is unmeasurable today.
- **Columnar dispatch partial**: `col_op_reduce` (`wirelog/columnar/ops.c:6090`) IS wired at `wirelog/columnar/eval.c:267-269` (`WL_PLAN_OP_REDUCE` case). `col_op_reduce_weighted` (`wirelog/columnar/ops.c:6200`) is built but has NO dispatch case in the switch at `eval.c:241-288`. Weighted reductions inside `iterate()` cannot execute.
- **count-stratified scope-asymmetry**: appears in the issue body but is absent from the acceptance bullet, and no test fixtures exist anywhere in the repo.
- **Phase 2B prerequisite**: #735/#809/#810/#811 (semi-naive Delta-R) is a separate multi-week workstream that #692 depends on; even with that closed, weighted REDUCE wiring + harness re-port + count-stratified fixtures + worker-sweep CI scaffolding remain.

Honest path: slip B5 to v0.43, narrow v0.42 to "non-agg recursion residue = 0". This preserves the v0.42 "Semantics Closure" name on the residual it can credibly deliver and explicitly schedules the remaining work.

## Atomic-commit workflow

This PR contains a single commit (`930b73b`) developed through the multi-agent atomic-commit workflow:

1. Architect + Critic discussion -> consensus: slip to v0.43; define residue operationally; narrow v0.42 exit.
2. Executor implemented `799522f`.
3. Code reviewer found one MAJOR factual error (`col_op_reduce` claimed unwired when it IS wired); executor amended to `89ffcb4` and posted a corrective gh comment on #692.
4. Architect + critic re-approved with one MINOR (anchor line outside the 8-line `check-semantics-future.sh` window). Executor amended to `930b73b`.

## Cross-references

- #682 v0.42 Epic
- #735 Phase 2B Epic (and #809/#810/#811 sub-issues)
- #816 `check-semantics-future.sh` gate (the new `Status: Future` section is anchored to satisfy it)

## Test plan

- [x] CHANGELOG bullet format gate (`#692` reference, under `### Documentation`).
- [x] `bash scripts/ci/check-semantics-future.sh` (when PR #816 lands) -- the new `Status: Future` section anchors `#692` and `Milestone v0.43` at line 128, within the 8-line window of the heading at line 126.
- [x] No out-of-scope changes: `docs/SEMANTICS.md` + `CHANGELOG.md` only (no bench/, no tests/, no wirelog/).
- [x] Issue #692: state OPEN, milestone v0.43 Platform Packaging.