### PR TITLE
Add relation IR accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to wirelog are documented in this file.
   `WL_MBEDTLS_ENABLED=1`, and runs `cryptographic_hashes` so optional
   crypto paths are covered without changing the default disabled
   artifact posture (#843).
+- Added `wirelog_program_get_relation_ir()`, a relation-scoped public
+  accessor that returns the borrowed merged IR root for a derived
+  relation and exposes multi-rule relations as `WIRELOG_IR_UNION`
+  without inventing a program-level super-root (#860).
 
 ### Changed
 

--- a/abi/libwirelog-1.0.abi.json
+++ b/abi/libwirelog-1.0.abi.json
@@ -58,6 +58,7 @@
     <elf-symbol name='wirelog_program_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_facts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_intern' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_program_get_relation_ir' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_rule_count' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_schema' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_stratum' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>

--- a/abi/libwirelog-1.0.macos.symbols
+++ b/abi/libwirelog-1.0.macos.symbols
@@ -38,6 +38,7 @@ wirelog_parse_with_error_info
 wirelog_program_free
 wirelog_program_get_facts
 wirelog_program_get_intern
+wirelog_program_get_relation_ir
 wirelog_program_get_rule_count
 wirelog_program_get_schema
 wirelog_program_get_stratum

--- a/abi/libwirelog-1.0.symbols
+++ b/abi/libwirelog-1.0.symbols
@@ -56,6 +56,7 @@ wirelog_parse_with_error_info
 wirelog_program_free
 wirelog_program_get_facts
 wirelog_program_get_intern
+wirelog_program_get_relation_ir
 wirelog_program_get_rule_count
 wirelog_program_get_schema
 wirelog_program_get_stratum

--- a/abi/libwirelog-1.0.windows.symbols
+++ b/abi/libwirelog-1.0.windows.symbols
@@ -38,6 +38,7 @@ wirelog_parse_with_error_info
 wirelog_program_free
 wirelog_program_get_facts
 wirelog_program_get_intern
+wirelog_program_get_relation_ir
 wirelog_program_get_rule_count
 wirelog_program_get_schema
 wirelog_program_get_stratum

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -2311,6 +2311,131 @@ test_api_get_schema_null(void)
 }
 
 static void
+test_api_get_relation_ir_single_rule(void)
+{
+    TEST("wirelog_program_get_relation_ir returns single-rule root");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl Arc(x: int32, y: int32)\n"
+            ".decl Reach(x: int32, y: int32)\n"
+            "Reach(x, y) :- Arc(x, y).\n",
+            NULL);
+
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    const wirelog_ir_node_t *root
+        = wirelog_program_get_relation_ir(prog, "Reach");
+    if (!root) {
+        wirelog_program_free(prog);
+        FAIL("Reach IR should not be NULL");
+        return;
+    }
+
+    if (wirelog_ir_node_get_type(root) != WIRELOG_IR_PROJECT) {
+        wirelog_program_free(prog);
+        FAIL("single-rule relation should expose PROJECT root");
+        return;
+    }
+
+    const char *relation = wirelog_ir_node_get_relation_name(root);
+    if (!relation || strcmp(relation, "Reach") != 0) {
+        wirelog_program_free(prog);
+        FAIL("root relation name should be Reach");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_api_get_relation_ir_multi_rule_union(void)
+{
+    TEST(
+        "wirelog_program_get_relation_ir returns UNION for multi-rule relation");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl Arc(x: int32, y: int32)\n"
+            ".decl Tc(x: int32, y: int32)\n"
+            "Tc(x, y) :- Arc(x, y).\n"
+            "Tc(x, y) :- Tc(x, z), Arc(z, y).\n",
+            NULL);
+
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    const wirelog_ir_node_t *root = wirelog_program_get_relation_ir(prog, "Tc");
+    if (!root) {
+        wirelog_program_free(prog);
+        FAIL("Tc IR should not be NULL");
+        return;
+    }
+
+    if (wirelog_ir_node_get_type(root) != WIRELOG_IR_UNION) {
+        wirelog_program_free(prog);
+        FAIL("multi-rule relation should expose UNION root");
+        return;
+    }
+
+    if (wirelog_ir_node_get_child_count(root) != 2) {
+        wirelog_program_free(prog);
+        FAIL("UNION root should have 2 children");
+        return;
+    }
+
+    if (!wirelog_ir_node_get_child(root, 0)
+        || !wirelog_ir_node_get_child(root, 1)) {
+        wirelog_program_free(prog);
+        FAIL("UNION children should be accessible");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_api_get_relation_ir_null_cases(void)
+{
+    TEST("wirelog_program_get_relation_ir returns NULL for absent IR roots");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl Arc(x: int32, y: int32)\n", NULL);
+
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    if (wirelog_program_get_relation_ir(prog, "Arc") != NULL) {
+        wirelog_program_free(prog);
+        FAIL("EDB-only relation should return NULL");
+        return;
+    }
+
+    if (wirelog_program_get_relation_ir(prog, "Missing") != NULL) {
+        wirelog_program_free(prog);
+        FAIL("unknown relation should return NULL");
+        return;
+    }
+
+    if (wirelog_program_get_relation_ir(NULL, "Arc") != NULL
+        || wirelog_program_get_relation_ir(prog, NULL) != NULL) {
+        wirelog_program_free(prog);
+        FAIL("NULL inputs should return NULL");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
 test_api_get_stratum_count(void)
 {
     TEST("wirelog_program_get_stratum_count returns 1");
@@ -3042,6 +3167,9 @@ main(void)
     test_api_get_schema();
     test_api_get_schema_compound_columns();
     test_api_get_schema_null();
+    test_api_get_relation_ir_single_rule();
+    test_api_get_relation_ir_multi_rule_union();
+    test_api_get_relation_ir_null_cases();
     test_api_get_stratum_count();
     test_api_get_stratum();
     test_api_get_stratum_oob();

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -14,6 +14,7 @@
  * - wirelog_program_get_stratum_count
  * - wirelog_program_get_stratum
  * - wirelog_program_is_stratified
+ * - wirelog_program_get_relation_ir
  * - wirelog_program_free
  */
 
@@ -110,7 +111,7 @@ wirelog_parse(const char *filename, wirelog_error_t *error)
 
 wirelog_program_t *
 wirelog_parse_with_error_info(const char *filename,
-                              wirelog_parse_error_t *error_info)
+    wirelog_parse_error_t *error_info)
 {
     (void)filename;
     if (error_info) {
@@ -137,7 +138,7 @@ wirelog_program_get_rule_count(const wirelog_program_t *program)
 
 const wirelog_schema_t *
 wirelog_program_get_schema(const wirelog_program_t *program,
-                           const char *relation_name)
+    const char *relation_name)
 {
     if (!program || !relation_name || !program->schemas)
         return NULL;
@@ -161,7 +162,7 @@ wirelog_program_get_stratum_count(const wirelog_program_t *program)
 
 const wirelog_stratum_t *
 wirelog_program_get_stratum(const wirelog_program_t *program,
-                            uint32_t stratum_id)
+    uint32_t stratum_id)
 {
     if (!program || stratum_id >= program->stratum_count)
         return NULL;
@@ -176,14 +177,32 @@ wirelog_program_is_stratified(const wirelog_program_t *program)
     return program->is_stratified;
 }
 
+const wirelog_ir_node_t *
+wirelog_program_get_relation_ir(const wirelog_program_t *program,
+    const char *relation_name)
+{
+    if (!program || !relation_name || !program->relations
+        || !program->relation_irs)
+        return NULL;
+
+    for (uint32_t i = 0; i < program->relation_count; i++) {
+        if (program->relations[i].name
+            && strcmp(program->relations[i].name, relation_name) == 0) {
+            return program->relation_irs[i];
+        }
+    }
+
+    return NULL;
+}
+
 /* ======================================================================== */
 /* Fact Extraction                                                          */
 /* ======================================================================== */
 
 int
 wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
-                          int64_t **data, uint32_t *num_rows,
-                          uint32_t *num_cols)
+    int64_t **data, uint32_t *num_rows,
+    uint32_t *num_cols)
 {
     if (!prog || !relation || !data || !num_rows || !num_cols)
         return -1;

--- a/wirelog/wirelog-ir.h
+++ b/wirelog/wirelog-ir.h
@@ -43,6 +43,7 @@ extern "C" {
 /* ======================================================================== */
 
 typedef struct wirelog_ir_node wirelog_ir_node_t;
+typedef struct wirelog_program wirelog_program_t;
 
 /**
  * wirelog_ir_node_type_t:
@@ -111,6 +112,27 @@ wirelog_ir_node_get_child_count(const wirelog_ir_node_t *node);
  */
 WIRELOG_API const wirelog_ir_node_t *
 wirelog_ir_node_get_child(const wirelog_ir_node_t *node, uint32_t index);
+
+/* ======================================================================== */
+/* Program IR Access                                                        */
+/* ======================================================================== */
+
+/**
+ * wirelog_program_get_relation_ir:
+ * @program: Parsed program
+ * @relation_name: Relation name
+ *
+ * Get the merged IR root for a derived relation. When multiple rules derive
+ * the relation, the returned root is a WIRELOG_IR_UNION node. The returned
+ * pointer is owned by @program, remains valid until wirelog_program_free(),
+ * and must not be freed by the caller.
+ *
+ * Returns: (transfer none): Relation IR root, or NULL for invalid arguments,
+ * unknown relations, EDB-only relations, or programs without built relation IRs.
+ */
+WIRELOG_API const wirelog_ir_node_t *
+wirelog_program_get_relation_ir(const wirelog_program_t *program,
+    const char *relation_name);
 
 /* ======================================================================== */
 /* IR Printing / Debugging                                                  */


### PR DESCRIPTION
## Summary

- Add `wirelog_program_get_relation_ir(program, relation_name)` as the public starting point for IR inspection.
- Keep the API relation-scoped because wirelog has no whole-program IR super-root.
- Return a borrowed program-owned IR root, with multi-rule relations exposed as `WIRELOG_IR_UNION`.
- Cover single-rule, multi-rule UNION, EDB-only, unknown relation, and NULL argument behavior.
- Update public ABI symbol allowlists and changelog.

Closes #860.

## Validation

- `meson test -C build-692 ir program public_api_macro public_api_exports public_header_surface public_prefix --print-errorlogs`
- `meson test -C build-692 log_abi_no_testhook_in_libwirelog wirelog_easy_abi_opts_symbol --print-errorlogs`
- `meson compile -C build-692`
- `git diff --check`
