### PR TITLE
ci: narrow native TSan advisory leg

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -264,33 +264,29 @@ jobs:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
 
   # ==========================================================================
-  # Phase 3b (advisory): TSan with -Dthreads=native on Linux glibc
+  # Phase 3b (advisory): TSan compile smoke with -Dthreads=native
   #
   # WHY THIS LEG EXISTS:
-  #   wirelog/thread_c11.c implements a thin trampoline over NPTL: on Linux
-  #   glibc, thrd_create resolves to pthread_create, mtx_lock to
-  #   pthread_mutex_lock, and cnd_wait to pthread_cond_wait.  libtsan
-  #   intercepts at the public-symbol level (not internal versioned aliases),
-  #   so the same happens-before edges observed under -Dthreads=posix are
-  #   observable here too.  Running TSan against -Dthreads=native therefore
-  #   exercises the 40-
-  #   line trampoline in thread_c11.c and its thin wrappers without leaving
-  #   a coverage gap for that translation unit.
+  #   The normal TSan job above forces -Dthreads=posix because libtsan's
+  #   reliable synchronization interceptors are pthread-based.  This job keeps
+  #   an advisory compile/link smoke for the native C11 backend under the same
+  #   sanitizer flags, so wirelog/thread_c11.c remains build-covered without
+  #   pretending that C11 thrd_*/mtx_*/cnd_* runtime execution is a valid race
+  #   signal under GCC/libtsan.
   #
-  # WHY IT IS ADVISORY:
-  #   TSan does not directly intercept C11 thrd_*/mtx_*/cnd_* call sites;
-  #   coverage relies on glibc's NPTL trampoline redirecting them to the
-  #   pthread symbols that libtsan intercepts.  On non-glibc platforms (musl,
-  #   Apple libc, MSVC) the C11 shim does not route through NPTL, so TSan
-  #   either produces false positives or misses races entirely.  This leg
-  #   runs on ubuntu-latest (glibc) only and converts test failures to a
-  #   GitHub Actions warning so that noise on edge cases does not block PRs.
-  #   The posix leg above remains the gating TSan signal.
+  # WHY THIS JOB DOES NOT RUN THE FULL TEST SUITE:
+  #   Issue #826 showed that executing instrumented C11-created worker threads
+  #   can crash the sanitizer runtime itself with ThreadSanitizer:DEADLYSIGNAL
+  #   SEGV 0x18 before wirelog synchronization can be diagnosed.  Suppressions
+  #   do not apply to that fatal runtime failure, and skipping only the first
+  #   failing tests would leave the job noisy and misleading.  Runtime C11
+  #   backend coverage comes from the ordinary non-TSan matrix; race detection
+  #   remains the responsibility of the gating posix TSan leg.
   #
   # Cross-references:
-  #   - docs/THREADING.md section 10 (Appendix: ThreadSanitizer configuration)
+  #   - docs/THREADING.md section 11 (Appendix: ThreadSanitizer configuration)
   #   - Risk C5, issue #708 (-Dthreads=native + TSan advisory leg)
-  #   - Issue #826 (native TSan SEGV triage surfaced by this advisory leg)
+  #   - Issue #826 (native C11 runtime under TSan is not a valid signal)
   # ==========================================================================
   tsan-native:
     name: TSan-native / ubuntu-latest / gcc
@@ -319,15 +315,7 @@ jobs:
       - name: Build with TSan (native threads)
         run: meson compile -C builddir-tsan-native
 
-      - name: Test with TSan (native threads)
+      - name: Policy smoke (native threads under TSan)
         run: |
