### PR TITLE
[codex] Add iOS CI smoke gate

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,53 @@
+name: iOS CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ios-arm64:
+    name: iOS arm64 smoke / Xcode 16.4
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s "$DEVELOPER_DIR"
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-path
+
+      - name: Install dependencies
+        run: brew install meson ninja
+
+      - name: Configure iOS arm64
+        run: >
+          meson setup builddir-ios
+          --cross-file cross/ios-arm64.ini
+          -Dios=true
+          -Dtests=false
+          -DmbedTLS=disabled
+
+      - name: Build iOS arm64
+        run: meson compile -C builddir-ios
+
+      - name: Check static archive symbols
+        run: scripts/ci/check-ios-symbols.sh builddir-ios
+
+      - name: Swift modulemap smoke typecheck
+        run: >
+          xcrun --sdk iphoneos swiftc
+          -target arm64-apple-ios13.0
+          -typecheck
+          -I "$PWD"
+          -I "$PWD/builddir-ios"
+          -Xcc -Wno-incomplete-umbrella
+          tests/ios/swift_smoke.swift

--- a/scripts/ci/check-ios-symbols.sh
+++ b/scripts/ci/check-ios-symbols.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Issue #468: verify iOS static archives retain adapter registration symbols.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <build_root> [archive]" >&2
+    exit 2
+fi
+
+build_root="$1"
+archive="${2:-}"
+
+if [ -z "$archive" ]; then
+    for candidate in \
+        "$build_root/libwirelog.a" \
+        "$build_root/libwirelog_static.a"; do
+        if [ -f "$candidate" ]; then
+            archive="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ -z "$archive" ] || [ ! -f "$archive" ]; then
+    echo "check-ios-symbols: FAIL: static archive not found under $build_root" >&2
+    echo "  expected libwirelog.a or libwirelog_static.a after meson compile" >&2
+    exit 1
+fi
+
+symbols="$(nm -gU "$archive" 2>/dev/null || nm -g "$archive")"
+
+for symbol in \
+    wirelog_io_register_adapter \
+    wirelog_io_unregister_adapter \
+    wirelog_io_find_adapter; do
+    if ! printf '%s\n' "$symbols" | awk -v sym="$symbol" \
+        '$NF == sym || $NF == "_" sym {found = 1} END {exit !found}'; then
+        echo "check-ios-symbols: FAIL: missing symbol $symbol in $archive" >&2
+        exit 1
+    fi
+done
+
+echo "check-ios-symbols: OK: adapter symbols retained in $archive"

--- a/tests/ios/swift_smoke.swift
+++ b/tests/ios/swift_smoke.swift
@@ -1,0 +1,36 @@
+import wirelog
+
+private let smokeReadCallback: @convention(c) (
+    OpaquePointer?,
+    UnsafeMutablePointer<UnsafeMutablePointer<Int64>?>?,
+    UnsafeMutablePointer<UInt32>?,
+    UnsafeMutableRawPointer?
+) -> Int32 = { ctx, outData, outRows, userData in
+    _ = ctx
+    _ = outData
+    _ = userData
+    outRows?.pointee = 0
+    return 0
+}
+
+private let smokeScheme = "swift-smoke"
+private let smokeDescription = "Swift modulemap smoke adapter"
+
+private func exerciseImportedAPI() {
+    smokeScheme.withCString { scheme in
+        smokeDescription.withCString { description in
+            var adapter = wirelog_io_adapter_t(
+                abi_version: WIRELOG_IO_ABI_VERSION,
+                scheme: scheme,
+                description: description,
+                read: smokeReadCallback,
+                validate: nil,
+                user_data: nil
+            )
+
+            _ = wirelog_io_register_adapter(&adapter)
+            _ = wirelog_io_find_adapter(scheme)
+            _ = wirelog_io_unregister_adapter(scheme)
+        }
+    }
+}


### PR DESCRIPTION
Closes #468

## Summary
- Add a pinned `macos-15` / Xcode 16.4 iOS arm64 CI workflow.
- Cross-build `cross/ios-arm64.ini` with `-Dios=true` and check the static archive for retained I/O adapter symbols.
- Add a Swift smoke file that imports the modulemap, constructs `wirelog_io_adapter_t`, and uses an `@convention(c)` read callback with trailing `user_data`.

## Validation
- `meson setup builddir-issue468-ios --cross-file cross/ios-arm64.ini -Dios=true -Dtests=false -DmbedTLS=disabled`
- `meson compile -C builddir-issue468-ios`
- `scripts/ci/check-ios-symbols.sh builddir-issue468-ios`
- `xcrun --sdk iphoneos swiftc -target arm64-apple-ios13.0 -typecheck -I "$PWD" -I "$PWD/builddir-issue468-ios" -Xcc -Wno-incomplete-umbrella tests/ios/swift_smoke.swift`
- `git diff --check -- .github/workflows/ios.yml scripts/ci/check-ios-symbols.sh tests/ios/swift_smoke.swift`

Note: the issue text requested `swiftc -parse`, but local verification showed `-parse` does not fail on a missing import. This PR uses `-typecheck` so modulemap/header regressions are actually caught.