### PR TITLE
[codex] Exclude examples from mobile cross builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -432,12 +432,14 @@ endif
 #Examples
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-subdir('examples/08-delta-queries')
-subdir('examples/09-retraction-basics')
-subdir('examples/10-recursive-under-update')
-subdir('examples/11-time-evolution')
-subdir('examples/12-snapshot-vs-delta')
-subdir('examples/13-daemon-style')
+if not mobile_cross
+  subdir('examples/08-delta-queries')
+  subdir('examples/09-retraction-basics')
+  subdir('examples/10-recursive-under-update')
+  subdir('examples/11-time-evolution')
+  subdir('examples/12-snapshot-vs-delta')
+  subdir('examples/13-daemon-style')
+endif
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Documentation


### PR DESCRIPTION
Closes #832

## Summary
- Wrap example subdirectories in the existing `mobile_cross` gate.
- Keep native builds including and compiling the example programs.
- Keep this change scoped to the mobile example exclusion after #831 was merged.

## Validation
- `git diff --check -- meson.build`
- `meson setup builddir-issue832-native -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue832-native`
- `meson introspect builddir-issue832-native --targets | jq -r '.[].defined_in' | rg 'examples/'`\n- `meson setup builddir-issue832-ios --cross-file cross/ios-arm64.ini -Dios=true -Dtests=false -DmbedTLS=disabled`\n- `meson compile -C builddir-issue832-ios`\n- `meson introspect builddir-issue832-ios --targets | jq -r '.[].defined_in' | rg 'examples/' || true`\n- `meson setup builddir-issue832-android -Dandroid=true -Dtests=false -DmbedTLS=disabled`\n- `meson introspect builddir-issue832-android --targets | jq -r '.[].defined_in' | rg 'examples/' || true`\n\nNote: full Android NDK cross configure was not run locally because `/opt/android-ndk-r27c` is not installed on this machine. The Android option-flow configure path was validated and omits examples.