### PR TITLE
build: harden mbedTLS PSA provider selection

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -81,14 +81,12 @@ Apache-2.0 path by default.
 | wirelog itself | this repository | LGPL-3.0-or-later (or commercial) |
 | Hash built-in | xxHash3 | BSD-2-Clause |
 | CRC-32 | in-tree | LGPL-3.0-or-later |
-| Optional crypto | system mbedTLS | Apache-2.0 (default) or GPL-2.0-or-later |
-| Optional crypto | mbedTLS sub-deps (`mbedx509`, `tfpsacrypto`) | Apache-2.0 |
+| Optional crypto | system PSA Crypto provider (`tfpsacrypto`, `mbedcrypto`, or PSA-capable `mbedtls`) | Apache-2.0 (default) or GPL-2.0-or-later |
 
 LGPL-3.0-or-later is compatible with Apache-2.0 in the *consumer*
 direction (consumer of mbedTLS may be LGPL-licensed). Downstream
 redistributors of an `mbedTLS=enabled` build must include the
-upstream Apache-2.0 NOTICE for mbedTLS plus the mbedx509/tfpsacrypto
-notices.
+upstream Apache-2.0 NOTICE for the selected PSA Crypto provider.
 
 ### 3.2 Export-control self-classification
 
@@ -160,8 +158,8 @@ You are responsible for:
   jurisdiction.
 - Filing any required notifications (US ENC notification, EU dual-use
   reporting, Japanese METI, etc.) for the artifact you ship.
-- Including the upstream mbedTLS NOTICE files when you redistribute
-  an `mbedTLS=enabled` build.
+- Including the upstream NOTICE files for the selected PSA Crypto
+  provider when you redistribute an `mbedTLS=enabled` build.
 
 The project provides this self-classification in good faith and as a
 starting point; it is not a substitute for review by qualified export
@@ -187,8 +185,8 @@ counsel for your specific distribution model.
   Lists Annex 1 Category 5 Part 2 (post-Brexit).
 - **Japan FEFTA** — METI Foreign Exchange and Foreign Trade Act,
   publicly-available-software exemptions.
-- **Apache License 2.0 NOTICE** — required attribution for mbedTLS
-  redistributions.
+- **Apache License 2.0 NOTICE** — required attribution for
+  redistributions of the selected PSA Crypto provider.
 - **`meson_options.txt`** — the `mbedTLS` build option entry repeats
   the headline disclosure inline.
 - **`SECURITY.md`** — vulnerability reporting channel.

