### PR TITLE
docs: align mbedTLS crypto surface

### DIFF
--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -59,11 +59,20 @@ advertises mbedTLS support.
 ## 3. mbedTLS-enabled build
 
 When the build is configured with `-DmbedTLS=enabled` (or
-`-DmbedTLS=auto` and the system mbedTLS is detected), wirelog adds:
+`-DmbedTLS=auto` and a system PSA Crypto provider is detected),
+wirelog exposes the following mbedTLS-backed Datalog built-ins:
 
-- Cryptographic hash families: SHA-1, SHA-2 (224/256/384/512), SHA-3.
-- HMAC over the same hash families.
-- UUIDv4 generation backed by a CSPRNG.
+- Digest built-ins: `md5(x)`, `sha1(x)`, `sha256(x)`, `sha512(x)`.
+- HMAC built-in: `hmac_sha256(msg, key)`.
+- UUID built-ins: `uuid4()`, `uuid5(namespace, name)`.
+
+wirelog does not currently expose broader digest-family or generic
+HMAC-family built-ins as callable Datalog functions.
+Digest and HMAC built-ins operate on `int64` Datalog values. They
+compute mbedTLS digest/HMAC bytes and fold those bytes with
+`XXH3_64bits()` into the single `int64` value stored by wirelog;
+they do not return hex strings or byte arrays. `uuid4()` and
+`uuid5(namespace, name)` return the first 8 UUID bytes as an `int64`.
 
 These functions become callable as Datalog built-ins; the host has no
 control over whether a `.dl` program calls them once mbedTLS is

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -195,9 +195,25 @@ Supported column types:
 
 `hash(x)`, `md5(x)`, `sha1(x)`, `sha256(x)`, `sha512(x)`, `hmac_sha256(msg, key)`
 
+`hash(x)` returns an `int64` xxHash3 value. The mbedTLS-backed
+digest/HMAC built-ins also return `int64` values: digest or HMAC
+bytes are folded with `XXH3_64bits()` and are not exposed as hex
+strings or byte arrays. With `mbedTLS=disabled`, the crypto built-ins
+parse and plan; when they are used to compute relation values, the
+runtime fallback value is `0`. Some predicate/filter paths, including
+top-level filters, may pass rows through on disabled-crypto evaluator
+errors, so disabled crypto calls must not be used in predicates or
+security checks.
+
 ### UUID Functions
 
 `uuid4()`, `uuid5(namespace, name)`
