### PR TITLE
Prepare wirelog 0.41.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.41.0] - 2026-05-20
+
+### Added
+
 - **Android CI smoke + 16 KB alignment hard gate** (#465):
   new `.github/workflows/android.yml` with three jobs.  `alignment-arm64`
   cross-compiles `libwirelog.so` via `cross/android-arm64.ini` and runs
@@ -98,9 +116,9 @@ All notable changes to wirelog are documented in this file.
   test or carries a `/* PARITY: ... */` block-comment on its
   declaration line naming the structural reason no advanced
   analogue exists (12 facade-only annotations covering opts
-  struct, `*_sym` variadics, `wirelog_easy_print_delta`, plus 2
-  deferred-annotations for the #665 partial-conjunction tests
-  whose easy-side test helper is not yet ported to advanced).
+  struct, `*_sym` variadics, and `wirelog_easy_print_delta`;
+  the #665 partial-conjunction regression tests are now paired on
+  the advanced side via #825).
   New gate `scripts/ci/check-test-parity.py` (registered as
   `meson test --suite abi:test_parity`) enforces the rule
   per-test, not as a numeric ratio, so future additions on
@@ -191,6 +209,13 @@ All notable changes to wirelog are documented in this file.
 ### Removed
 
 ### Fixed
+
+- **Advanced-side #665 partial-conjunction parity** (#825):
+  `tests/test_wirelog_advanced.c` now mirrors the two easy-facade
+  #665 partial-conjunction regression tests under both default and
+  multi-worker execution.  The easy-side parity annotations now point
+  at the live paired advanced tests instead of a closed #785 follow-up,
+  and `scripts/ci/check-test-parity.py` continues to pass.
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,12 @@ All notable changes to wirelog are documented in this file.
   multi-worker execution.  The easy-side parity annotations now point
   at the live paired advanced tests instead of a closed #785 follow-up,
   and `scripts/ci/check-test-parity.py` continues to pass.
+- **Platform ABI advisory test registration** (#788, #681):
+  the macOS advisory export check is registered only on Darwin hosts
+  and the Windows advisory export check only on Windows hosts.  This
+  keeps Linux arm64 runners that happen to have `pwsh` installed from
+  spending the Meson test timeout launching a Windows-only PowerShell
+  check that should never run on that platform.
 
 ### Performance
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,9 +1,37 @@
 # Migration Guide
 
-**Last Updated:** 2026-04-24
+**Last Updated:** 2026-05-20
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
+
+---
+
+## 0.40 -> 0.41
+
+0.41.0 is an ABI-infrastructure release.  It adds release gates,
+manifests, and cross-platform advisory checks around the public
+surface, but it does not introduce new source-level migration steps
+for applications already updated to the 0.40 public API.
+
+### ABI and release-process checks (#681)
+
+The release pins the v1.0 ABI baseline more tightly:
+
+- Linux x86_64 has both the existing 53-symbol allowlist gate and a
+  libabigail `.abi.json` manifest gate.
+- Linux arm64 participates in the default PR build and the
+  arch-agnostic `abi_symbols` gate; per #824, per-architecture
+  libabigail baselines are out of scope for this release.
+- macOS and Windows export-surface checks are warning-only advisory
+  checks, not hard ABI guarantees.
+- Installed public prototypes use `WIRELOG_API`; `WIRELOG_PUBLIC`
+  remains a compatibility alias for downstream code that referenced
+  it directly during the 0.40 cycle.
+
+No downstream code changes are required solely because of these
+checks.  Consumers that still use pre-0.40 names should follow the
+0.30 -> 1.0 migration entries below.
 
 ---
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.40.99',
+  version: '0.41.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -518,7 +518,7 @@ endif
 # Linux remains the hard v1.0 ABI gate.  These checks run on every
 # default `meson test` invocation but only emit GitHub warning
 # annotations when macOS/Windows export surfaces drift.
-if sh.found()
+if host_machine.system() == 'darwin' and sh.found()
   test('abi_symbols_macos', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols-macos.sh',
               meson.project_build_root()],
@@ -526,7 +526,7 @@ if sh.found()
 endif
 
 powershell = find_program('pwsh', 'powershell', required: false)
-if powershell.found()
+if host_machine.system() == 'windows' and powershell.found()
   test('abi_symbols_windows', powershell,
        args: ['-NoProfile',
               '-ExecutionPolicy', 'Bypass',


### PR DESCRIPTION
## Summary
- bump project version to 0.41.0
- cut CHANGELOG.md from [Unreleased] to [0.41.0] - 2026-05-20 and restore empty Unreleased headings
- add 0.40 -> 0.41 migration notes for the ABI infrastructure release
- correct the #785 changelog text now that #825 advanced-side partial-conjunction parity is closed

## Validation
- uv venv
- source .venv/bin/activate && python scripts/ci/check-changelog-format.py
- meson setup builddir-release-041 -Dtests=true -DmbedTLS=disabled
- source .venv/bin/activate && python scripts/ci/check-version-sync.py builddir-release-041/wirelog
- git diff --check
- meson compile -C builddir-release-041
- meson test -C builddir-release-041 --suite abi --print-errorlogs
- meson test -C builddir-release-041 --suite abi_advisory --print-errorlogs

## Pre-tag notes
- #681 is closed with the release-readiness rationale.
- Latest main CI for 003f8f6 was still in progress when this PR was opened; this release PR must wait for its own full CI matrix before tagging.
- macOS/Windows ABI checks remain warning-only advisory coverage, not hard cross-platform ABI guarantees.
- release-tag.yml is not present yet, so tag artefacts/checksums/SBOM/provenance need an explicit manual or follow-up plan before publishing if required for 0.41.0.