-          set +e
-          meson test -C builddir-tsan-native --print-errorlogs
-          rc=$?
-          set -e
-          if [ "$rc" -ne 0 ]; then
-            echo "::warning title=Advisory TSan-native failures::meson test failed with rc=$rc under -Dthreads=native; the posix TSan job remains the gating signal."
-            exit 0
-          fi
-        env:
-          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+          echo "::notice title=TSan-native policy::Native C11 runtime tests are intentionally not executed under TSan; see docs/THREADING.md and issue #826."
+          meson test -C builddir-tsan-native threading_doc --print-errorlogs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,19 +199,19 @@ All notable changes to wirelog are documented in this file.
   exit criterion to "non-agg recursion residue = 0" via Phase 2B;
   recursive aggregation residue = 0 slips to v0.43 per architect+critic
   synthesis on 2026-05-18.
-- **Advisory TSan leg for `-Dthreads=native` on Linux glibc** (#708):
+- **Advisory TSan compile smoke for `-Dthreads=native`** (#708, #826):
   `.github/workflows/ci-pr.yml` gains a `tsan-native` job mirroring the
-  existing `tsan` (posix) leg but configured with `-Dthreads=native`;
-  native-leg failures are emitted as GitHub Actions warnings so the check
-  remains advisory.  On Linux glibc the C11 `<threads.h>` shim
-  routes to NPTL, so libtsan's pthread interceptors observe the same
-  happens-before edges as the posix backend; the advisory leg therefore
-  covers `wirelog/thread_c11.c`'s trampoline without blocking PRs on
-  non-glibc noise.  `docs/THREADING.md` section 10 is updated to soften
-  the "non-negotiable" language (now qualified to non-glibc only) and adds
-  a coverage matrix table (posix = gating, native/glibc = advisory,
-  native/musl/Apple/MSVC = not covered).  Refs #708; native-leg SEGV
-  triage is tracked in #826.
+  existing `tsan` (posix) configuration through configure/compile only,
+  but it no longer runs the full native C11 runtime suite under TSan.
+  Issue #826 showed that instrumented workers created through
+  `thrd_create` can crash GCC/libtsan itself with
+  `ThreadSanitizer:DEADLYSIGNAL` / SEGV `0x18`, before wirelog
+  synchronization can be diagnosed; suppressions and per-test skips would
+  therefore be misleading.  `docs/THREADING.md` section 11 now makes
+  `-Dthreads=posix` the only gating race-detection surface, records
+  native/glibc as compile-only advisory coverage, and leaves runtime C11
+  backend coverage to the ordinary non-TSan matrix.  Closes #826; refs
+  #708.
 - **`docs/SEMANTICS.md` cross-facade parity audit subsection**
   (#785, under epic #681): the existing "Cross-facade parity
   (Status: Current)" block gains a new sub-block recording the

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -85,9 +85,10 @@ option('threads', type: 'combo', choices: ['native', 'posix'],
   falls back to pthreads (or Windows on `_WIN32`).
 - `-Dthreads=posix`: the probe is skipped and `pthreads` is forced
   unconditionally. **This is required for ThreadSanitizer** because
-  TSan only intercepts pthread synchronization primitives; C11
-  `<threads.h>` calls bypass the interceptor. The TSan CI legs at
-  `.github/workflows/ci-pr.yml` invoke meson with `-Dthreads=posix`.
+  TSan only provides reliable race diagnostics for wirelog when the
+  worker threads are created through the pthread backend. The gating
+  TSan CI leg at `.github/workflows/ci-pr.yml` invokes meson with
+  `-Dthreads=posix`.
 
 ### Public API
 
@@ -662,33 +663,37 @@ meson setup build-tsan \
 meson test -C build-tsan --suite tsan
 ```
 
-The `-Dthreads=posix` requirement is non-negotiable on non-glibc
-platforms; on Linux glibc, the C11 `<threads.h>` backend is
-implemented as a thin shim over NPTL (e.g., `thrd_create` ->
-`pthread_create`, `mtx_lock` -> `pthread_mutex_lock`), so libtsan's
-pthread interceptors — which hook at the public-symbol level, not at
-internal glibc versioned aliases — still observe the same
-happens-before edges that the posix backend exposes.  The posix
-backend remains canonical for race gating; the native backend is
-exercised by an advisory TSan leg under `.github/workflows/ci-pr.yml`
-that reports native-leg failures as GitHub Actions warnings.
+The `-Dthreads=posix` requirement is non-negotiable for race gating.
+Issue #826 showed that the Linux glibc C11 `<threads.h>` backend is
+not a reliable TSan runtime signal even though glibc implements the C11
+surface over NPTL.  Executing instrumented workers created through
+`thrd_create` can crash the sanitizer runtime itself with
+`ThreadSanitizer:DEADLYSIGNAL` / SEGV `0x18` before wirelog
+synchronization is meaningfully diagnosed.  Suppressions do not apply
+to that fatal sanitizer crash.
+
+The posix backend is therefore the only canonical TSan race surface.
+The `tsan-native` CI leg under `.github/workflows/ci-pr.yml`
+configures and compiles with `-Dthreads=native` plus
+`-Db_sanitize=thread`, then runs only a policy/documentation smoke. It
+does not execute the full runtime test suite under native C11 TSan.
+Runtime coverage for the native C11 backend comes from the ordinary
+non-TSan matrix.
 
 ### TSan coverage matrix
 
 | Backend | Platform | TSan status | Notes |
 |---------|----------|-------------|-------|
 | `posix` | all | **gating** | libtsan intercepts pthread_* directly; canonical race surface |
-| `native` | Linux glibc | advisory | C11 shim routes to NPTL; same happens-before edges as posix; failures are reported as CI warnings |
+| `native` | Linux glibc | compile-only advisory | CI configures and compiles with TSan, but does not run native C11 worker tests because issue #826 shows sanitizer-runtime SEGVs before race diagnostics |
 | `native` | musl | not covered | musl C11 shim does not route through NPTL pthread symbols |
 | `native` | Apple libc | not covered | Apple libc lacks `<threads.h>`; C11 backend not buildable (see meson.build:42) |
 | `native` | Windows MSVC | not covered | no libtsan; Win32 threads only |
 
-On glibc, both the posix and native backends ultimately resolve to
-the same NPTL synchronization primitives, so the advisory TSan leg
-catches regressions in `wirelog/thread_c11.c`'s trampoline and thin
-wrappers without leaving a coverage gap for that translation unit.
-On non-glibc platforms the native backend is not TSan-testable; the
-posix backend remains the only reliable option.
+The compile-only native leg exists to keep `wirelog/thread_c11.c`
+buildable under sanitizer flags. It is not evidence that libtsan has
+observed C11-thread happens-before edges. On all platforms the posix
+backend remains the only reliable TSan option.
 
 Cross-references: Risk C5, issue #708 (-Dthreads=native + TSan
 advisory leg); issue #826 (native TSan SEGV triage);


### PR DESCRIPTION
## Summary
- narrow `tsan-native` from full native C11 runtime execution to configure/compile plus `threading_doc` policy smoke
- document #826 root cause: GCC/libtsan can crash with `ThreadSanitizer:DEADLYSIGNAL` / SEGV `0x18` before C11-thread race diagnostics are meaningful
- keep `-Dthreads=posix` as the only gating TSan race signal and leave native C11 runtime coverage to the ordinary non-TSan matrix

## Verification
- `meson compile -C builddir-tsan-native-826`
- `meson test -C builddir-tsan-native-826 threading_doc --print-errorlogs`
- `meson test -C builddir-tsan-posix-826 --suite tsan --print-errorlogs`
- `meson test -C builddir-tsan-posix-826 workqueue workqueue_capacity lockfree_queue --print-errorlogs`
- `meson test -C builddir workqueue workqueue_capacity lockfree_queue io_adapter_concurrent --print-errorlogs`
- `meson test -C builddir --suite abi --print-errorlogs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-pr.yml'); puts 'ok'"`
- `git diff --check`

Closes #826
Refs #708
