### PR TITLE
docs: scope arm64 ABI manifest coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ All notable changes to wirelog are documented in this file.
   message -- abidiff treats ELF architecture as an ABI-breaking
   change (`architecture changed from 'elf-amd-x86_64' to
   'elf-arm-aarch64'`, rc=12), so the committed x86_64 baseline
-  cannot directly diff against an arm64 build.  Per-arch baselines
-  are a v0.41 follow-up; arm64 still exercises the arch-agnostic
-  `abi_symbols` allowlist on every PR.  The gate's other SKIP
-  paths remain for platforms where libabigail is unavailable
+  cannot directly diff against an arm64 build.  Issue #824 explicitly
+  scopes v1.0 Linux arm64 ABI coverage to the arch-agnostic
+  `abi_symbols` allowlist on every PR; per-arch libabigail baselines
+  are out of scope for #681 / v1.0 unless a later policy issue adds
+  an arm64 baseline file and regeneration workflow.  The gate's other
+  SKIP paths remain for platforms where libabigail is unavailable
   (Windows, macOS, cross-builds).  Demonstrated firing on a
   synthetic break: adding a new `WIRELOG_API` function trips the
   gate with `abidiff rc=4` and a clear remediation paragraph
@@ -110,8 +112,9 @@ All notable changes to wirelog are documented in this file.
   `'ubuntu-24.04-arm'`, so the SIMD-capability verification block
   now runs on the arm64 leg as intended.  Required-check
   promotion is a follow-up repo-admin action (branch protection),
-  not part of this PR; the libabigail `.abi.json` half of the
-  cross-arch ABI gate lands under #786 once that issue ships.
+  not part of this PR; per #824, Linux arm64 v1.0 ABI coverage is the
+  arch-agnostic `abi_symbols` gate while libabigail `.abi.json`
+  enforcement remains Linux x86_64-only.
 - **Adopt `WIRELOG_API` on every installed public prototype** (#782):
   76 occurrences of `WIRELOG_PUBLIC` across the 8 prototype headers
   (`wirelog.h`, `wirelog-types.h`, `wirelog-ir.h`, `wirelog-parser.h`,

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -59,6 +59,16 @@ alongside the API change.  The gate SKIPs cleanly when libabigail is
 not installed or when the baseline is absent — first-time seeding only
 requires running the regeneration script once on a Linux/x86_64 host.
 
+The v1.0 libabigail baseline is intentionally Linux/x86_64-only.  On
+Linux arm64, v1.0 ABI coverage is the arch-agnostic
+`abi/libwirelog-1.0.symbols` gate (`meson test --suite
+abi:abi_symbols`); `abi_manifest` skips because libabigail treats the
+ELF architecture difference between the x86_64 baseline and an arm64
+build as an ABI break.  Per issue #824, arm64 per-architecture
+libabigail baselines are out of scope for #681 / v1.0 unless a later
+policy issue adds an arm64 baseline file and matching regeneration
+workflow.
+
 ### Template (Markdown)
 
 ```md
@@ -122,8 +132,8 @@ release-pinned benchmark snapshot.
   checksums committed alongside).
 - **SBOM**: `wirelog-X.Y.Z.spdx.json` (SPDX 2.3) +
   `wirelog-X.Y.Z.cdx.json` (CycloneDX 1.5).
-- **ABI manifest**: `abi/libwirelog-1.0.symbols` +
-  `abi/libwirelog-1.0.abi.json` (libabigail).
+- **ABI manifest**: `abi/libwirelog-1.0.symbols` on Linux x86_64 and
+  arm64; `abi/libwirelog-1.0.abi.json` (libabigail) on Linux x86_64.
 
 ## Acknowledgments
 

--- a/scripts/ci/check-abi-manifest.sh
+++ b/scripts/ci/check-abi-manifest.sh
@@ -39,6 +39,10 @@
 #   - `abidiff` not on PATH (libabigail not installed).
 #   - Baseline `abi/libwirelog-1.0.abi.json` absent (first-time setup;
 #     run `scripts/release/regenerate-abi-manifest.sh` to seed).
+#   - Host architecture is not x86_64.  The v1.0 libabigail baseline is
+#     intentionally x86_64-only; Linux arm64 ABI coverage is symbol-only
+#     unless and until a per-architecture baseline policy is added after
+#     v1.0 (issue #824).
 
 set -euo pipefail
 
@@ -85,15 +89,17 @@ fi
 # The committed baseline is generated on Linux x86_64.  abidiff treats
 # ELF architecture as an ABI-breaking change (rc=12 "ELF architecture
 # changed"), so on a non-x86_64 host the gate would always fail despite
-# the source-level public API being identical.  Per-arch baselines are
-# tracked as future work (see #799 / v0.41 soak).  For now SKIP cleanly
-# on non-x86_64 hosts -- arm64 still exercises the arch-agnostic
-# `abi_symbols` allowlist gate.
+# the source-level public API being identical.  Issue #824 explicitly
+# scopes v1.0 Linux arm64 ABI coverage to the arch-agnostic
+# `abi_symbols` allowlist; richer per-arch libabigail baselines are a
+# post-v1.0 policy decision, not a v0.41 / #681 closure requirement.
 host_arch=$(uname -m)
 if [ "$host_arch" != "x86_64" ]; then
     echo "check-abi-manifest: SKIP: host arch '$host_arch' is not x86_64" >&2
-    echo "  baseline at $baseline is x86_64-only; per-arch baselines" >&2
-    echo "  pending (#799 soak / v0.41 follow-up)." >&2
+    echo "  baseline at $baseline is x86_64-only." >&2
+    echo "  issue #824 scopes v1.0 Linux arm64 ABI coverage to" >&2
+    echo "  abi/libwirelog-1.0.symbols; per-arch libabigail baselines" >&2
+    echo "  require a separate post-v1.0 policy and regeneration flow." >&2
     exit 0
 fi
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -514,7 +514,9 @@ endif
 # and visibility/linkage drift that nm -D cannot see.  Linux/ELF-focused;
 # SKIPs cleanly when libwirelog.so is missing (Windows, static-only),
 # when abidiff is not on PATH, or when the baseline has not been seeded
-# yet (run scripts/release/regenerate-abi-manifest.sh to seed).
+# yet (run scripts/release/regenerate-abi-manifest.sh to seed).  Per
+# issue #824, the committed v1.0 libabigail baseline is x86_64-only;
+# Linux arm64 v1.0 ABI coverage is symbol-only via abi_symbols.
 if sh.found()
   test('abi_manifest', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-manifest.sh',


### PR DESCRIPTION
## Summary
- replace the stale `#799` arm64 libabigail skip reference with the #824 policy decision
- document that v1.0 Linux arm64 ABI coverage is symbol-only via `abi_symbols`, while libabigail `.abi.json` enforcement remains Linux x86_64-only
- update release-process, changelog, and Meson test comments so #681 closure does not imply an arm64 libabigail baseline exists

## Verification
- `meson test -C builddir abi_manifest release_template changelog_format --print-errorlogs`
- `meson test -C builddir --suite abi --print-errorlogs`
- fake-`uname` `aarch64` run of `scripts/ci/check-abi-manifest.sh builddir` prints the #824 skip rationale and exits 0
- `git diff --check`

Closes #824
Refs #681
