### PR TITLE
Fix #841: restore public ABI facade symbols

### DIFF
--- a/abi/libwirelog-1.0.abi.json
+++ b/abi/libwirelog-1.0.abi.json
@@ -1,8 +1,11 @@
-<abi-corpus version='2.4' path='/home/joykim/data/semantic-reasoning/wirelog/build/libwirelog.so' architecture='elf-amd-x86_64' soname='libwirelog.so.1'>
+<abi-corpus version='2.4' path='/home/joykim/git/semantic-reasoning/wirelog/builddir/libwirelog.so' architecture='elf-amd-x86_64' soname='libwirelog.so.1'>
   <elf-function-symbols>
     <elf-symbol name='wirelog_agg_fn_str' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_arith_op_str' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_cmp_op_str' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_config_embedded' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_config_ipc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_config_threads' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_easy_banner' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_easy_close' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_easy_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -17,6 +20,10 @@
     <elf-symbol name='wirelog_easy_set_delta_cb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_easy_snapshot' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_easy_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_error_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_evaluate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_executor_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_executor_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_io_ctx_col_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_io_ctx_intern_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_io_ctx_num_cols' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -34,6 +41,17 @@
     <elf-symbol name='wirelog_ir_node_get_type' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_ir_node_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_ir_node_to_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_load_all_facts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_load_facts_from_csv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_load_input_files' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimize' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimize_apply_pass' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimize_with_config' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimizer_cost_estimate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimizer_debug' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimizer_debug_print' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimizer_get_default_config' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_optimizer_get_stats' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_parse' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_parse_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_parse_with_error_info' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -45,6 +63,10 @@
     <elf-symbol name='wirelog_program_get_stratum' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_stratum_count' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_is_stratified' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_result_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_result_get_relation' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_result_relation_cardinality' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_result_write_csv' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_session_create' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_session_destroy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_session_insert' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -53,6 +75,7 @@
     <elf-symbol name='wirelog_session_set_delta_cb' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_session_snapshot' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_session_step' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_version_string' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <undefined-elf-function-symbols>
     <elf-symbol name='ArrowSchemaInit' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -83,6 +106,7 @@
     <elf-symbol name='fgets' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='fopen64' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='fprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
+    <elf-symbol name='fputc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='fputs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='fwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
@@ -97,7 +121,6 @@
     <elf-symbol name='mtx_unlock' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='printf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='puts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
-    <elf-symbol name='qsort_r' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='realloc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='snprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>
     <elf-symbol name='sqrt' version='GLIBC_2.2.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='no'/>

--- a/abi/libwirelog-1.0.symbols
+++ b/abi/libwirelog-1.0.symbols
@@ -1,6 +1,9 @@
 wirelog_agg_fn_str
 wirelog_arith_op_str
 wirelog_cmp_op_str
+wirelog_config_embedded
+wirelog_config_ipc
+wirelog_config_threads
 wirelog_easy_banner
 wirelog_easy_close
 wirelog_easy_insert
@@ -15,6 +18,10 @@ wirelog_easy_remove_sym
 wirelog_easy_set_delta_cb
 wirelog_easy_snapshot
 wirelog_easy_step
+wirelog_error_string
+wirelog_evaluate
+wirelog_executor_create
+wirelog_executor_free
 wirelog_io_ctx_col_type
 wirelog_io_ctx_intern_string
 wirelog_io_ctx_num_cols
@@ -32,6 +39,17 @@ wirelog_ir_node_get_relation_name
 wirelog_ir_node_get_type
 wirelog_ir_node_print
 wirelog_ir_node_to_string
+wirelog_load_all_facts
+wirelog_load_facts_from_csv
+wirelog_load_input_files
+wirelog_optimize
+wirelog_optimize_apply_pass
+wirelog_optimize_with_config
+wirelog_optimizer_cost_estimate
+wirelog_optimizer_debug
+wirelog_optimizer_debug_print
+wirelog_optimizer_get_default_config
+wirelog_optimizer_get_stats
 wirelog_parse
 wirelog_parse_string
 wirelog_parse_with_error_info
@@ -43,6 +61,10 @@ wirelog_program_get_schema
 wirelog_program_get_stratum
 wirelog_program_get_stratum_count
 wirelog_program_is_stratified
+wirelog_result_free
+wirelog_result_get_relation
+wirelog_result_relation_cardinality
+wirelog_result_write_csv
 wirelog_session_create
 wirelog_session_destroy
 wirelog_session_insert
@@ -51,3 +73,4 @@ wirelog_session_remove
 wirelog_session_set_delta_cb
 wirelog_session_snapshot
 wirelog_session_step
+wirelog_version_string

