### PR TITLE
Fix recursive aggregation residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Recursive aggregation conformance for columnar MIN/MAX** (#692):
+  REDUCE plan ops now carry aggregate expressions, so recursive
+  aggregates evaluate `min(l)` / `max(d + w)` instead of falling back to
+  a positional input column.  Recursive MIN/MAX IDBs are canonicalized
+  after sequential fixed-point convergence and TDD final merge so
+  dominated aggregate rows are removed from snapshots.  Adds
+  `recursive_agg_conformance` coverage for CC-min, SSSP-max, and
+  stratified COUNT at workers 1, 4, 8, and 16.
+
 ### Performance
 
 ### Security

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -123,9 +123,9 @@ not assume symmetric coverage.
 - `CHANGELOG.md` — entry for #718.
 - `stable-release-plan.md` §3, §7 — public-surface and conformance plans.
 
-## Recursive aggregation residue (Status: Future)
+## Recursive aggregation residue (Status: Implemented for MIN/MAX)
 
-Tracked under #692.  Target: residue = 0 in Milestone v0.43.
+Tracked under #692.
 
 ### Definition
 
@@ -134,48 +134,28 @@ conformance tests in `tests/test_recursive_agg*.c` that prevent
 recursive aggregation programs (CC-min, SSSP-max, count-stratified)
 from producing semantically correct output at workers in {1, 4, 8, 16}.
 
-### Current state (as of v0.42)
+### Current state
 
-- **Conformance harness disabled**: `tests/test_recursive_agg.c`,
-  `tests/test_recursive_agg_cc_min.c`, and
-  `tests/test_recursive_agg_sssp_max.c` are disabled in
-  `tests/meson.build:184-198, 2190-2194`.  The harness depended on the
-  DD/Rust FFI backend, which has been removed.  No replacement fixtures
-  have been ported to the columnar backend.
-- **Columnar dispatch state** at `wirelog/columnar/eval.c:241-288`:
-  - `col_op_reduce` (`wirelog/columnar/ops.c:6090`) IS wired into the
-    recursive dispatch switch (`WL_PLAN_OP_REDUCE` case at
-    `eval.c:267-269`).  Conformance for recursive monotone aggregation
-    (MIN/MAX) cannot run today only because the harness in
-    `tests/test_recursive_agg*.c` is disabled.
-  - `col_op_reduce_weighted` (`wirelog/columnar/ops.c:6200`) is built
-    but NOT dispatched (no `WL_PLAN_OP_REDUCE_WEIGHTED:` case in the
-    switch).  Weighted reductions inside `iterate()` cannot execute.
-- **count-stratified scope asymmetry**: count-stratified aggregation
-  appears in the #692 issue body but is absent from the acceptance
-  criteria, and no test fixtures exist.
-
-### Path to residue = 0
-
-1. **Phase 2B prerequisite**: semi-naive Delta-R for non-aggregation
-   recursion (#735, #809, #810, #811) must land first.  Phase 2B covers
-   non-agg recursion; REDUCE-inside-iterate is a separate concern.
-2. **v0.43 work**: re-enable the conformance harness against the
-   columnar backend; add a `WL_PLAN_OP_REDUCE_WEIGHTED:` case to wire
-   `col_op_reduce_weighted` into the recursive dispatch switch; add
-   count-stratified fixtures.
-
-v0.42 narrowed exit criterion: "non-agg recursion residue = 0" via
-Phase 2B sub-issues (#809/#810/#811).  Recursive aggregation residue = 0
-carries to v0.43 under #692.
+- `WL_PLAN_OP_REDUCE` carries the aggregate expression into the exec
+  plan, so recursive aggregate rules such as `min(l)` and `max(d + w)`
+  aggregate the requested expression rather than the fallback column.
+- Recursive MIN/MAX IDB materialization is canonicalized after fixed-point
+  convergence in both sequential and TDD final-merge paths, removing
+  dominated rows from snapshots.
+- `tests/test_recursive_agg_conformance.c` covers CC-min, SSSP-max, and
+  stratified COUNT for workers in {1, 4, 8, 16}.
+- The old `tests/test_recursive_agg*.c` DD/Rust FFI harness remains
+  disabled because that backend was removed; the columnar conformance
+  harness is the active replacement.
+- `col_op_reduce_weighted` remains a weighted Z-set helper and is not part
+  of the #692 MIN/MAX recursive aggregate closure.
 
 ### References
 
 - Issue #692 — Blocker B5: Recursive aggregation residue = 0.
-- Phase 2B: #735, #809, #810, #811.
-- `wirelog/columnar/ops.c` — `col_op_reduce`, `col_op_reduce_weighted`.
-- `wirelog/columnar/eval.c:241-288` — recursive dispatch switch.
-- `tests/meson.build:184-198, 2190-2194` — disabled harness entries.
+- `wirelog/columnar/ops.c` — `col_op_reduce`.
+- `wirelog/columnar/eval.c` — recursive aggregate canonicalization.
+- `tests/test_recursive_agg_conformance.c` — active columnar harness.
 
 ---
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -672,6 +672,24 @@ test_plan_gen_exe = executable(
 
 test('plan_gen', test_plan_gen_exe)
 
+test_recursive_agg_conformance_exe = executable(
+  'test_recursive_agg_conformance',
+  files('test_recursive_agg_conformance.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('recursive_agg_conformance', test_recursive_agg_conformance_exe,
+     suite: 'semantics')
+
 # ============================================================================
 # Plan Exchange Insertion Tests (Issue #319)
 # ============================================================================

--- a/tests/test_recursive_agg_conformance.c
+++ b/tests/test_recursive_agg_conformance.c
@@ -1,0 +1,197 @@
+/*
+ * tests/test_recursive_agg_conformance.c - Recursive aggregation conformance
+ *
+ * Covers issue #692: recursive MIN/MAX aggregate materialization must not
+ * retain dominated aggregate rows after fixed-point evaluation.
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    const char *relation;
+    uint32_t ncols;
+    int64_t rows[64][4];
+    uint32_t count;
+} row_set_t;
+
+static void
+collect_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    row_set_t *set = (row_set_t *)user_data;
+    if (!relation || strcmp(relation, set->relation) != 0)
+        return;
+    if (ncols > 4 || set->count >= 64)
+        abort();
+    set->ncols = ncols;
+    for (uint32_t c = 0; c < ncols; c++)
+        set->rows[set->count][c] = row[c];
+    set->count++;
+}
+
+static int
+row_set_contains(const row_set_t *set, const int64_t *row, uint32_t ncols)
+{
+    for (uint32_t r = 0; r < set->count; r++) {
+        int match = 1;
+        for (uint32_t c = 0; c < ncols; c++) {
+            if (set->rows[r][c] != row[c]) {
+                match = 0;
+                break;
+            }
+        }
+        if (match)
+            return 1;
+    }
+    return 0;
+}
+
+static int
+run_program(const char *src, const char *relation, uint32_t workers,
+    row_set_t *out)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return rc;
+    }
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);
+    if (rc != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return rc;
+    }
+
+    rc = wl_session_load_facts(sess, prog);
+    if (rc == 0) {
+        memset(out, 0, sizeof(*out));
+        out->relation = relation;
+        rc = wl_session_snapshot(sess, collect_rows, out);
+    }
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+static int
+expect_rows(const row_set_t *set, const int64_t expected[][2],
+    uint32_t expected_count)
+{
+    if (set->count != expected_count)
+        return 0;
+    if (set->ncols != 2)
+        return 0;
+    for (uint32_t i = 0; i < expected_count; i++) {
+        if (!row_set_contains(set, expected[i], 2))
+            return 0;
+    }
+    return 1;
+}
+
+static int
+test_cc_min(uint32_t workers)
+{
+    static const char *src =
+        ".decl Edge(x: int32, y: int32)\n"
+        ".decl Label(x: int32, l: int32)\n"
+        "Edge(1,2). Edge(2,1). Edge(2,3). Edge(3,2).\n"
+        "Edge(4,5). Edge(5,4).\n"
+        "Label(x, min(x)) :- Edge(x, y).\n"
+        "Label(y, min(y)) :- Edge(x, y).\n"
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n";
+    static const int64_t expected[][2] = {
+        {1, 1}, {2, 1}, {3, 1}, {4, 4}, {5, 4},
+    };
+    row_set_t rows;
+    return run_program(src, "Label", workers, &rows) == 0
+           && expect_rows(&rows, expected, 5);
+}
+
+static int
+test_sssp_max(uint32_t workers)
+{
+    static const char *src =
+        ".decl Edge(x: int32, y: int32, w: int32)\n"
+        ".decl Dist(x: int32, d: int32)\n"
+        "Edge(1,2,5). Edge(1,3,1). Edge(2,3,7).\n"
+        "Dist(1, max(0)) :- Edge(1, y, w).\n"
+        "Dist(y, max(d + w)) :- Dist(x, d), Edge(x, y, w).\n";
+    static const int64_t expected[][2] = {
+        {1, 0}, {2, 5}, {3, 12},
+    };
+    row_set_t rows;
+    return run_program(src, "Dist", workers, &rows) == 0
+           && expect_rows(&rows, expected, 3);
+}
+
+static int
+test_count_stratified(uint32_t workers)
+{
+    static const char *src =
+        ".decl Edge(x: int32, y: int32)\n"
+        ".decl EdgeCount(x: int32, c: int32)\n"
+        "Edge(1,2). Edge(1,3). Edge(1,4). Edge(2,3). Edge(2,4). Edge(3,4).\n"
+        "EdgeCount(x, count(y)) :- Edge(x, y).\n";
+    static const int64_t expected[][2] = {
+        {1, 3}, {2, 2}, {3, 1},
+    };
+    row_set_t rows;
+    return run_program(src, "EdgeCount", workers, &rows) == 0
+           && expect_rows(&rows, expected, 3);
+}
+
+int
+main(void)
+{
+    static const uint32_t worker_counts[] = {1, 4, 8, 16};
+    int failures = 0;
+
+    for (uint32_t i = 0; i < sizeof(worker_counts) / sizeof(worker_counts[0]);
+        i++) {
+        uint32_t workers = worker_counts[i];
+        if (!test_cc_min(workers)) {
+            printf("FAIL cc-min workers=%u\n", workers);
+            failures++;
+        }
+        if (!test_sssp_max(workers)) {
+            printf("FAIL sssp-max workers=%u\n", workers);
+            failures++;
+        }
+        if (!test_count_stratified(workers)) {
+            printf("FAIL count-stratified workers=%u\n", workers);
+            failures++;
+        }
+    }
+
+    if (failures == 0) {
+        printf("PASS recursive aggregation conformance\n");
+        return 0;
+    }
+    return 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -362,6 +362,115 @@ col_frontier_compute(const col_rel_t *rel);
 static int
 col_eval_nonrecursive_relation_parallel(const wl_plan_relation_t *rp,
     wl_col_session_t *coord);
+static int
+col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess);
+
+static bool
+col_reduce_output_group_equal(const col_rel_t *rel, uint32_t a, uint32_t b,
+    uint32_t group_by_count)
+{
+    for (uint32_t c = 0; c < group_by_count; c++) {
+        if (col_rel_get(rel, a, c) != col_rel_get(rel, b, c))
+            return false;
+    }
+    return true;
+}
+
+static const wl_plan_op_t *
+col_relation_recursive_reduce_op(const wl_plan_relation_t *rp)
+{
+    const wl_plan_op_t *reduce_op = NULL;
+
+    for (uint32_t oi = 0; oi < rp->op_count; oi++) {
+        const wl_plan_op_t *op = &rp->ops[oi];
+        if (op->op != WL_PLAN_OP_REDUCE)
+            continue;
+        if (op->agg_fn != WIRELOG_AGG_MIN && op->agg_fn != WIRELOG_AGG_MAX)
+            return NULL;
+        if (reduce_op
+            && (reduce_op->agg_fn != op->agg_fn
+            || reduce_op->group_by_count != op->group_by_count)) {
+            return NULL;
+        }
+        reduce_op = op;
+    }
+
+    return reduce_op;
+}
+
+static int
+col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
+    const wl_plan_op_t *reduce_op)
+{
+    if (!rel || !reduce_op || rel->nrows < 2)
+        return 0;
+
+    uint32_t gc = reduce_op->group_by_count;
+    if (rel->ncols <= gc)
+        return EINVAL;
+
+    uint32_t out = 0;
+    for (uint32_t row = 0; row < rel->nrows; row++) {
+        uint32_t found = UINT32_MAX;
+        for (uint32_t keep = 0; keep < out; keep++) {
+            if (col_reduce_output_group_equal(rel, keep, row, gc)) {
+                found = keep;
+                break;
+            }
+        }
+
+        if (found != UINT32_MAX) {
+            int64_t cur = col_rel_get(rel, found, gc);
+            int64_t val = col_rel_get(rel, row, gc);
+            bool better = (reduce_op->agg_fn == WIRELOG_AGG_MIN)
+                ? val < cur : val > cur;
+            if (better) {
+                col_rel_set(rel, found, gc, val);
+                if (rel->timestamps)
+                    rel->timestamps[found] = rel->timestamps[row];
+            }
+            continue;
+        }
+
+        if (out != row) {
+            for (uint32_t c = 0; c < rel->ncols; c++)
+                col_rel_set(rel, out, c, col_rel_get(rel, row, c));
+            if (rel->timestamps)
+                rel->timestamps[out] = rel->timestamps[row];
+        }
+        out++;
+    }
+
+    if (out != rel->nrows) {
+        rel->nrows = out;
+        rel->sorted_nrows = out;
+        rel->base_nrows = out;
+        rel->run_count = 0;
+        rel->dedup_count = 0;
+        memset(rel->run_ends, 0, sizeof(rel->run_ends));
+    }
+
+    return 0;
+}
+
+static int
+col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess)
+{
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rp = &sp->relations[ri];
+        const wl_plan_op_t *reduce_op = col_relation_recursive_reduce_op(rp);
+        if (!reduce_op)
+            continue;
+        col_rel_t *rel = session_find_rel(sess, rp->name);
+        int rc = col_canonicalize_recursive_aggregate_relation(rel, reduce_op);
+        if (rc != 0)
+            return rc;
+        col_session_invalidate_arrangements(&sess->base, rp->name);
+    }
+    return 0;
+}
 
 /*
  * col_eval_stratum:
@@ -1006,6 +1115,17 @@ stride_error:
                 sess->worker_id, stratum_idx, sess->outer_epoch,
                 strat_frontier.iteration);
         }
+    }
+
+    int agg_rc = col_canonicalize_recursive_aggregates(sp, sess);
+    if (agg_rc != 0) {
+        for (uint32_t ri = 0; ri < nrels; ri++) {
+            if (delta_rels[ri])
+                col_rel_destroy(delta_rels[ri]);
+        }
+        free(snap);
+        free(delta_rels);
+        return agg_rc;
     }
 
     /* Cleanup all delta relations after frontier has been computed */
@@ -7215,6 +7335,7 @@ done:
                 if (r && r->nrows > 1)
                     tdd_dedup_rel(r);
             }
+            rc = col_canonicalize_recursive_aggregates(sp, coord);
             coord->tdd_final_merge_ns += now_ns() - merge_t0;
         } else {
             /* Non-BDX: Merge worker IDB into coordinator */
@@ -7230,6 +7351,7 @@ done:
                     if (r && r->nrows > 1)
                         tdd_dedup_rel(r);
                 }
+                rc = col_canonicalize_recursive_aggregates(sp, coord);
             }
             coord->tdd_final_merge_ns += now_ns() - merge_t0;
         }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -6102,11 +6102,27 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
 
+    col_expr_compiled_t *agg_ce = NULL;
+    if (op->agg_expr.data && op->agg_expr.size > 0)
+        agg_ce = col_expr_compile(op->agg_expr.data, op->agg_expr.size);
+
     /* Sort by group key for group-by */
     /* (Simple O(n^2) implementation; sufficient for Phase 2A) */
     for (uint32_t r = 0; r < in->nrows; r++) {
         int64_t row_buf[COL_STACK_MAX]; col_rel_row_copy_out(in, r, row_buf);
         const int64_t *row = row_buf;
+        int64_t agg_val = (in->ncols > gc) ? row[gc] : 1;
+        if (op->agg_fn != WIRELOG_AGG_COUNT
+            && op->agg_expr.data && op->agg_expr.size > 0) {
+            if (agg_ce) {
+                int64_t val = 0;
+                if (col_eval_expr_compiled(agg_ce, row, in->ncols, &val) == 0)
+                    agg_val = val;
+            } else {
+                agg_val = col_eval_expr_i64(op->agg_expr.data,
+                        op->agg_expr.size, row, in->ncols, sess->intern);
+            }
+        }
 
         /* Check if this group key already exists in output */
         bool found = false;
@@ -6120,22 +6136,21 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             }
             if (match) {
                 /* Update aggregate */
-                int64_t val = (in->ncols > gc) ? row[gc] : 1;
                 int64_t cur = col_rel_get(out, o, gc);
                 switch (op->agg_fn) {
                 case WIRELOG_AGG_COUNT:
                     col_rel_set(out, o, gc, cur + 1);
                     break;
                 case WIRELOG_AGG_SUM:
-                    col_rel_set(out, o, gc, cur + val);
+                    col_rel_set(out, o, gc, cur + agg_val);
                     break;
                 case WIRELOG_AGG_MIN:
-                    if (val < cur)
-                        col_rel_set(out, o, gc, val);
+                    if (agg_val < cur)
+                        col_rel_set(out, o, gc, agg_val);
                     break;
                 case WIRELOG_AGG_MAX:
-                    if (val > cur)
-                        col_rel_set(out, o, gc, val);
+                    if (agg_val > cur)
+                        col_rel_set(out, o, gc, agg_val);
                     break;
                 default:
                     break;
@@ -6150,10 +6165,10 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     = op->group_by_indices ? op->group_by_indices[k] : k;
                 tmp[k] = row[gi < in->ncols ? gi : 0];
             }
-            int64_t init_val = (in->ncols > gc) ? row[gc] : 1;
-            tmp[gc] = (op->agg_fn == WIRELOG_AGG_COUNT) ? 1 : init_val;
+            tmp[gc] = (op->agg_fn == WIRELOG_AGG_COUNT) ? 1 : agg_val;
             int rc = col_rel_append_row(out, tmp);
             if (rc != 0) {
+                col_expr_compiled_free(agg_ce);
                 free(tmp);
                 col_rel_destroy(out);
                 if (e.owned)
@@ -6163,6 +6178,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     }
 
+    col_expr_compiled_free(agg_ce);
     free(tmp);
     if (e.owned)
         col_rel_destroy(in);

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -353,6 +353,7 @@ typedef struct {
     wl_plan_expr_buffer_t filter_expr;
 
     wirelog_agg_fn_t agg_fn;
+    wl_plan_expr_buffer_t agg_expr;
     const uint32_t *group_by_indices;
     uint32_t group_by_count;
 

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -971,6 +971,31 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
         op->group_by_indices
             = dup_indices(node->group_by_indices, node->group_by_count);
         op->group_by_count = node->group_by_count;
+        if (node->agg_expr) {
+            char **child_col_names = NULL;
+            uint32_t child_col_count = 0;
+            if (node->column_names && node->column_count > 0) {
+                child_col_count = node->column_count;
+                child_col_names = (char **)calloc(child_col_count,
+                        sizeof(char *));
+                if (!child_col_names)
+                    return -1;
+                for (uint32_t i = 0; i < child_col_count; i++)
+                    child_col_names[i] = dup_str(node->column_names[i]);
+            } else {
+                const wirelog_ir_node_t *child0
+                    = (node->child_count > 0) ? node->children[0] : NULL;
+                collect_output_columns(child0, &child_col_names,
+                    &child_col_count);
+            }
+            int agg_rc = serialize_expr_to_buffer_ctx(node->agg_expr,
+                    child_col_names, child_col_count, &op->agg_expr);
+            for (uint32_t c = 0; c < child_col_count; c++)
+                free(child_col_names[c]);
+            free((void *)child_col_names);
+            if (agg_rc != 0)
+                return -1;
+        }
         return 0;
     }
 
@@ -1121,6 +1146,7 @@ free_op(wl_plan_op_t *op)
     free((void *)op->project_indices);
     free(op->filter_expr.data);
     free(op->right_filter_expr.data);
+    free(op->agg_expr.data);
     free((void *)op->group_by_indices);
 
     if (op->map_exprs) {
@@ -1479,6 +1505,14 @@ clone_plan_op(const wl_plan_op_t *src, wl_plan_op_t *dst)
         memcpy(dst->right_filter_expr.data, src->right_filter_expr.data,
             src->right_filter_expr.size);
         dst->right_filter_expr.size = src->right_filter_expr.size;
+    }
+
+    if (src->agg_expr.data && src->agg_expr.size > 0) {
+        dst->agg_expr.data = (uint8_t *)malloc(src->agg_expr.size);
+        if (!dst->agg_expr.data)
+            return -1;
+        memcpy(dst->agg_expr.data, src->agg_expr.data, src->agg_expr.size);
+        dst->agg_expr.size = src->agg_expr.size;
     }
 
     if (src->map_exprs && src->map_expr_count > 0) {

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -874,6 +874,32 @@ convert_expr(const wl_parser_ast_node_t *node)
     }
 }
 
+static void
+rewrite_expr_vars_to_columns(wl_ir_expr_t *expr, char **vars,
+    uint32_t var_count)
+{
+    if (!expr)
+        return;
+
+    if (expr->type == WL_IR_EXPR_VAR && expr->var_name) {
+        for (uint32_t i = 0; i < var_count; i++) {
+            if (vars[i] && strcmp(vars[i], expr->var_name) == 0) {
+                char col[32];
+                snprintf(col, sizeof(col), "col%u", i);
+                char *next = strdup_safe(col);
+                if (next) {
+                    free(expr->var_name);
+                    expr->var_name = next;
+                }
+                return;
+            }
+        }
+    }
+
+    for (uint32_t i = 0; i < expr->child_count; i++)
+        rewrite_expr_vars_to_columns(expr->children[i], vars, var_count);
+}
+
 /* ---- Variable Name Tracking Helpers ---- */
 
 static void
@@ -899,37 +925,15 @@ merge_var_names(char **left, uint32_t left_count, char **right,
         return NULL;
     }
 
-    uint32_t count = 0;
-
     for (uint32_t i = 0; i < left_count; i++) {
-        if (!left[i])
-            continue;
-        bool dup = false;
-        for (uint32_t j = 0; j < count; j++) {
-            if (merged[j] && strcmp(merged[j], left[i]) == 0) {
-                dup = true;
-                break;
-            }
-        }
-        if (!dup)
-            merged[count++] = strdup_safe(left[i]);
+        merged[i] = left[i] ? strdup_safe(left[i]) : NULL;
     }
 
     for (uint32_t i = 0; i < right_count; i++) {
-        if (!right[i])
-            continue;
-        bool dup = false;
-        for (uint32_t j = 0; j < count; j++) {
-            if (merged[j] && strcmp(merged[j], right[i]) == 0) {
-                dup = true;
-                break;
-            }
-        }
-        if (!dup)
-            merged[count++] = strdup_safe(right[i]);
+        merged[left_count + i] = right[i] ? strdup_safe(right[i]) : NULL;
     }
 
-    *out_count = count;
+    *out_count = max_count;
     return merged;
 }
 
