### PR TITLE
ci: add mbedTLS enabled coverage

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -172,6 +172,45 @@ jobs:
           echo "Status: **${STATUS}** (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
 
   # ==========================================================================
+  # Phase 2b: Optional crypto coverage (monitoring-only on main)
+  # Mirrors the PR check name and coverage policy from #849.
+  # ==========================================================================
+  mbedtls-enabled:
+    name: mbedtls-enabled / ubuntu-latest / gcc
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build libmbedtls-dev
+
+      - name: Configure with mbedTLS enabled
+        run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
+        env:
+          CC: gcc
+
+      - name: Build with mbedTLS enabled
+        run: meson compile -C builddir-mbedtls
+
+      - name: Verify enabled compile flag
+        run: grep -R -- '-DWL_MBEDTLS_ENABLED=1' builddir-mbedtls/compile_commands.json
+
+      - name: Test mbedTLS crypto built-ins
+        run: meson test -C builddir-mbedtls cryptographic_hashes --print-errorlogs
+
+      - name: Publish results
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          echo "## mbedTLS-enabled Results: ubuntu-latest / gcc (main monitor)" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo "Status: **${STATUS}** (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+
+  # ==========================================================================
   # Phase 3: Sanitizers — ASan + UBSan (parallel, non-blocking)
   # Linux: GCC + Clang; macOS: Apple Clang
   # fail-fast: false — all configurations run to completion

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -161,6 +161,37 @@ jobs:
             ./builddir-path-a/pcap_skeleton
 
   # ==========================================================================
+  # Phase 2b: Optional crypto coverage
+  # Dedicated stable check name for branch-protection policy (#849).
+  # ==========================================================================
+  mbedtls-enabled:
+    name: mbedtls-enabled / ubuntu-latest / gcc
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build libmbedtls-dev
+
+      - name: Configure with mbedTLS enabled
+        run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
+        env:
+          CC: gcc
+
+      - name: Build with mbedTLS enabled
+        run: meson compile -C builddir-mbedtls
+
+      - name: Verify enabled compile flag
+        run: grep -R -- '-DWL_MBEDTLS_ENABLED=1' builddir-mbedtls/compile_commands.json
+
+      - name: Test mbedTLS crypto built-ins
+        run: meson test -C builddir-mbedtls cryptographic_hashes --print-errorlogs
+
+  # ==========================================================================
   # Phase 3a: ASan + UBSan matrix
   # Runs after lint and in parallel with the normal build matrix.
   # Linux: GCC + Clang; macOS: Clang

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- Added a dedicated `mbedtls-enabled / ubuntu-latest / gcc` CI leg
+  that configures with `-DmbedTLS=enabled`, verifies
+  `WL_MBEDTLS_ENABLED=1`, and runs `cryptographic_hashes` so optional
+  crypto paths are covered without changing the default disabled
+  artifact posture (#843).
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
## Summary

- Adds a dedicated PR check named `mbedtls-enabled / ubuntu-latest / gcc`.
- Configures that job with `-DmbedTLS=enabled`, verifies `WL_MBEDTLS_ENABLED=1`, and runs `cryptographic_hashes`.
- Mirrors the same enabled coverage in `ci-main.yml` as monitoring-only with `continue-on-error: true`.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n "mbedtls-enabled / ubuntu-latest / gcc|-DmbedTLS=enabled|cryptographic_hashes|WL_MBEDTLS_ENABLED" .github/workflows/ci-pr.yml .github/workflows/ci-main.yml CHANGELOG.md`
- `rm -rf builddir-843-enabled && meson setup builddir-843-enabled -Dtests=true -DmbedTLS=enabled && meson compile -C builddir-843-enabled && grep -R -- '-DWL_MBEDTLS_ENABLED=1' builddir-843-enabled/compile_commands.json && meson test -C builddir-843-enabled cryptographic_hashes --print-errorlogs`
- `meson test -C builddir-846-disabled cryptographic_hashes --print-errorlogs`

Closes #843