--- a/meson.build
+++ b/meson.build
@@ -287,6 +287,7 @@ wirelog_sources += wirelog_io_src
 wirelog_sources += wirelog_string_ops_src
 wirelog_sources += wirelog_wl_easy_src
 wirelog_sources += wirelog_advanced_src
+wirelog_sources += wirelog_api_facade_src
 wirelog_sources += wirelog_util_log_src
 
 #Public headers

--- a/scripts/ci/check-public-api-exports.py
+++ b/scripts/ci/check-public-api-exports.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Ensure installed WIRELOG_API function declarations are exported.
+
+The ABI symbol allowlist must not drift behind the installed public
+headers.  This static lint compares every WIRELOG_API function prototype
+on public headers with abi/libwirelog-1.0.symbols.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+WIRELOG_API_PROTO_RE = re.compile(r"\bWIRELOG_API\b\s+([^;]*?)\s*;", re.DOTALL)
+FUNCTION_NAME_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def parse_meson_public_headers() -> set[str]:
+    text = (REPO_ROOT / "meson.build").read_text(encoding="utf-8")
+    list_match = re.search(
+        r"wirelog_public_headers\s*=\s*\[(.*?)\]", text, re.DOTALL
+    )
+    if not list_match:
+        print(
+            "check-public-api-exports: meson.build wirelog_public_headers "
+            "list not found",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    headers = set(re.findall(r"'(wirelog/[^']+\.h)'", list_match.group(1)))
+    headers |= set(
+        re.findall(
+            r"install_headers\(\s*'(wirelog/[^']+\.h)'", text, re.DOTALL
+        )
+    )
+    if len(headers) < 5:
+        print(
+            "check-public-api-exports: parsed too few public headers from "
+            "meson.build",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return headers
+
+
+def strip_comments(src: str) -> str:
+    stripped = BLOCK_COMMENT_RE.sub(" ", src)
+    return "\n".join(line.split("//", 1)[0] for line in stripped.splitlines())
+
+
+def public_api_functions(header: pathlib.Path) -> list[str]:
+    src = strip_comments(header.read_text(encoding="utf-8"))
+    names: list[str] = []
+    for match in WIRELOG_API_PROTO_RE.finditer(src):
+        prototype = " ".join(match.group(1).split())
+        if "(" not in prototype:
+            continue
+        candidates = FUNCTION_NAME_RE.findall(prototype)
+        if candidates:
+            names.append(candidates[-1])
+    return names
+
+
+def main() -> int:
+    expected: dict[str, str] = {}
+    for rel in sorted(parse_meson_public_headers()):
+        path = REPO_ROOT / rel
+        if not path.exists():
+            print(f"check-public-api-exports: missing header {rel}", file=sys.stderr)
+            return 1
+        for name in public_api_functions(path):
+            expected[name] = rel
+
+    symbols_path = REPO_ROOT / "abi/libwirelog-1.0.symbols"
+    exported = set(
+        line.strip()
+        for line in symbols_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    )
+
+    missing = sorted(name for name in expected if name not in exported)
+    if not missing:
+        print(
+            "check-public-api-exports: OK; "
+            f"{len(expected)} WIRELOG_API function(s) covered by ABI symbols"
+        )
+        return 0
+
+    print(
+        "check-public-api-exports: FAIL; public WIRELOG_API declarations "
+        "missing from abi/libwirelog-1.0.symbols:",
+        file=sys.stderr,
+    )
+    for name in missing:
+        print(f"  {expected[name]}: {name}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -421,6 +421,12 @@ test('public_api_macro', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-public-api-macro.py'],
      suite: 'abi')
 
+# Issue #841: every installed public WIRELOG_API function declaration
+# must be present in the ABI dynamic-symbol allowlist.
+test('public_api_exports', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-public-api-exports.py'],
+     suite: 'abi')
+
 # Issue #785: cross-facade test parity.  Every test_* function in
 # tests/test_wirelog_easy.c must either pair with a same-named
 # function in tests/test_wirelog_advanced.c or carry a
@@ -3845,6 +3851,17 @@ test_wirelog_advanced_exe = executable(
 )
 
 test('wirelog_advanced', test_wirelog_advanced_exe)
+
+# Issue #841: umbrella public API symbols are real linkable/runtime
+# entry points, not only header declarations.
+test_wirelog_public_api_exe = executable(
+  'test_wirelog_public_api',
+  files('test_wirelog_public_api.c'),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  link_with: wirelog_lib,
+)
+
+test('wirelog_public_api', test_wirelog_public_api_exe)
 
 # ============================================================================
 # Baseline .input Fixture Snapshot Tests (Issue #448)

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -1,0 +1,143 @@
+/*
+ * test_wirelog_public_api.c - public umbrella API regression tests (#841).
+ *
+ * Copyright (C) CleverPlant
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static int
+test_utility_api(void)
+{
+    if (!wirelog_version_string() || wirelog_version_string()[0] == '\0') {
+        fprintf(stderr, "version string is empty\n");
+        return 1;
+    }
+    if (!wirelog_error_string(WIRELOG_OK)
+        || !wirelog_error_string(WIRELOG_ERR_EXEC)) {
+        fprintf(stderr, "error strings are missing\n");
+        return 1;
+    }
+    if (!wirelog_config_threads()) {
+        fprintf(stderr, "threads config should be enabled in this build\n");
+        return 1;
+    }
+    (void)wirelog_config_embedded();
+    (void)wirelog_config_ipc();
+    return 0;
+}
+
+static int
+test_optimizer_api(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "edge(1,2).\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "parse failed err=%d\n", err);
+        return 1;
+    }
+
+    wirelog_opt_config_t config = wirelog_optimizer_get_default_config();
+    if (!config.enable_logic_fusion || !config.enable_join_ordering
+        || !config.enable_semijoin) {
+        fprintf(stderr, "default optimizer config is incomplete\n");
+        wirelog_program_free(program);
+        return 1;
+    }
+    if (!wirelog_optimize(program, &err) || err != WIRELOG_OK) {
+        fprintf(stderr, "optimize failed err=%d\n", err);
+        wirelog_program_free(program);
+        return 1;
+    }
+    wirelog_opt_stats_t stats = { 0 };
+    if (!wirelog_optimizer_get_stats(program, &stats)
+        || stats.optimized_node_count == 0 || stats.passes_applied == 0) {
+        fprintf(stderr, "optimizer stats were not recorded\n");
+        wirelog_program_free(program);
+        return 1;
+    }
+    if (wirelog_optimizer_cost_estimate(program) == 0) {
+        fprintf(stderr, "cost estimate should be non-zero\n");
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_program_free(program);
+    return 0;
+}
+
+static int
+test_executor_result_api(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "edge(1,2).\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "parse failed err=%d\n", err);
+        return 1;
+    }
+
+    wirelog_executor_t *executor = wirelog_executor_create(program, &err);
+    if (!executor || err != WIRELOG_OK) {
+        fprintf(stderr, "executor create failed err=%d\n", err);
+        wirelog_program_free(program);
+        return 1;
+    }
+    if (wirelog_load_all_facts(program, program) != -1
+        || wirelog_load_input_files(program, program) != -1) {
+        fprintf(stderr, "legacy loaders accepted a non-executor worker\n");
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_result_t *result = wirelog_evaluate(executor, &err);
+    if (!result || err != WIRELOG_OK) {
+        fprintf(stderr, "evaluate failed err=%d\n", err);
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    uint64_t rows = wirelog_result_relation_cardinality(result, "path");
+    const int64_t *path
+        = (const int64_t *)wirelog_result_get_relation(result, "path");
+    if (rows != 1 || !path || path[0] != 1 || path[1] != 2) {
+        fprintf(stderr, "unexpected path result rows=%" PRIu64 "\n", rows);
+        wirelog_result_free(result);
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_result_free(result);
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    return 0;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+    failures += test_utility_api();
+    failures += test_optimizer_api();
+    failures += test_executor_result_api();
+    if (failures == 0)
+        printf("test_wirelog_public_api: OK\n");
+    return failures == 0 ? 0 : 1;
+}

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -1,0 +1,679 @@
+/*
+ * api_facade.c - legacy umbrella public API facade.
+ *
+ * Copyright (C) CleverPlant
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "wirelog/wirelog.h"
+
+#include "backend.h"
+#include "exec_plan_gen.h"
+#include "io/csv_reader.h"
+#include "ir/program.h"
+#include "ir/stratify.h"
+#include "passes/fusion.h"
+#include "passes/jpp.h"
+#include "passes/magic_sets.h"
+#include "passes/sip.h"
+#include "passes/subsumption.h"
+#include "session.h"
+#include "session_facts.h"
+#include "wirelog-config.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define WIRELOG_EXECUTOR_MAGIC UINT64_C(0x574c455845433831)
+
+struct wirelog_executor {
+    uint64_t magic;
+    wirelog_program_t *program;
+    wl_plan_t *plan;
+    wl_session_t *session;
+};
+
+typedef struct {
+    char *name;
+    int64_t *data;
+    uint64_t rows;
+    uint32_t cols;
+    uint64_t capacity_rows;
+} wl_result_relation_t;
+
+struct wirelog_result {
+    wl_result_relation_t *relations;
+    uint32_t count;
+    uint32_t capacity;
+};
+
+static void
+set_error(wirelog_error_t *error, wirelog_error_t value)
+{
+    if (error)
+        *error = value;
+}
+
+static char *
+wl_strdup(const char *s)
+{
+    if (!s)
+        return NULL;
+    size_t len = strlen(s) + 1;
+    char *copy = (char *)malloc(len);
+    if (copy)
+        memcpy(copy, s, len);
+    return copy;
+}
+
+static const wl_ir_relation_info_t *
+find_relation(const wirelog_program_t *program, const char *name)
+{
+    if (!program || !name)
+        return NULL;
+    for (uint32_t i = 0; i < program->relation_count; i++) {
+        const wl_ir_relation_info_t *rel = &program->relations[i];
+        if (rel->name && strcmp(rel->name, name) == 0)
+            return rel;
+    }
+    return NULL;
+}
+
+static wirelog_executor_t *
+checked_executor(void *worker)
+{
+    wirelog_executor_t *executor = (wirelog_executor_t *)worker;
+    if (!executor || executor->magic != WIRELOG_EXECUTOR_MAGIC)
+        return NULL;
+    return executor;
+}
+
+static uint32_t
+count_ir_nodes(const wirelog_program_t *program)
+{
+    if (!program || !program->relation_irs)
+        return 0;
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < program->relation_count; i++)
+        total += wl_fusion_count_nodes(program->relation_irs[i]);
+    return total;
+}
+
+static bool
+run_optimizer_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
+    wirelog_error_t *error, uint32_t *passes_applied,
+    wirelog_opt_stats_t *stats)
+{
+    int rc = 0;
+
+    switch (pass) {
+    case WIRELOG_OPT_LOGIC_FUSION: {
+        wl_fusion_stats_t fusion = { 0 };
+        rc = wl_fusion_apply(program, &fusion);
+        if (stats)
+            stats->fusion_count += fusion.fusions_applied;
+        break;
+    }
+    case WIRELOG_OPT_JOIN_PROJECT_PLAN: {
+        wl_jpp_stats_t jpp = { 0 };
+        rc = wl_jpp_apply(program, &jpp);
+        if (stats)
+            stats->join_reorders += jpp.joins_reordered;
+        break;
+    }
+    case WIRELOG_OPT_SEMIJOIN:
+        rc = wl_sip_apply(program, NULL);
+        break;
+    case WIRELOG_OPT_SUBPLAN_SHARING:
+    case WIRELOG_OPT_BOOLEAN_SPEC:
+        rc = 0;
+        break;
+    default:
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+
+    if (rc != 0) {
+        set_error(error,
+            rc == -1 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+
+    if (passes_applied)
+        (*passes_applied)++;
+    return true;
+}
+
+static bool
+rebuild_after_magic_sets(wirelog_program_t *program, wirelog_error_t *error)
+{
+    if (!program || !program->magic_sets_applied)
+        return true;
+    if (wl_ir_program_rebuild_relation_irs(program) != 0) {
+        set_error(error, WIRELOG_ERR_MEMORY);
+        return false;
+    }
+    wl_ir_program_free_strata(program);
+    int rc = wl_ir_stratify_program(program);
+    if (rc != 0) {
+        set_error(error, rc == -1 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_PARSE);
+        return false;
+    }
+    return true;
+}
+
+static void
+free_result_relation(wl_result_relation_t *rel)
+{
+    if (!rel)
+        return;
+    free(rel->name);
+    free(rel->data);
+}
+
+static wl_result_relation_t *
+find_result_relation(const wirelog_result_t *result, const char *relation_name)
+{
+    if (!result || !relation_name)
+        return NULL;
+    for (uint32_t i = 0; i < result->count; i++) {
+        wl_result_relation_t *rel = &result->relations[i];
+        if (rel->name && strcmp(rel->name, relation_name) == 0)
+            return rel;
+    }
+    return NULL;
+}
+
+static wl_result_relation_t *
+ensure_result_relation(wirelog_result_t *result, const char *relation,
+    uint32_t cols)
+{
+    wl_result_relation_t *existing = find_result_relation(result, relation);
+    if (existing)
+        return existing->cols == cols ? existing : NULL;
+
+    if (result->count == result->capacity) {
+        uint32_t next = result->capacity ? result->capacity * 2 : 8;
+        wl_result_relation_t *rels = (wl_result_relation_t *)realloc(
+            result->relations, next * sizeof(wl_result_relation_t));
+        if (!rels)
+            return NULL;
+        memset(rels + result->capacity, 0,
+            (next - result->capacity) * sizeof(wl_result_relation_t));
+        result->relations = rels;
+        result->capacity = next;
+    }
+
+    wl_result_relation_t *rel = &result->relations[result->count++];
+    rel->name = wl_strdup(relation);
+    if (!rel->name)
+        return NULL;
+    rel->cols = cols;
+    return rel;
+}
+
+static bool
+append_result_row(wl_result_relation_t *rel, const int64_t *row)
+{
+    if (rel->rows == rel->capacity_rows) {
+        uint64_t next = rel->capacity_rows ? rel->capacity_rows * 2 : 16;
+        if (rel->cols != 0 && next > UINT64_MAX / rel->cols)
+            return false;
+        int64_t *data = (int64_t *)realloc(
+            rel->data, next * rel->cols * sizeof(int64_t));
+        if (!data)
+            return false;
+        rel->data = data;
+        rel->capacity_rows = next;
+    }
+    memcpy(rel->data + rel->rows * rel->cols, row, rel->cols * sizeof(int64_t));
+    rel->rows++;
+    return true;
+}
+
+typedef struct {
+    wirelog_result_t *result;
+    bool failed;
+} wl_collect_ctx_t;
+
+static void
+collect_tuple(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    wl_collect_ctx_t *ctx = (wl_collect_ctx_t *)user_data;
+    if (!ctx || ctx->failed)
+        return;
+    wl_result_relation_t *rel = ensure_result_relation(ctx->result, relation,
+            ncols);
+    if (!rel || !append_result_row(rel, row))
+        ctx->failed = true;
+}
+
+wirelog_opt_config_t
+wirelog_optimizer_get_default_config(void)
+{
+    return (wirelog_opt_config_t) {
+               .enable_logic_fusion = true,
+               .enable_join_ordering = true,
+               .enable_semijoin = true,
+               .enable_subplan_sharing = true,
+               .enable_boolean_spec = true,
+               .max_join_search_space = 1024,
+               .debug_trace = false,
+    };
+}
+
+bool
+wirelog_optimize_with_config(wirelog_program_t *program,
+    const wirelog_opt_config_t *config, wirelog_error_t *error)
+{
+    if (!program) {
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+
+    wirelog_opt_config_t default_config;
+    if (!config) {
+        default_config = wirelog_optimizer_get_default_config();
+        config = &default_config;
+    }
+
+    wirelog_opt_stats_t stats = {
+        .original_node_count = count_ir_nodes(program),
+    };
+    uint32_t applied = 0;
+
+    int rc = wl_subsumption_apply(program, NULL);
+    if (rc != 0) {
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+
+    if (config->enable_logic_fusion
+        && !run_optimizer_pass(program, WIRELOG_OPT_LOGIC_FUSION, error,
+        &applied, &stats))
+        return false;
+    if (config->enable_join_ordering
+        && !run_optimizer_pass(program, WIRELOG_OPT_JOIN_PROJECT_PLAN, error,
+        &applied, &stats))
+        return false;
+    if (config->enable_semijoin
+        && !run_optimizer_pass(program, WIRELOG_OPT_SEMIJOIN, error, &applied,
+        &stats))
+        return false;
+    if (config->enable_subplan_sharing
+        && !run_optimizer_pass(program, WIRELOG_OPT_SUBPLAN_SHARING, error,
+        &applied, &stats))
+        return false;
+    if (config->enable_boolean_spec
+        && !run_optimizer_pass(program, WIRELOG_OPT_BOOLEAN_SPEC, error,
+        &applied, &stats))
+        return false;
+
+    rc = wl_magic_sets_apply_with_demands(
+        program, program->demands, program->demand_count, NULL);
+    if (rc != 0) {
+        set_error(error,
+            rc == -1 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+    if (!rebuild_after_magic_sets(program, error))
+        return false;
+
+    stats.passes_applied = applied;
+    stats.optimized_node_count = count_ir_nodes(program);
+    program->optimizer_stats_valid = true;
+    program->optimizer_original_node_count = stats.original_node_count;
+    program->optimizer_optimized_node_count = stats.optimized_node_count;
+    program->optimizer_passes_applied = stats.passes_applied;
+    program->optimizer_fusion_count = stats.fusion_count;
+    program->optimizer_join_reorders = stats.join_reorders;
+    program->optimizer_time_ms = stats.optimization_time_ms;
+    set_error(error, WIRELOG_OK);
+    return true;
+}
+
+bool
+wirelog_optimize(wirelog_program_t *program, wirelog_error_t *error)
+{
+    return wirelog_optimize_with_config(program, NULL, error);
+}
+
+bool
+wirelog_optimize_apply_pass(wirelog_program_t *program, wirelog_opt_pass_t pass,
+    wirelog_error_t *error)
+{
+    if (!program) {
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+    uint32_t applied = 0;
+    bool ok = run_optimizer_pass(program, pass, error, &applied, NULL);
+    if (ok)
+        set_error(error, WIRELOG_OK);
+    return ok;
+}
+
+bool
+wirelog_optimizer_get_stats(const wirelog_program_t *program,
+    wirelog_opt_stats_t *stats)
+{
+    if (!program || !stats)
+        return false;
+    if (!program->optimizer_stats_valid)
+        return false;
+    memset(stats, 0, sizeof(*stats));
+    stats->original_node_count = program->optimizer_original_node_count;
+    stats->optimized_node_count = program->optimizer_optimized_node_count;
+    stats->passes_applied = program->optimizer_passes_applied;
+    stats->fusion_count = program->optimizer_fusion_count;
+    stats->join_reorders = program->optimizer_join_reorders;
+    stats->optimization_time_ms = program->optimizer_time_ms;
+    return true;
+}
+
+void
+wirelog_optimizer_debug_print(const wirelog_program_t *program)
+{
+    if (!program) {
+        fprintf(stderr, "wirelog optimizer: NULL program\n");
+        return;
+    }
+
+    fprintf(stderr, "wirelog optimizer: relations=%u rules=%u strata=%u\n",
+        program->relation_count, program->rule_count, program->stratum_count);
+    if (!program->relation_irs)
+        return;
+    for (uint32_t i = 0; i < program->relation_count; i++) {
+        if (!program->relation_irs[i])
+            continue;
+        fprintf(stderr, "relation %s:\n",
+            program->relations[i].name ? program->relations[i].name : "(null)");
+        wirelog_ir_node_print(program->relation_irs[i], 2);
+    }
+}
+
+void
+wirelog_optimizer_debug(const wirelog_program_t *program)
+{
+    wirelog_optimizer_debug_print(program);
+}
+
+uint64_t
+wirelog_optimizer_cost_estimate(const wirelog_program_t *program)
+{
+    return count_ir_nodes(program);
+}
+
+int
+wirelog_load_all_facts(const wirelog_program_t *prog, void *worker)
+{
+    wirelog_executor_t *executor = checked_executor(worker);
+    if (!prog || !executor || executor->program != prog)
+        return -1;
+    return wl_session_load_facts(executor->session, prog);
+}
+
+int
+wirelog_load_input_files(const wirelog_program_t *prog, void *worker)
+{
+    wirelog_executor_t *executor = checked_executor(worker);
+    if (!prog || !executor || executor->program != prog)
+        return -1;
+    return wl_session_load_input_files(executor->session, prog);
+}
+
+wirelog_executor_t *
+wirelog_executor_create(wirelog_program_t *program, wirelog_error_t *error)
+{
+    if (!program) {
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return NULL;
+    }
+
+    wirelog_executor_t *executor
+        = (wirelog_executor_t *)calloc(1, sizeof(wirelog_executor_t));
+    if (!executor) {
+        set_error(error, WIRELOG_ERR_MEMORY);
+        return NULL;
+    }
+    executor->magic = WIRELOG_EXECUTOR_MAGIC;
+    executor->program = program;
+
+    if (wl_plan_from_program(program, &executor->plan) != 0) {
+        wirelog_executor_free(executor);
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return NULL;
+    }
+    if (wl_session_create(wl_backend_columnar(), executor->plan, 1,
+        &executor->session) != 0) {
+        wirelog_executor_free(executor);
+        set_error(error, WIRELOG_ERR_EXEC);
+        return NULL;
+    }
+    if (wl_session_load_facts(executor->session, program) != 0
+        || wl_session_load_input_files(executor->session, program) != 0) {
+        wirelog_executor_free(executor);
+        set_error(error, WIRELOG_ERR_IO);
+        return NULL;
+    }
+
+    set_error(error, WIRELOG_OK);
+    return executor;
+}
+
+void
+wirelog_executor_free(wirelog_executor_t *executor)
+{
+    if (!executor)
+        return;
+    executor->magic = 0;
+    wl_session_destroy(executor->session);
+    wl_plan_free(executor->plan);
+    free(executor);
+}
+
+bool
+wirelog_load_facts_from_csv(wirelog_executor_t *executor,
+    const char *relation_name, const char *csv_file, wirelog_error_t *error)
+{
+    if (!executor || !relation_name || !csv_file) {
+        set_error(error, WIRELOG_ERR_EXEC);
+        return false;
+    }
+    const wl_ir_relation_info_t *rel
+        = find_relation(executor->program, relation_name);
+    if (!rel) {
+        set_error(error, WIRELOG_ERR_INVALID_IR);
+        return false;
+    }
+
+    int64_t *data = NULL;
+    uint32_t nrows = 0;
+    uint32_t ncols = 0;
+    wirelog_column_type_t *types = NULL;
+    if (rel->column_count > 0) {
+        types = (wirelog_column_type_t *)malloc(
+            rel->column_count * sizeof(wirelog_column_type_t));
+        if (!types) {
+            set_error(error, WIRELOG_ERR_MEMORY);
+            return false;
+        }
+        for (uint32_t i = 0; i < rel->column_count; i++)
+            types[i] = rel->columns[i].type;
+    }
+
+    int rc = wl_csv_read_file_ex(csv_file, ',', types, rel->column_count,
+            &data, &nrows, &ncols, executor->program->intern);
+    free(types);
+    if (rc != 0) {
+        set_error(error, rc == -3 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_IO);
+        return false;
+    }
+
+    rc = wl_session_insert(executor->session, relation_name, data, nrows,
+            ncols);
+    free(data);
+    if (rc != 0) {
+        set_error(error, WIRELOG_ERR_EXEC);
+        return false;
+    }
+    set_error(error, WIRELOG_OK);
+    return true;
+}
+
+wirelog_result_t *
+wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error)
+{
+    if (!executor || !executor->session) {
+        set_error(error, WIRELOG_ERR_EXEC);
+        return NULL;
+    }
+
+    wirelog_result_t *result
+        = (wirelog_result_t *)calloc(1, sizeof(wirelog_result_t));
+    if (!result) {
+        set_error(error, WIRELOG_ERR_MEMORY);
+        return NULL;
+    }
+
+    wl_collect_ctx_t ctx = {
+        .result = result,
+        .failed = false,
+    };
+    if (wl_session_snapshot(executor->session, collect_tuple, &ctx) != 0
+        || ctx.failed) {
+        wirelog_result_free(result);
+        set_error(error, ctx.failed ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC);
+        return NULL;
+    }
+
+    set_error(error, WIRELOG_OK);
+    return result;
+}
+
+const void *
+wirelog_result_get_relation(const wirelog_result_t *result,
+    const char *relation_name)
+{
+    wl_result_relation_t *rel = find_result_relation(result, relation_name);
+    if (!rel || rel->rows == 0)
+        return NULL;
+    return rel->data;
+}
+
+uint64_t
+wirelog_result_relation_cardinality(const wirelog_result_t *result,
+    const char *relation_name)
+{
+    wl_result_relation_t *rel = find_result_relation(result, relation_name);
+    return rel ? rel->rows : 0;
+}
+
+bool
+wirelog_result_write_csv(const wirelog_result_t *result,
+    const char *relation_name, const char *output_file, wirelog_error_t *error)
+{
+    wl_result_relation_t *rel = find_result_relation(result, relation_name);
+    if (!rel || !output_file) {
+        set_error(error, WIRELOG_ERR_EXEC);
+        return false;
+    }
+
+    FILE *out = fopen(output_file, "w");
+    if (!out) {
+        set_error(error, WIRELOG_ERR_IO);
+        return false;
+    }
+
+    for (uint64_t r = 0; r < rel->rows; r++) {
+        for (uint32_t c = 0; c < rel->cols; c++) {
+            if (c > 0)
+                fputc(',', out);
+            fprintf(out, "%" PRId64, rel->data[r * rel->cols + c]);
+        }
+        fputc('\n', out);
+    }
+
+    if (fclose(out) != 0) {
+        set_error(error, WIRELOG_ERR_IO);
+        return false;
+    }
+    set_error(error, WIRELOG_OK);
+    return true;
+}
+
+void
+wirelog_result_free(wirelog_result_t *result)
+{
+    if (!result)
+        return;
+    for (uint32_t i = 0; i < result->count; i++)
+        free_result_relation(&result->relations[i]);
+    free(result->relations);
+    free(result);
+}
+
+const char *
+wirelog_version_string(void)
+{
+    return WIRELOG_VERSION_STRING;
+}
+
+const char *
+wirelog_error_string(wirelog_error_t error)
+{
+    switch (error) {
+    case WIRELOG_OK:
+        return "ok";
+    case WIRELOG_ERR_PARSE:
+        return "parse error";
+    case WIRELOG_ERR_INVALID_IR:
+        return "invalid IR";
+    case WIRELOG_ERR_EXEC:
+        return "execution error";
+    case WIRELOG_ERR_MEMORY:
+        return "out of memory";
+    case WIRELOG_ERR_IO:
+        return "I/O error";
+    case WIRELOG_ERR_COMPOUND_SATURATED:
+        return "compound arena saturated";
+    case WIRELOG_ERR_COMPOUND_BUSY:
+        return "compound arena busy";
+    case WIRELOG_ERR_UNKNOWN:
+    default:
+        return "unknown error";
+    }
+}
+
+bool
+wirelog_config_embedded(void)
+{
+#ifdef WIRELOG_EMBEDDED
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool
+wirelog_config_ipc(void)
+{
+#ifdef WIRELOG_IPC
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool
+wirelog_config_threads(void)
+{
+#ifdef WIRELOG_THREADS
+    return true;
+#else
+    return false;
+#endif
+}

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -100,6 +100,15 @@ struct wirelog_program {
     wl_magic_demand_t *demands;
     uint32_t demand_count;
     uint32_t demand_capacity;
+
+    /* Public optimizer facade stats (#841). */
+    bool optimizer_stats_valid;
+    uint32_t optimizer_original_node_count;
+    uint32_t optimizer_optimized_node_count;
+    uint32_t optimizer_passes_applied;
+    uint32_t optimizer_fusion_count;
+    uint32_t optimizer_join_reorders;
+    double optimizer_time_ms;
 };
 
 /* ======================================================================== */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -133,6 +133,12 @@ wirelog_wl_easy_src = files('wirelog-easy.c', )
 wirelog_advanced_src = files('wirelog_advanced.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+#Umbrella API Facade (Issue #841)
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+
+wirelog_api_facade_src = files('api_facade.c', )
+
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Version header generation (Issue #688 / #704)
 #configure_file() runs in this subdir so the generated header lands at
 #build/wirelog/wirelog-version.h, matching the canonical include path

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -196,29 +196,33 @@ wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
     uint32_t *num_cols);
 
 /**
- * Load all inline facts from the program into a DD worker.
+ * Load all inline facts from the program into a batch executor.
  *
  * Iterates over all relations with inline facts (fact_count > 0) and
- * loads each batch into the DD execution engine via the project's
- * internal EDB-load helper.  This bridges the parser's fact storage
- * with the DD execution engine.
+ * loads each batch into the batch executor created by
+ * wirelog_executor_create().  The @worker parameter is retained as
+ * void* for ABI compatibility with the legacy DD-era declaration; new
+ * callers must pass a wirelog_executor_t*.  Other public handles,
+ * including wirelog_session_t*, are rejected.
  *
  * @param prog    Compiled program with inline facts
- * @param worker  DD worker handle to load facts into
+ * @param worker  wirelog_executor_t* to load facts into
  * @return 0 on success, -1 on error (NULL args or EDB load failure)
  */
 WIRELOG_API int
 wirelog_load_all_facts(const wirelog_program_t *prog, void *worker);
 
 /**
- * Load CSV files for all relations with .input directives.
+ * Load CSV files for all relations with .input directives into a batch executor.
  *
  * Iterates over all relations with has_input=true, reads the "filename"
  * and "delimiter" parameters, parses the CSV file, and loads the data
- * into the DD worker via the project's internal EDB-load helper.
+ * into the batch executor created by wirelog_executor_create().  The
+ * @worker parameter is retained as void* for ABI compatibility with the
+ * legacy DD-era declaration; new callers must pass a wirelog_executor_t*.
  *
  * @param prog    Compiled program with .input directives
- * @param worker  DD worker handle to load facts into
+ * @param worker  wirelog_executor_t* to load facts into
  * @return 0 on success, -1 on error (NULL args, missing file, parse error)
  */
 WIRELOG_API int
@@ -238,6 +242,14 @@ wirelog_optimizer_debug(const wirelog_program_t *program);
 /* Executor API                                                             */
 /* ======================================================================== */
 
+/**
+ * Create a batch executor for a parsed program.
+ *
+ * The executor BORROWS @program; callers must keep the program alive
+ * until after wirelog_executor_free().  The executor owns its execution
+ * plan and backend session, and eagerly seeds inline facts and .input
+ * directive files before returning.
+ */
 WIRELOG_API wirelog_executor_t *
 wirelog_executor_create(wirelog_program_t *program, wirelog_error_t *error);
 


### PR DESCRIPTION
## Summary
- implement the missing public umbrella/optimizer ABI facade symbols from `wirelog.h` and `wirelog-optimizer.h`
- update `abi/libwirelog-1.0.symbols` and regenerate `abi/libwirelog-1.0.abi.json`
- add a Meson-SSoT public API export gate plus a runtime public API regression test

## Review workflow
- Architect and critic confirmed the root cause was public header/export drift, not a linker allowlist-only issue.
- Implementer guidance was applied using the current columnar session/runtime APIs rather than DD-era internals.
- Reviewer findings were addressed: ABI JSON regenerated, unsafe internal-session cast removed, executor program lifetime documented, and export lint switched to Meson public-header SSoT parsing.

## Notes
- `wirelog_executor_t` borrows the parsed program; the header now documents that the program must outlive the executor.
- The legacy `wirelog_load_all_facts()` / `wirelog_load_input_files()` ABI now accepts the public batch `wirelog_executor_t *` through the retained `void *worker` slot and rejects non-executor handles.

## Verification
- `meson compile -C builddir`
- `meson test -C builddir --suite abi --print-errorlogs`
- `meson test -C builddir wirelog_public_api wirelog_easy wirelog_advanced --print-errorlogs`
- `git diff --check`

Fixes #841