+
+The UUID built-ins require mbedTLS for non-zero runtime output and
+return the first 8 UUID bytes as an `int64`, not formatted text. With
+`mbedTLS=disabled`, relation-value computations fall back to `0`;
+disabled UUID calls in predicate/filter expressions follow the same
+error-handling warning described for crypto hash functions.
 
 ### Comparison Operators
 

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -113,21 +113,21 @@ typedef enum {
     WL_PLAN_EXPR_ARITH_CRC32_CAST
         = 0x1D, /* CRC-32C Castagnoli (poly 0x1EDC6F41) */
 
-    /* Unary cryptographic hash functions (pop 1 push 1, requires mbedTLS) */
-    WL_PLAN_EXPR_ARITH_MD5 = 0x1E,  /* md5() - MD5 32-char hex digest */
-    WL_PLAN_EXPR_ARITH_SHA1 = 0x1F, /* sha1() - SHA-1 40-char hex digest */
+    /* Unary mbedTLS digest functions (pop 1, push folded int64) */
+    WL_PLAN_EXPR_ARITH_MD5 = 0x1E,  /* md5() - MD5 digest */
+    WL_PLAN_EXPR_ARITH_SHA1 = 0x1F, /* sha1() - SHA-1 digest */
     WL_PLAN_EXPR_ARITH_SHA256
-        = 0x20, /* sha256() - SHA-256 64-char hex digest */
+        = 0x20, /* sha256() - SHA-256 digest */
     WL_PLAN_EXPR_ARITH_SHA512
-        = 0x21, /* sha512() - SHA-512 128-char hex digest */
+        = 0x21, /* sha512() - SHA-512 digest */
 
-    /* Binary cryptographic hash functions (pop 2 push 1, requires mbedTLS) */
+    /* Binary mbedTLS HMAC function (pop 2, push folded int64) */
     WL_PLAN_EXPR_ARITH_HMAC_SHA256
-        = 0x28, /* hmac_sha256(msg, key) - HMAC-SHA-256 64-char hex digest */
+        = 0x28, /* hmac_sha256(msg, key) - HMAC-SHA-256 */
 
-    /* UUID functions (requires mbedTLS) */
-    WL_PLAN_EXPR_ARITH_UUID4 = 0x29, /* uuid4() - nullary, push 1 */
-    WL_PLAN_EXPR_ARITH_UUID5 = 0x2A, /* uuid5(ns, name) - pop 2 push 1 */
+    /* UUID functions (requires mbedTLS, push UUID prefix as int64) */
+    WL_PLAN_EXPR_ARITH_UUID4 = 0x29, /* uuid4() - nullary */
+    WL_PLAN_EXPR_ARITH_UUID5 = 0x2A, /* uuid5(ns, name) - pop 2 */
 
     /* Comparison operators (binary, pop 2 push 1) */
     WL_PLAN_EXPR_CMP_EQ = 0x22,

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -71,13 +71,13 @@ typedef enum {
     WIRELOG_ARITH_HASH,      /* hash - xxHash3 64-bit (unary) */
     WIRELOG_ARITH_CRC32_ETH, /* crc32_ethernet() - CRC-32 Ethernet/ISO (unary) */
     WIRELOG_ARITH_CRC32_CAST, /* crc32_castagnoli() - CRC-32C iSCSI (unary) */
-    WIRELOG_ARITH_MD5,        /* md5() - MD5 hex digest (unary, mbedTLS) */
-    WIRELOG_ARITH_SHA1,       /* sha1() - SHA-1 hex digest (unary, mbedTLS) */
-    WIRELOG_ARITH_SHA256, /* sha256() - SHA-256 hex digest (unary, mbedTLS) */
-    WIRELOG_ARITH_SHA512, /* sha512() - SHA-512 hex digest (unary, mbedTLS) */
-    WIRELOG_ARITH_HMAC_SHA256, /* hmac_sha256(msg, key) - HMAC-SHA-256 hex digest (binary, mbedTLS) */
-    WIRELOG_ARITH_UUID4, /* uuid4() - random UUID v4 (mbedTLS CTR-DRBG) */
-    WIRELOG_ARITH_UUID5, /* uuid5(ns, name) - SHA-1 name-based UUID v5 (mbedTLS) */
+    WIRELOG_ARITH_MD5,        /* md5() - MD5 digest folded to int64 (unary, mbedTLS) */
+    WIRELOG_ARITH_SHA1,       /* sha1() - SHA-1 digest folded to int64 (unary, mbedTLS) */
+    WIRELOG_ARITH_SHA256, /* sha256() - SHA-256 digest folded to int64 (unary, mbedTLS) */
+    WIRELOG_ARITH_SHA512, /* sha512() - SHA-512 digest folded to int64 (unary, mbedTLS) */
+    WIRELOG_ARITH_HMAC_SHA256, /* hmac_sha256(msg, key) - HMAC-SHA-256 folded to int64 (binary, mbedTLS) */
+    WIRELOG_ARITH_UUID4, /* uuid4() - random UUID v4 prefix as int64 (mbedTLS) */
+    WIRELOG_ARITH_UUID5, /* uuid5(ns, name) - name-based UUID v5 prefix as int64 (mbedTLS) */
 } wirelog_arith_op_t;
 
 /* ======================================================================== */


### PR DESCRIPTION
## Summary
- narrow SECURITY_MODEL.md to the mbedTLS-backed Datalog built-ins that are currently callable
- document folded int64 return values for digest/HMAC built-ins and UUID prefix returns
- replace public/internal header comments that incorrectly described crypto outputs as hex digests

## Validation
- meson test -C builddir-846-disabled --suite abi --print-errorlogs
- meson test -C builddir-846-disabled --suite crypto --print-errorlogs
- meson test -C builddir-846-psa --suite crypto --print-errorlogs
- git diff --check HEAD~1..HEAD
- rg -n "hex digest|SHA-3|SHA-224|SHA-384|224/256/384|HMAC over the same|Predicate/filter expressions that hit|textual UUID|UUID string" docs/SECURITY_MODEL.md docs/SYNTAX.md wirelog/wirelog-types.h wirelog/exec_plan.h tests/test_cryptographic_hashes.c tests/meson.build

Closes #847