### PR TITLE
[codex] Add iOS Meson cross build plumbing

### DIFF
--- a/cross/ios-arm64.ini
+++ b/cross/ios-arm64.ini
@@ -1,0 +1,23 @@
+[binaries]
+c = ['xcrun', '--sdk', 'iphoneos', 'clang']
+cpp = ['xcrun', '--sdk', 'iphoneos', 'clang++']
+ar = ['xcrun', '--sdk', 'iphoneos', 'ar']
+strip = ['xcrun', '--sdk', 'iphoneos', 'strip']
+
+[built-in options]
+c_args = ['-target', 'arm64-apple-ios13.0']
+c_link_args = ['-target', 'arm64-apple-ios13.0']
+cpp_args = ['-target', 'arm64-apple-ios13.0']
+cpp_link_args = ['-target', 'arm64-apple-ios13.0']
+
+[properties]
+needs_exe_wrapper = true
+wirelog_ios_platform = 'iphoneos'
+wirelog_ios_arch = 'arm64'
+wirelog_ios_min_version = '13.0'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'arm64'
+endian = 'little'

--- a/cross/ios-simulator-arm64.ini
+++ b/cross/ios-simulator-arm64.ini
@@ -1,0 +1,23 @@
+[binaries]
+c = ['xcrun', '--sdk', 'iphonesimulator', 'clang']
+cpp = ['xcrun', '--sdk', 'iphonesimulator', 'clang++']
+ar = ['xcrun', '--sdk', 'iphonesimulator', 'ar']
+strip = ['xcrun', '--sdk', 'iphonesimulator', 'strip']
+
+[built-in options]
+c_args = ['-target', 'arm64-apple-ios13.0-simulator']
+c_link_args = ['-target', 'arm64-apple-ios13.0-simulator']
+cpp_args = ['-target', 'arm64-apple-ios13.0-simulator']
+cpp_link_args = ['-target', 'arm64-apple-ios13.0-simulator']
+
+[properties]
+needs_exe_wrapper = true
+wirelog_ios_platform = 'iphonesimulator'
+wirelog_ios_arch = 'arm64'
+wirelog_ios_min_version = '13.0'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'arm64'
+endian = 'little'

--- a/cross/ios-simulator-x86_64.ini
+++ b/cross/ios-simulator-x86_64.ini
@@ -1,0 +1,23 @@
+[binaries]
+c = ['xcrun', '--sdk', 'iphonesimulator', 'clang']
+cpp = ['xcrun', '--sdk', 'iphonesimulator', 'clang++']
+ar = ['xcrun', '--sdk', 'iphonesimulator', 'ar']
+strip = ['xcrun', '--sdk', 'iphonesimulator', 'strip']
+
+[built-in options]
+c_args = ['-target', 'x86_64-apple-ios13.0-simulator']
+c_link_args = ['-target', 'x86_64-apple-ios13.0-simulator']
+cpp_args = ['-target', 'x86_64-apple-ios13.0-simulator']
+cpp_link_args = ['-target', 'x86_64-apple-ios13.0-simulator']
+
+[properties]
+needs_exe_wrapper = true
+wirelog_ios_platform = 'iphonesimulator'
+wirelog_ios_arch = 'x86_64'
+wirelog_ios_min_version = '13.0'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'

--- a/meson.build
+++ b/meson.build
@@ -117,6 +117,7 @@ docs_option = get_option('documentation')
 # crc32_variant_option already defined earlier before compiler settings
 
 io_plugin_dlopen_option = get_option('io_plugin_dlopen')
+ios_option = get_option('ios')
 
 message('wirelog ' + project_version)
 message('  Platform: ' + platform)
@@ -125,6 +126,27 @@ message('  IPC support: ' + ipc_option)
 message('  Threading: ' + threads_option)
 message('  CRC-32 variant: ' + crc32_variant_option)
 message('  Plugin loader (dlopen): ' + io_plugin_dlopen_option)
+message('  iOS: @0@'.format(ios_option))
+
+mobile_cross = is_android or ios_option
+wirelog_ios_link_args = []
+
+if ios_option
+  ios_min_version = meson.get_external_property('wirelog_ios_min_version', '13.0')
+  ios_platform = meson.get_external_property('wirelog_ios_platform', 'iphoneos')
+  ios_arch = meson.get_external_property('wirelog_ios_arch',
+    host_machine.cpu_family() == 'x86_64' ? 'x86_64' : 'arm64')
+
+  if ios_platform == 'iphonesimulator'
+    ios_target = ios_arch + '-apple-ios' + ios_min_version + '-simulator'
+  else
+    ios_target = ios_arch + '-apple-ios' + ios_min_version
+  endif
+
+  add_project_arguments(['-target', ios_target], language: 'c')
+  wirelog_ios_link_args += ['-target', ios_target]
+  message('  iOS target: ' + ios_target)
+endif
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Dependencies
@@ -290,7 +312,7 @@ wirelog_lib = library(
   config_h_file,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],
