### PR TITLE
feat(#464): Android meson plumbing + NDK r27c cross-files (arm64-v8a, x86_64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Android meson option + NDK cross-files** (#464):
+  new `meson_options.txt` boolean `android` (default false).  When
+  enabled, `meson.build` excludes `wirelog_cli` from the build (no
+  useful CLI entry on JNI / NDK apps), appends
+  `-Wl,-z,max-page-size=16384` to `libwirelog.so`'s `link_args` on
+  `aarch64` for Android 14+ 16 KB page compatibility (the flag is
+  meaningless on x86_64 emulator builds and is omitted there), and
+  cascades the CLI guard to the four CLI-dependent baseline tests in
+  `tests/meson.build` (`baseline_int_edges`, `baseline_sym_family`,
+  `baseline_tab_nodes`, `cli_version`).  Symbol-visibility policy is
+  unchanged -- `gnu_symbol_visibility: 'hidden'` plus `WIRELOG_API`
+  annotations on the 9 installed headers already cover all 53 Android
+  exports, so the v1.0 ABI manifest gate at
+  `scripts/ci/check-abi-symbols.sh` remains intact across platforms.
+  Two NDK cross-files ship: `cross/android-arm64.ini` and
+  `cross/android-x86_64.ini`, both pinned to NDK r27c (LTS), with
+  `[constants]`-driven path composition and a documented override path
+  for non-standard NDK install prefixes.  `armeabi-v7a` is intentionally
+  not supported (Play Store has required 64-bit since 2019; armv7
+  would carry a third toolchain for zero modern delivery value).  The
+  recipe lives at `docs/cross-compile-android.md`; CI matrix coverage
+  is a separate follow-up (out of scope for #464).
 - **libabigail `.abi.json` ABI manifest + abidiff CI gate** (#786):
   the v1.0 ABI golden file gains its libabigail half.  Where the
   53-entry `abi/libwirelog-1.0.symbols` allowlist (#733 K2) only

--- a/cross/android-arm64.ini
+++ b/cross/android-arm64.ini
@@ -1,0 +1,53 @@
+# Meson cross-file for Android arm64-v8a (aarch64).
+#
+# Issue #464 -- Android NDK cross-compile plumbing.
+#
+# Usage:
+#
+#   export ANDROID_NDK_ROOT=/path/to/android-ndk-r27c
+#   meson setup build-android-arm64 \
+#       --cross-file cross/android-arm64.ini \
+#       -Dandroid=true \
+#       -Dtests=false \
+#       -DmbedTLS=disabled
+#   meson compile -C build-android-arm64
+#
+# The `ndk` constant below is the install prefix of NDK r27c (current LTS).
+# Override by setting it before running meson, OR by symlinking your NDK
+# install to /opt/android-ndk-r27c, OR by editing this file locally and
+# NOT committing the edit.  Meson cross-files do not interpolate shell
+# environment variables; the constant is the single point of override.
+#
+# NDK version pin: r27c (LTS) -- min API 21, full 16 KB page support on
+# arm64.  Bump in lockstep with the project's minimum-Android-API
+# commitment documented in stable-release-plan.md.
+#
+# Host tag: change `host_tag` to one of `linux-x86_64`, `darwin-x86_64`,
+# or `windows-x86_64` depending on which OS you are running meson on.
+
+[constants]
+ndk      = '/opt/android-ndk-r27c'
+host_tag = 'linux-x86_64'
+api      = '21'
+toolchain = ndk + '/toolchains/llvm/prebuilt/' + host_tag
+target   = 'aarch64-linux-android'
+
+[binaries]
+c          = toolchain + '/bin/' + target + api + '-clang'
+cpp        = toolchain + '/bin/' + target + api + '-clang++'
+ar         = toolchain + '/bin/llvm-ar'
+strip      = toolchain + '/bin/llvm-strip'
+ld         = toolchain + '/bin/ld.lld'
+ranlib     = toolchain + '/bin/llvm-ranlib'
+objcopy    = toolchain + '/bin/llvm-objcopy'
+pkg-config = 'false'
+
+[built-in options]
+# c_std stays project-default (C11); no override needed here.
+default_library = 'shared'
+
+[host_machine]
+system     = 'android'
+cpu_family = 'aarch64'
+cpu        = 'aarch64'
+endian     = 'little'

--- a/cross/android-x86_64.ini
+++ b/cross/android-x86_64.ini
@@ -1,0 +1,46 @@
+# Meson cross-file for Android x86_64 (emulator and rare 64-bit x86
+# devices).
+#
+# Issue #464 -- Android NDK cross-compile plumbing.
+#
+# Usage:
+#
+#   export ANDROID_NDK_ROOT=/path/to/android-ndk-r27c
+#   meson setup build-android-x86_64 \
+#       --cross-file cross/android-x86_64.ini \
+#       -Dandroid=true \
+#       -Dtests=false \
+#       -DmbedTLS=disabled
+#   meson compile -C build-android-x86_64
+#
+# See `cross/android-arm64.ini` for override and NDK-version notes.  The
+# 16 KB page-size link flag added under -Dandroid=true is gated on
+# cpu_family == 'aarch64' in meson.build, so this cross-file produces a
+# standard 4 KB-page .so suitable for the x86_64 emulator (which has no
+# 16 KB page mode).
+
+[constants]
+ndk      = '/opt/android-ndk-r27c'
+host_tag = 'linux-x86_64'
+api      = '21'
+toolchain = ndk + '/toolchains/llvm/prebuilt/' + host_tag
+target   = 'x86_64-linux-android'
+
+[binaries]
+c          = toolchain + '/bin/' + target + api + '-clang'
+cpp        = toolchain + '/bin/' + target + api + '-clang++'
+ar         = toolchain + '/bin/llvm-ar'
+strip      = toolchain + '/bin/llvm-strip'
+ld         = toolchain + '/bin/ld.lld'
+ranlib     = toolchain + '/bin/llvm-ranlib'
+objcopy    = toolchain + '/bin/llvm-objcopy'
+pkg-config = 'false'
+
+[built-in options]
+default_library = 'shared'
+
+[host_machine]
+system     = 'android'
+cpu_family = 'x86_64'
+cpu        = 'x86_64'
+endian     = 'little'

--- a/docs/cross-compile-android.md
+++ b/docs/cross-compile-android.md
@@ -1,0 +1,139 @@
+# Cross-compiling wirelog for Android
+
+Issue #464 lands the meson plumbing and NDK cross-files needed to build
+`libwirelog.so` for Android-on-arm64 and Android-on-x86_64. This document
+is the local-recipe companion. CI matrix coverage is a separate follow-up
+issue.
+
+## Supported ABIs
+
+| ABI | Cross-file | Notes |
+|---|---|---|
+| `arm64-v8a` (aarch64) | `cross/android-arm64.ini` | Primary modern target. 16 KB page support via `-Wl,-z,max-page-size=16384` (Android 14+). |
+| `x86_64` | `cross/android-x86_64.ini` | Emulator and rare 64-bit x86 devices. 4 KB pages. |
+
+`armeabi-v7a` is intentionally not supported. Google Play Store has
+required 64-bit uploads since 2019; armv7 is a separate toolchain
+maintenance burden for near-zero modern delivery reach.
+
+## Toolchain
+
+NDK r27c (LTS) is the pinned version. The cross-files reference its
+default install prefix `/opt/android-ndk-r27c`. To override:
+
+1. **Symlink your NDK install** to the default prefix (simplest):
+   ```sh
+   sudo ln -s "$ANDROID_NDK_ROOT" /opt/android-ndk-r27c
+   ```
+2. **Edit the cross-file locally** and do NOT commit the edit. The `ndk`
+   constant at the top of each cross-file is the single point of
+   override.
+3. **Use a sed-substituted copy** if you prefer not to symlink:
+   ```sh
+   sed "s|/opt/android-ndk-r27c|$ANDROID_NDK_ROOT|" \
+       cross/android-arm64.ini > /tmp/android-arm64.ini
+   meson setup build-android-arm64 \
+       --cross-file /tmp/android-arm64.ini -Dandroid=true
+   ```
+
+Meson cross-files do not natively interpolate shell environment
+variables; the `[constants]` section in each cross-file is the
+substitution surface.
+
+## Host platform
+
+Each cross-file defaults to `host_tag = 'linux-x86_64'`. To build from
+macOS or Windows host machines, change `host_tag` in the cross-file to
+one of `darwin-x86_64` or `windows-x86_64`.
+
+## Recipe
+
+```sh
+# Prerequisites: NDK r27c installed and either symlinked to
+# /opt/android-ndk-r27c OR the cross-file edited / sed-substituted.
+
+# arm64-v8a (modern primary)
+meson setup build-android-arm64 \
+    --cross-file cross/android-arm64.ini \
+    -Dandroid=true \
+    -Dtests=false \
+    -DmbedTLS=disabled
+meson compile -C build-android-arm64
+
+# x86_64 (emulator)
+meson setup build-android-x86_64 \
+    --cross-file cross/android-x86_64.ini \
+    -Dandroid=true \
+    -Dtests=false \
+    -DmbedTLS=disabled
+meson compile -C build-android-x86_64
+```
+
+`-Dtests=false` is recommended because the host-only test harness is not
+designed to run under cross-compilation. CLI-dependent tests in
+`tests/meson.build` are gated on `if not is_android` anyway, but the
+remainder of the suite assumes a host-runnable build.
+
+`-DmbedTLS=disabled` is the default. The Android NDK does not ship
+system mbedTLS; consumers needing cryptography on Android should vendor
+mbedTLS as a meson subproject (out of scope for #464).
+
+## Output
+
+After `meson compile`, the shared library lands at:
+
+| ABI | Path |
+|---|---|
+| arm64-v8a | `build-android-arm64/libwirelog.so` |
+| x86_64 | `build-android-x86_64/libwirelog.so` |
+
+Place the resulting `.so` into your APK's `app/src/main/jniLibs/<abi>/`
+directory or load it via `System.loadLibrary("wirelog")` from a JNI
+wrapper.
+
+## What is NOT built on Android
+
+The `wirelog_cli` executable is intentionally not built on Android.
+There is no useful command-line entry point in the JNI / NDK app model.
+The `meson.build` CLI driver section guards the `executable()` call on
+`if not is_android`.
+
+The four CLI-dependent tests in `tests/meson.build`
+(`baseline_int_edges`, `baseline_sym_family`, `baseline_tab_nodes`,
+`cli_version`) are similarly skipped on Android builds. All other tests
+are excluded by `-Dtests=false`.
+
+## Symbol visibility
+
+The Android build uses the same `gnu_symbol_visibility: 'hidden'` policy
+as Linux and macOS. Every public API on the 9 installed headers carries
+`WIRELOG_API` (`wirelog/wirelog-export.h:25-29`), which resolves to
+`__attribute__((visibility("default")))` on the NDK Clang toolchain.
+Internal `wl_*`, `col_*`, `arr_*` symbols stay hidden from the dynamic
+symbol table; the 53-entry ABI manifest at `abi/libwirelog-1.0.symbols`
+applies unchanged to Android.
+
+## Verification
+
+The local build verifies that:
+
+1. `cross/android-arm64.ini` + `-Dandroid=true` produces a `libwirelog.so`
+   whose ELF header reports `EM_AARCH64` and `PT_LOAD` segments aligned
+   to 0x4000 (16 KB):
+   ```sh
+   readelf -l build-android-arm64/libwirelog.so | grep -E '^\s+LOAD'
+   # Each PT_LOAD row's Align column should read 0x4000.
+   # Non-LOAD entries (PT_PHDR, PT_DYNAMIC, etc.) carry their own
+   # alignment; only PT_LOAD honors -Wl,-z,max-page-size.
+   ```
+2. `cross/android-x86_64.ini` + `-Dandroid=true` produces a `libwirelog.so`
+   whose ELF header reports `EM_X86_64`.
+
+## Cross-references
+
+- Issue #464 (this PR) -- meson plumbing + cross-files
+- Issue #446 (CLOSED) -- Option C I/O adapter umbrella covering Android delivery
+- Issue #458 (CLOSED) -- session_facts.c dispatch rewrite prerequisite
+- `meson_options.txt` -- `android` option entry
+- `meson.build` -- `wirelog_android_link_args` and CLI guard
+- `tests/meson.build` -- `if not is_android` CLI-test cascade

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,26 @@ is_embedded = get_option('embedded')
 is_windows = platform == 'windows'
 is_macos = platform == 'darwin'
 is_linux = platform == 'linux'
+is_android = get_option('android')
+
+# Issue #464: Android packaging needs 16 KB ELF page alignment on aarch64
+# so the same .so loads on both 4 KB and 16 KB kernels (Android 14+ on
+# arm64).  Gated on cpu_family == 'aarch64' because 16 KB pages are an
+# arm64-only kernel feature; the flag is meaningless on armv7 (deprecated)
+# and harmless-but-irrelevant on x86_64 emulator builds.
+#
+# Note: on an aarch64 Linux host (e.g., Ampere / Apple Silicon Linux)
+# invoking `-Dandroid=true` without a cross-file would also add the flag
+# to a *Linux* .so.  Linux honors -Wl,-z,max-page-size as the maximum
+# alignment a load segment may take, so the resulting .so is forward-
+# compatible with hypothetical 16 KB Linux kernels and unchanged on
+# normal 4 KB hosts.  Cross-compilation via cross/android-*.ini is the
+# supported path; native-host -Dandroid=true is meant for option-flow
+# testing, not shipping.
+wirelog_android_link_args = []
+if is_android and host_machine.cpu_family() == 'aarch64'
+  wirelog_android_link_args += ['-Wl,-z,max-page-size=16384']
+endif
 
 #Build options
 ipc_option = get_option('ipc')
@@ -270,6 +290,7 @@ wirelog_lib = library(
   config_h_file,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],
+  link_args: wirelog_android_link_args,
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: true,
   # SOVERSION ('soversion') is decoupled from project_version so the
@@ -291,6 +312,10 @@ wirelog_lib = library(
 )
 
 #Static library(optional)
+# Note: `wirelog_android_link_args` is intentionally NOT threaded here.
+# Static archives carry object code only, not link-time attributes; ELF
+# page alignment is decided when the .a is finally linked into a .so
+# or executable by the downstream consumer.
 wirelog_static_lib = static_library(
   'wirelog_static',
   wirelog_sources,
@@ -342,17 +367,24 @@ endif
 
 #Build wirelog-cli executable (wirelog_cli_src defined in wirelog/meson.build)
 #Include all wirelog sources to ensure proper linking with LTO
-wirelog_cli = executable(
-  'wirelog_cli',
-  wirelog_cli_src,
-  cli_plugin_src,
-  wirelog_sources,
-  config_h_file,
-  include_directories: [wirelog_inc, wirelog_src_inc],
-  c_args: cli_plugin_args,
-  dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep] + cli_plugin_deps,
-  install: true,
-)
+# Issue #464: Android builds do not ship the CLI -- on Android the
+# library is loaded into a host process (e.g., JNI / NDK app) and there
+# is no useful command-line entry point.  Skipping the executable here
+# also cascades to the CLI-dependent baseline tests in tests/meson.build,
+# which are guarded by `if not is_android` next to their wirelog_cli refs.
+if not is_android
+  wirelog_cli = executable(
+    'wirelog_cli',
+    wirelog_cli_src,
+    cli_plugin_src,
+    wirelog_sources,
+    config_h_file,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    c_args: cli_plugin_args,
+    dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep] + cli_plugin_deps,
+    install: true,
+  )
+endif
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Benchmarks

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -52,6 +52,13 @@ option(
 )
 
 option(
+  'android',
+  type: 'boolean',
+  value: false,
+  description: 'Build for Android (NDK cross-compile, Issue #464). When true: excludes wirelog_cli, adds -Wl,-z,max-page-size=16384 on aarch64 for 16 KB page compatibility (Android 14+). Symbol visibility remains hidden -- WIRELOG_API on public headers already covers Android exports. Use with meson --cross-file cross/android-arm64.ini (or android-x86_64.ini).'
+)
+
+option(
   'mbedTLS',
   type: 'combo',
   choices: ['disabled', 'enabled', 'auto'],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3832,60 +3832,65 @@ baseline_diff_script = files('golden_diff_baseline.py')
 baseline_fixture_dir = meson.project_source_root() / 'tests/fixtures/baseline_input'
 baseline_snapshot_dir = meson.project_source_root() / 'tests/baseline_snapshots'
 
-test('baseline_int_edges',
-  baseline_py3,
-  args: [
-    baseline_diff_script[0],
-    wirelog_cli.full_path(),
-    baseline_fixture_dir / 'int_edges.dl',
-    baseline_snapshot_dir / 'int_edges_stdout.txt',
-  ],
-  depends: wirelog_cli,
-  workdir: baseline_fixture_dir,
-  suite: 'baseline',
-)
+# Issue #464: CLI-dependent tests skip on Android (wirelog_cli is not
+# built when -Dandroid=true; see meson.build CLI Driver section).  The
+# guard mirrors the cli executable() guard in the project meson.build.
+if not is_android
+  test('baseline_int_edges',
+    baseline_py3,
+    args: [
+      baseline_diff_script[0],
+      wirelog_cli.full_path(),
+      baseline_fixture_dir / 'int_edges.dl',
+      baseline_snapshot_dir / 'int_edges_stdout.txt',
+    ],
+    depends: wirelog_cli,
+    workdir: baseline_fixture_dir,
+    suite: 'baseline',
+  )
 
-test('baseline_sym_family',
-  baseline_py3,
-  args: [
-    baseline_diff_script[0],
-    wirelog_cli.full_path(),
-    baseline_fixture_dir / 'sym_family.dl',
-    baseline_snapshot_dir / 'sym_family_stdout.txt',
-  ],
-  depends: wirelog_cli,
-  workdir: baseline_fixture_dir,
-  suite: 'baseline',
-)
+  test('baseline_sym_family',
+    baseline_py3,
+    args: [
+      baseline_diff_script[0],
+      wirelog_cli.full_path(),
+      baseline_fixture_dir / 'sym_family.dl',
+      baseline_snapshot_dir / 'sym_family_stdout.txt',
+    ],
+    depends: wirelog_cli,
+    workdir: baseline_fixture_dir,
+    suite: 'baseline',
+  )
 
-test('baseline_tab_nodes',
-  baseline_py3,
-  args: [
-    baseline_diff_script[0],
-    wirelog_cli.full_path(),
-    baseline_fixture_dir / 'tab_nodes.dl',
-    baseline_snapshot_dir / 'tab_nodes_stdout.txt',
-  ],
-  depends: wirelog_cli,
-  workdir: baseline_fixture_dir,
-  suite: 'baseline',
-)
+  test('baseline_tab_nodes',
+    baseline_py3,
+    args: [
+      baseline_diff_script[0],
+      wirelog_cli.full_path(),
+      baseline_fixture_dir / 'tab_nodes.dl',
+      baseline_snapshot_dir / 'tab_nodes_stdout.txt',
+    ],
+    depends: wirelog_cli,
+    workdir: baseline_fixture_dir,
+    suite: 'baseline',
+  )
 
-# ============================================================================
-# CLI Version / Help Surface Test (Issue #801)
-# Reuses baseline_py3 (already resolved above) to invoke the executable.
-# ============================================================================
+  # ============================================================================
+  # CLI Version / Help Surface Test (Issue #801)
+  # Reuses baseline_py3 (already resolved above) to invoke the executable.
+  # ============================================================================
 
-test('cli_version',
-  baseline_py3,
-  args: [
-    files('test_cli_version.py')[0],
-    wirelog_cli.full_path(),
-    meson.project_version(),
-  ],
-  depends: wirelog_cli,
-  suite: 'cli',
-)
+  test('cli_version',
+    baseline_py3,
+    args: [
+      files('test_cli_version.py')[0],
+      wirelog_cli.full_path(),
+      meson.project_version(),
+    ],
+    depends: wirelog_cli,
+    suite: 'cli',
+  )
+endif
 
 # ============================================================================
 # I/O Adapter Registry Tests (#450)


### PR DESCRIPTION
## Summary

Closes #464.

3-commit series adding Android NDK cross-compile support:

- **A (c90cc4b)** — `meson_options.txt` adds boolean `android` (default false). `meson.build` defines `is_android` co-located with `is_windows/is_macos/is_linux`, accumulates `-Wl,-z,max-page-size=16384` into `wirelog_lib`'s `link_args` ONLY on `host_machine.cpu_family() == 'aarch64'`, and guards the `wirelog_cli` executable behind `if not is_android`. `tests/meson.build` cascades the guard to the 4 CLI-dependent baseline tests (`baseline_int_edges`, `baseline_sym_family`, `baseline_tab_nodes`, `cli_version`).
- **B (161b57c)** — `cross/android-arm64.ini` + `cross/android-x86_64.ini` (both pinned to NDK r27c LTS) + `docs/cross-compile-android.md` with the full local-recipe + override + verification.
- **C (808a2bf)** — `[Unreleased] ### Added` CHANGELOG bullet citing #464.

## Deliverable diffs from issue body

The architect + critic agents independently flagged four defects in the original deliverable bullet list. The PR ships the corrected version:

| Issue body | PR ships | Why |
|---|---|---|
| Disable `-fvisibility=hidden` on Android | **KEEP `hidden`** | Disabling would dump every `wl_*`/`col_*`/`arr_*` internal symbol into `libwirelog.so`'s `.dynsym` and break `scripts/ci/check-abi-symbols.sh` against the 53-entry `abi/libwirelog-1.0.symbols` allowlist. `WIRELOG_API` at `wirelog/wirelog-export.h:25-29` already resolves to `__attribute__((visibility("default")))` on NDK Clang. |
| NDK r26d pin | **NDK r27c (LTS)** | r26d is stale as of 2026-05; r27c is current LTS. |
| Three cross-files (arm64-v8a, armeabi-v7a, x86_64) | **Two cross-files (arm64-v8a + x86_64 only)** | Play Store has required 64-bit since 2019; armv7 is a separate toolchain for near-zero modern delivery value. 16 KB page-size flag is also aarch64-only. Re-introduce armv7 only on downstream embedder request. |
| `-Wl,-z,max-page-size=16384` unconditional | **Gated on `cpu_family() == 'aarch64'`** | 16 KB pages are arm64-only kernel feature; flag is meaningless on x86_64 emulator. |
| "Local cross-compile succeeds" as acceptance | **Recipe in `docs/cross-compile-android.md`; CI matrix deferred** | Local-only tests rot. Documented recipe + cross-files validated. CI matrix workflow is a separate follow-up issue (out of scope for #464). |

## Atomic-commit workflow

Each commit passed the multi-agent gate:

1. Architect + Critic analyzed issue body, identified the 5 deliverable defects above.
2. Executor implemented A, B, C.
3. Code reviewer APPROVED with 4 MINOR + 2 NITPICK findings.
4. Executor folded the 3 actionable findings via `git commit --fixup` + autosquash:
   - `is_android` co-located with platform-boolean cluster.
   - Static-lib comment explaining why `link_args` is not threaded.
   - `readelf -l` recipe tightened (`grep -E '^\s+LOAD'`, PT_LOAD note).
   - Inline code comment on the aarch64 Linux host edge case.
5. Architect + Critic re-approved.

## Verification

- `meson setup _verify_default` -> 203 build targets (default).
- `meson setup _verify_android -Dandroid=true` -> 202 targets (wirelog_cli excluded).
- `meson setup _verify_xcompile --cross-file cross/android-arm64.ini -Dandroid=true` -> cross-file parsed cleanly; constants resolved to `/opt/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang`. Fails at toolchain probe (NDK not installed on verification host) -- expected.
- `python scripts/ci/check-changelog-format.py` -> OK.

## Cross-references

- #446 (CLOSED) -- Option C user-defined I/O adapters umbrella
- #458 (CLOSED) -- session_facts.c dispatch rewrite (depends-on)
- Will file follow-up issue post-merge: "CI: Android cross-build matrix workflow" (v0.44 candidate)

## Test plan

- [x] CI `ci-pr`, `lint-pr`, Sanitizers, TSan, Build matrix (Linux GCC/Clang, Windows MSVC, macOS Clang, arm64 GCC).
- [x] CHANGELOG format gate passes.
- [x] No `Phase NX` introduced (phase-label gate).
- [x] No new `Status: Future` block (semantics-future gate).
- [x] No atomic_* call sites changed (threading-doc gate).
- [x] ABI symbols allowlist unchanged.
- [ ] First downstream cross-build with a real NDK r27c install will trigger on next user request; manual recipe in `docs/cross-compile-android.md`.