--- a/meson.build
+++ b/meson.build
@@ -220,54 +220,57 @@ int main(void) {
   return 0;
 }
 '''
-if mbedtls_option == 'auto'
-  _mbedtls_crypto = dependency('tfpsacrypto', required: false)
-  if not _mbedtls_crypto.found()
-    _mbedtls_crypto = dependency('mbedcrypto', required: false)
-  endif
-  if not _mbedtls_crypto.found()
-    _mbedtls_crypto = dependency('mbedtls', required: false)
-  endif
-  if _mbedtls_crypto.found()
-    mbedtls_dep = [_mbedtls_crypto]
-    _mbedtls_psa_ok = true
+mbedtls_psa_candidates = [
+  'tfpsacrypto',
+  'mbedcrypto',
+  'mbedtls',
+]
+if mbedtls_option == 'auto' or mbedtls_option == 'enabled'
+  mbedtls_psa_provider = ''
+  mbedtls_psa_provider_version = ''
+  mbedtls_psa_rejections = []
+  foreach _mbedtls_candidate : mbedtls_psa_candidates
+    if mbedtls_psa_provider != ''
+      continue
+    endif
+    _mbedtls_crypto = dependency(_mbedtls_candidate, required: false)
+    if not _mbedtls_crypto.found()
+      mbedtls_psa_rejections += [_mbedtls_candidate + ': not found']
+      continue
+    endif
+
+    _mbedtls_candidate_dep = [_mbedtls_crypto]
+    _mbedtls_missing_headers = []
     foreach _mbedtls_header : mbedtls_required_headers
-      if not cc.has_header(_mbedtls_header, dependencies: mbedtls_dep)
-        _mbedtls_psa_ok = false
+      if not cc.has_header(_mbedtls_header, dependencies: _mbedtls_candidate_dep)
+        _mbedtls_missing_headers += [_mbedtls_header]
       endif
     endforeach
-    if _mbedtls_psa_ok and cc.links(mbedtls_psa_probe,
-        dependencies: mbedtls_dep,
-        name: 'PSA Crypto hash, HMAC, and random APIs')
-      add_project_arguments('-DWL_MBEDTLS_ENABLED=1', language: 'c')
-    else
-      warning('mbedTLS auto-detection found a crypto package but not the required PSA Crypto public API; crypto built-ins will remain disabled')
-      mbedtls_dep = []
+
+    if _mbedtls_missing_headers.length() > 0
+      mbedtls_psa_rejections += [_mbedtls_candidate + ': missing headers <' + '>, <'.join(_mbedtls_missing_headers) + '>']
+      continue
     endif
-  endif
-elif mbedtls_option == 'enabled'
-  _mbedtls_crypto = dependency('tfpsacrypto', required: false)
-  if not _mbedtls_crypto.found()
-    _mbedtls_crypto = dependency('mbedcrypto', required: false)
-  endif
-  if not _mbedtls_crypto.found()
-    _mbedtls_crypto = dependency('mbedtls', required: false)
-  endif
-  if not _mbedtls_crypto.found()
-    error('mbedTLS enabled requires a PSA Crypto development package; install TF-PSA-Crypto (tfpsacrypto) or a distro mbedcrypto package exposing <psa/crypto.h>')
-  endif
-  mbedtls_dep = [_mbedtls_crypto]
-  foreach _mbedtls_header : mbedtls_required_headers
-    if not cc.has_header(_mbedtls_header, dependencies: mbedtls_dep)
-      error('mbedTLS enabled requires public PSA Crypto header <' + _mbedtls_header + '>')
+
+    if cc.links(mbedtls_psa_probe,
+        dependencies: _mbedtls_candidate_dep,
+        name: 'PSA Crypto hash, HMAC, and random APIs via ' + _mbedtls_candidate)
+      mbedtls_dep = _mbedtls_candidate_dep
+      mbedtls_psa_provider = _mbedtls_candidate
+      mbedtls_psa_provider_version = _mbedtls_crypto.version()
+    else
+      mbedtls_psa_rejections += [_mbedtls_candidate + ': failed PSA Crypto link probe']
     endif
   endforeach
-  if not cc.links(mbedtls_psa_probe,
-      dependencies: mbedtls_dep,
-      name: 'PSA Crypto hash, HMAC, and random APIs')
-    error('mbedTLS enabled requires linkable PSA Crypto hash, HMAC, and random APIs')
+
+  if mbedtls_psa_provider != ''
+    message('  mbedTLS PSA provider: ' + mbedtls_psa_provider + ' ' + mbedtls_psa_provider_version)
+    add_project_arguments('-DWL_MBEDTLS_ENABLED=1', language: 'c')
+  elif mbedtls_option == 'auto'
+    warning('mbedTLS auto-detection did not find a linkable PSA Crypto provider; crypto built-ins will remain disabled. Candidates: ' + '; '.join(mbedtls_psa_rejections))
+  else
+    error('mbedTLS enabled requires a linkable PSA Crypto provider exposing <psa/crypto.h>. Candidates: ' + '; '.join(mbedtls_psa_rejections))
   endif
-  add_project_arguments('-DWL_MBEDTLS_ENABLED=1', language: 'c')
 endif
 
 xxhash_dep = xxhash_proj.get_variable('xxhash_dep')


### PR DESCRIPTION
## Summary
- verify each PSA Crypto provider candidate before selecting it
- fall through from broken `tfpsacrypto` metadata to later providers such as `mbedcrypto`
- report the selected provider and keep SECURITY_MODEL NOTICE wording provider-neutral

## Validation
- `meson setup builddir-845-psa -Dtests=true -DmbedTLS=enabled`
- `meson compile -C builddir-845-psa tests/test_cryptographic_hashes`
- `meson test -C builddir-845-psa cryptographic_hashes --print-errorlogs`
- `meson setup builddir-845-auto -Dtests=true -DmbedTLS=auto`
- `meson setup builddir-845-disabled -Dtests=true -DmbedTLS=disabled`
- `meson compile -C builddir-845-disabled tests/test_cryptographic_hashes`
- `meson test -C builddir-845-disabled cryptographic_hashes --print-errorlogs`
- `PKG_CONFIG_PATH=/tmp/wirelog-845-pc meson setup builddir-845-fallback -Dtests=true -DmbedTLS=enabled`
- `meson test -C builddir-845-psa --print-errorlogs` (239 OK, 8 skipped)
- `git diff --check`

Closes #845