### PR TITLE
chore(version): bump project_version to 0.41.99 (post-v0.41.0 dev cycle)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.41.0',
+  version: '0.41.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

- Bump `meson.build` `project_version` from `0.41.0` to `0.41.99` now that `v0.41.0` has been tagged and pushed.
- Mirrors the v0.40.0 -> 0.40.99 pattern from ba669dd: the `.99` PATCH component marks the in-development trunk between `v0.41.0` and the next `v0.42.0` cut so any build off `main` reports a version that cannot be confused with a published release.
- `WIRELOG_VERSION_STRING` becomes the literal `"0.41.99"`; the integer triple becomes `MAJOR=0`, `MINOR=41`, `PATCH=99`, so downstream consumers using `WIRELOG_VERSION_AT_LEAST(0, 41, 99)` can distinguish a trunk build from the v0.41.0 release.

## Test plan

- [x] `meson setup --reconfigure build` reports `Project version: 0.41.99`.
- [x] `meson compile -C build` succeeds (208 build targets).
- [x] `LC_ALL=C meson test -C build --suite abi` -> 29/29 OK (including `version_sync`, `abi_symbols`, `abi_manifest`, `release_template`, `changelog_format`).
- [x] `build/wirelog/wirelog-version.h` carries `WIRELOG_VERSION_MAJOR=0`, `_MINOR=41`, `_PATCH=99`, `WIRELOG_VERSION_STRING "0.41.99"`.

## Notes

- The `v0.41.0` tag was pushed to `origin` immediately before this branch was opened, pointing at main HEAD (`9a30658 Restrict platform ABI advisory tests to matching hosts`).
- This PR is the only change for the post-release dev cycle bump; CHANGELOG and MIGRATION already carry the `[Unreleased]` block from the prep commit (2e02cf9).