-  link_args: wirelog_android_link_args,
+  link_args: wirelog_android_link_args + wirelog_ios_link_args,
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: true,
   # SOVERSION ('soversion') is decoupled from project_version so the
@@ -308,7 +330,7 @@ wirelog_lib = library(
   # symbols (wl_*, col_*, arr_*) are now hidden from the dynamic-symbol
   # table; consumers who relied on resolving them through libwirelog.so
   # must rebuild against the public surface.  See #733.
-  gnu_symbol_visibility: 'hidden',
+  gnu_symbol_visibility: ios_option ? 'default' : 'hidden',
 )
 
 #Static library(optional)
@@ -322,6 +344,7 @@ wirelog_static_lib = static_library(
   config_h_file,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],
+  link_args: wirelog_ios_link_args,
   dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: false,  # Not installed by default
 )
@@ -335,6 +358,11 @@ install_headers(
 install_headers(
   'wirelog/io/io_adapter.h',
   subdir: 'wirelog/io'
+)
+
+install_data(
+  'wirelog/module.modulemap',
+  install_dir: wirelog_includedir / 'wirelog'
 )
 
 #pkg - config file
@@ -356,7 +384,7 @@ pkg.generate(
 cli_plugin_src = []
 cli_plugin_deps = []
 cli_plugin_args = []
-if io_plugin_dlopen_option == 'enabled' and not is_windows
+if io_plugin_dlopen_option == 'enabled' and not (is_windows or ios_option)
   _dl_dep = cc.find_library('dl', required: false)
   if _dl_dep.found()
     cli_plugin_deps += [_dl_dep]
@@ -367,12 +395,10 @@ endif
 
 #Build wirelog-cli executable (wirelog_cli_src defined in wirelog/meson.build)
 #Include all wirelog sources to ensure proper linking with LTO
-# Issue #464: Android builds do not ship the CLI -- on Android the
-# library is loaded into a host process (e.g., JNI / NDK app) and there
-# is no useful command-line entry point.  Skipping the executable here
-# also cascades to the CLI-dependent baseline tests in tests/meson.build,
-# which are guarded by `if not is_android` next to their wirelog_cli refs.
-if not is_android
+# Mobile builds do not ship the CLI: Android loads the library into a
+# host process, and iOS uses the library/module surface rather than a
+# command-line entry point.
+if not mobile_cross
   wirelog_cli = executable(
     'wirelog_cli',
     wirelog_cli_src,
@@ -390,13 +416,15 @@ endif
 #Benchmarks
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-subdir('bench')
+if not mobile_cross
+  subdir('bench')
+endif
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Tests
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-if tests_option
+if tests_option and not mobile_cross
   subdir('tests')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -59,6 +59,13 @@ option(
 )
 
 option(
+  'ios',
+  type: 'boolean',
+  value: false,
+  description: 'Build for iOS. Disables executable targets and plugin loading, and applies Apple iOS target flags.'
+)
+
+option(
   'mbedTLS',
   type: 'combo',
   choices: ['disabled', 'enabled', 'auto'],

--- a/wirelog/module.modulemap
+++ b/wirelog/module.modulemap
@@ -1,0 +1,6 @@
+module wirelog {
+  umbrella header "wirelog.h"
+  header "io/io_adapter.h"
+  export *
+  link "wirelog"
+}


### PR DESCRIPTION
## Summary

- Add `-Dios=true` Meson plumbing for iOS cross builds.
- Add iOS device and simulator cross-files backed by `xcrun --sdk` tool lookup.
- Install a Clang module map for Swift/Clang module consumers.
- Skip mobile CLI/tests/bench build surfaces for iOS while preserving examples in this PR.
- Split Android/iOS example exclusion into follow-up #832.

Closes #467.

## Validation

- `meson setup builddir-issue467-rebase -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue467-rebase`
- `meson setup builddir-issue467-rebase-ios-arm64 --cross-file cross/ios-arm64.ini -Dios=true -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue467-rebase-ios-arm64`
- `meson setup builddir-issue467-rebase-ios-sim-arm64 --cross-file cross/ios-simulator-arm64.ini -Dios=true -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue467-rebase-ios-sim-arm64`
- `meson setup builddir-issue467-rebase-ios-sim-x86_64 --cross-file cross/ios-simulator-x86_64.ini -Dios=true -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue467-rebase-ios-sim-x86_64`