@@ -943,6 +947,15 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
     uint32_t key_count = 0;
     for (uint32_t i = 0; i < left_count; i++) {
         if (!left_vars[i])
+            continue;
+        bool seen_left = false;
+        for (uint32_t prev = 0; prev < i; prev++) {
+            if (left_vars[prev] && strcmp(left_vars[prev], left_vars[i]) == 0) {
+                seen_left = true;
+                break;
+            }
+        }
+        if (seen_left)
             continue;
         for (uint32_t j = 0; j < right_count; j++) {
             if (!right_vars[j])
@@ -966,6 +979,15 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
     uint32_t k = 0;
     for (uint32_t i = 0; i < left_count; i++) {
         if (!left_vars[i])
+            continue;
+        bool seen_left = false;
+        for (uint32_t prev = 0; prev < i; prev++) {
+            if (left_vars[prev] && strcmp(left_vars[prev], left_vars[i]) == 0) {
+                seen_left = true;
+                break;
+            }
+        }
+        if (seen_left)
             continue;
         for (uint32_t j = 0; j < right_count; j++) {
             if (!right_vars[j])
@@ -1881,6 +1903,20 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
             if (agg_node->child_count >= 1) {
                 root->agg_expr = convert_expr(agg_node->children[0]);
+                rewrite_expr_vars_to_columns(root->agg_expr, cur_vars,
+                    cur_vcount);
+            }
+
+            root->column_count = cur_vcount;
+            if (cur_vcount > 0) {
+                root->column_names
+                    = (char **)calloc(cur_vcount, sizeof(char *));
+                if (root->column_names) {
+                    for (uint32_t j = 0; j < cur_vcount; j++)
+                        root->column_names[j] = strdup_safe(cur_vars[j]);
+                } else {
+                    root->column_count = 0;
+                }
             }
 
             root->group_by_count = non_agg_count;


### PR DESCRIPTION
## Summary
- carry aggregate expressions through REDUCE plan ops and evaluate them in columnar reduce
- preserve physical join column positions for aggregate variable resolution
- canonicalize recursive MIN/MAX aggregate IDBs after fixed-point/TDD merge to remove dominated rows
- add columnar recursive aggregation conformance coverage for CC-min, SSSP-max, and stratified COUNT at workers 1, 4, 8, 16

Closes #692.

## Tests
- meson test -C build-692 recursive_agg_conformance plan_gen diff_multiworker --print-errorlogs