### PR TITLE
fix(#811): skip clean snapshot reevaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to wirelog are documented in this file.
 
 ### Performance
 
+- **Stable snapshot fast path** (#811): clean sessions now read cached
+  materialized IDB rows directly on repeated snapshots instead of
+  re-running TDD evaluation when no input or retraction state is pending.
+
 ### Security
 
 ### Documentation

--- a/tests/test_tdd_decision_stats.c
+++ b/tests/test_tdd_decision_stats.c
@@ -61,6 +61,12 @@ typedef struct count_ctx {
 
 static int
 run_bdx_mode(decision_stats_t *stats, int use_step);
+static int
+run_bdx_repeated_snapshot(decision_stats_t *first, decision_stats_t *second,
+    int64_t *first_count, int64_t *second_count);
+static int
+run_remove_invalidates_stable_snapshot(decision_stats_t *after_remove,
+    int64_t *before_count, int64_t *after_count);
 
 static void
 count_cb(const char *relation, const int64_t *row, uint32_t ncols,
@@ -142,6 +148,140 @@ run_bdx_mode(decision_stats_t *stats, int use_step)
 }
 
 static int
+run_bdx_repeated_snapshot(decision_stats_t *first, decision_stats_t *second,
+    int64_t *first_count, int64_t *second_count)
+{
+    const char *source =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl r(x: int32, y: int32)\n"
+        "r(x, y) :- edge(x, y).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(source, &err);
+    if (!prog)
+        return 1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0 || !plan)
+        return 1;
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
+    if (rc != 0 || !sess) {
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    int64_t rows[200];
+    for (uint32_t i = 0; i < 100; i++) {
+        rows[i * 2] = (int64_t)i;
+        rows[i * 2 + 1] = (int64_t)i + 1;
+    }
+    rc = wl_session_insert(sess, "edge", rows, 100, 2);
+    if (rc == 0) {
+        count_ctx_t ctx = { 0 };
+        rc = wl_session_snapshot(sess, count_cb, &ctx);
+        *first_count = ctx.count;
+    }
+    if (rc == 0) {
+        wl_columnar_session_get_tdd_decision_stats(sess,
+            &first->recursive, &first->executed, &first->fallback,
+            &first->snapshot_ineligible, &first->no_exchange,
+            &first->unsafe_plan, &first->adaptive_workers,
+            &first->last_reason);
+    }
+    if (rc == 0) {
+        count_ctx_t ctx = { 0 };
+        rc = wl_session_snapshot(sess, count_cb, &ctx);
+        *second_count = ctx.count;
+    }
+    if (rc == 0) {
+        wl_columnar_session_get_tdd_decision_stats(sess,
+            &second->recursive, &second->executed, &second->fallback,
+            &second->snapshot_ineligible, &second->no_exchange,
+            &second->unsafe_plan, &second->adaptive_workers,
+            &second->last_reason);
+    }
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    return rc == 0 ? 0 : 1;
+}
+
+static int
+run_remove_invalidates_stable_snapshot(decision_stats_t *after_remove,
+    int64_t *before_count, int64_t *after_count)
+{
+    const char *source =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl r(x: int32, y: int32)\n"
+        "r(x, y) :- edge(x, y).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(source, &err);
+    if (!prog)
+        return 1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    if (rc != 0 || !plan)
+        return 1;
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
+    if (rc != 0 || !sess) {
+        wl_plan_free(plan);
+        return 1;
+    }
+
+    int64_t rows[200];
+    for (uint32_t i = 0; i < 100; i++) {
+        rows[i * 2] = (int64_t)i;
+        rows[i * 2 + 1] = (int64_t)i + 1;
+    }
+    rc = wl_session_insert(sess, "edge", rows, 100, 2);
+    if (rc == 0) {
+        count_ctx_t ctx = { 0 };
+        rc = wl_session_snapshot(sess, count_cb, &ctx);
+        *before_count = ctx.count;
+    }
+    if (rc == 0)
+        rc = wl_session_remove(sess, "edge", rows, 1, 2);
+    if (rc == 0) {
+        count_ctx_t ctx = { 0 };
+        rc = wl_session_snapshot(sess, count_cb, &ctx);
+        *after_count = ctx.count;
+    }
+    if (rc == 0) {
+        wl_columnar_session_get_tdd_decision_stats(sess,
+            &after_remove->recursive, &after_remove->executed,
+            &after_remove->fallback,
+            &after_remove->snapshot_ineligible,
+            &after_remove->no_exchange,
+            &after_remove->unsafe_plan,
+            &after_remove->adaptive_workers,
+            &after_remove->last_reason);
+    }
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    return rc == 0 ? 0 : 1;
+}
+
+static int
 expect(const char *name, int ok)
 {
     if (ok) {
@@ -188,6 +328,39 @@ main(void)
             && stats.adaptive_workers == 0
             && stats.last_reason
             && strcmp(stats.last_reason, "none") == 0);
+
+    decision_stats_t first;
+    decision_stats_t second;
+    int64_t first_count = 0;
+    int64_t second_count = 0;
+    memset(&first, 0, sizeof(first));
+    memset(&second, 0, sizeof(second));
+    setenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER", "1", 1);
+    failed += expect("clean repeated snapshot reads stable rows",
+            run_bdx_repeated_snapshot(&first, &second, &first_count,
+            &second_count) == 0
+            && first_count > 0
+            && second_count == first_count
+            && first.recursive == 1
+            && first.executed == 1
+            && second.recursive == 0
+            && second.executed == 0
+            && second.fallback == 0
+            && second.last_reason
+            && strcmp(second.last_reason, "none") == 0);
+
+    decision_stats_t after_remove;
+    int64_t before_remove_count = 0;
+    int64_t after_remove_count = 0;
+    memset(&after_remove, 0, sizeof(after_remove));
+    setenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER", "1", 1);
+    failed += expect("remove invalidates stable snapshot",
+            run_remove_invalidates_stable_snapshot(&after_remove,
+            &before_remove_count, &after_remove_count) == 0
+            && before_remove_count == 5050
+            && after_remove_count == 4950
+            && after_remove.recursive == 1
+            && (after_remove.executed + after_remove.fallback) == 1);
 
     unsetenv("WIRELOG_TDD_MIN_ROWS_PER_WORKER");
     return failed == 0 ? 0 : 1;

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -894,6 +894,10 @@ typedef struct wl_col_session_t {
      * stratum selection must conservatively evaluate every stratum while
      * preserving last_inserted_relation as the most recent input name. */
     bool pending_full_input_eval;
+    /* True after a successful step/snapshot has materialized stable IDB rows.
+     * A clean snapshot may enumerate those rows directly instead of running
+     * another evaluation pass. */
+    bool snapshot_stable_valid;
     /* Current fixed-point iteration counter within col_eval_stratum.
      * Set at the start of each iteration; operators use this to distinguish
      * iteration 0 (base case: FORCE_DELTA falls back to full relation) from

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -132,6 +132,7 @@ session_note_inserted_input(wl_col_session_t *sess, const char *relation,
         sess->pending_full_input_eval = true;
     sess->last_inserted_relation = relation;
     sess->pending_input_change = true;
+    sess->snapshot_stable_valid = false;
 }
 
 int
@@ -1886,6 +1887,9 @@ col_session_remove(wl_session_t *session, const char *relation,
         r->nrows = out_r;
 next_del:;
     }
+    session_invalidate_relation_caches(sess, relation);
+    sess->pending_input_change = true;
+    sess->snapshot_stable_valid = false;
     return 0;
 }
 
@@ -2136,6 +2140,12 @@ col_session_step(wl_session_t *session)
     sess->last_inserted_relation = NULL;
     sess->pending_input_change = false;
     sess->pending_full_input_eval = false;
+    for (uint32_t i = 0; i < sess->nrels; i++) {
+        col_rel_t *r = sess->rels[i];
+        if (r)
+            r->base_nrows = r->nrows;
+    }
+    sess->snapshot_stable_valid = true;
     return 0;
 }
 
@@ -2163,36 +2173,9 @@ col_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     sess->delta_data = user_data;
 }
 
-/*
- * col_session_snapshot: Evaluate all strata and emit current IDB tuples
- *
- * Implements wl_compute_backend_t.session_snapshot vtable slot.
- *
- * Evaluation order:
- *   1. Execute all strata in plan order (col_eval_stratum per stratum)
- *   2. For each IDB relation in each stratum, invoke callback once per row
- *
- * Complexity: O(S * R * N) where S=strata, R=relations per stratum, N=rows
- *
- * TODO(#811): Snapshot should read from stable R (not recompute);
- * currently re-evaluates on every call which is O(input) per snapshot.
- *
- * @param session:   wl_session_t* (cast to wl_col_session_t* internally)
- * @param callback:  Invoked once per output tuple (relation, row, ncols)
- * @param user_data: Opaque pointer passed through to callback
- * @return 0 on success, EINVAL if session/callback NULL, non-zero on eval error
- */
-static int
-col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
-    void *user_data)
+static void
+col_session_reset_snapshot_profile(wl_col_session_t *sess)
 {
-    if (!session || !callback)
-        return EINVAL;
-
-    wl_col_session_t *sess = COL_SESSION(session);
-    const wl_plan_t *plan = sess->plan;
-
-    /* Reset profiling counters for this evaluation pass */
     sess->consolidation_ns = 0;
     sess->kfusion_ns = 0;
     sess->kfusion_alloc_ns = 0;
@@ -2227,6 +2210,95 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
         sizeof(sess->tdd_fallback_reason_counts));
     sess->tdd_last_fallback_reason = WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NONE;
     sess->tdd_decision_tracking_active = false;
+}
+
+static int
+col_session_emit_snapshot(const wl_plan_t *plan, wl_col_session_t *sess,
+    wirelog_on_tuple_fn callback, void *user_data)
+{
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        const wl_plan_stratum_t *sp = &plan->strata[si];
+        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+            const char *rname = sp->relations[ri].name;
+            col_rel_t *r = session_find_rel(sess, rname);
+            if (!r || r->nrows == 0)
+                continue;
+            for (uint32_t row = 0; row < r->nrows; row++) {
+                callback(rname, col_rel_row(r, row), r->ncols,
+                    user_data);
+            }
+        }
+    }
+    return 0;
+}
+
+static void
+col_session_clear_idb_rows(const wl_plan_t *plan, wl_col_session_t *sess)
+{
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        const wl_plan_stratum_t *sp = &plan->strata[si];
+        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+            col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
+            if (!r)
+                continue;
+            r->nrows = 0;
+            r->sorted_nrows = 0;
+            r->run_count = 0;
+            r->base_nrows = 0;
+            col_session_invalidate_arrangements(&sess->base, r->name);
+        }
+    }
+    col_mat_cache_clear(&sess->mat_cache);
+}
+
+/*
+ * col_session_snapshot: Evaluate all strata and emit current IDB tuples
+ *
+ * Implements wl_compute_backend_t.session_snapshot vtable slot.
+ *
+ * Evaluation order:
+ *   1. If the session is already clean and stable, read cached IDB rows.
+ *   2. Otherwise execute all strata in plan order.
+ *   3. For each IDB relation in each stratum, invoke callback once per row
+ *
+ * Complexity: O(S * R * N) where S=strata, R=relations per stratum, N=rows
+ *
+ * Issue #811: clean snapshots read stable R without recomputing.
+ *
+ * @param session:   wl_session_t* (cast to wl_col_session_t* internally)
+ * @param callback:  Invoked once per output tuple (relation, row, ncols)
+ * @param user_data: Opaque pointer passed through to callback
+ * @return 0 on success, EINVAL if session/callback NULL, non-zero on eval error
+ */
+static int
+col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
+    void *user_data)
+{
+    if (!session || !callback)
+        return EINVAL;
+
+    wl_col_session_t *sess = COL_SESSION(session);
+    const wl_plan_t *plan = sess->plan;
+
+    /* Reset profiling counters for this evaluation pass */
+    col_session_reset_snapshot_profile(sess);
+
+    if (sess->snapshot_stable_valid
+        && !sess->pending_input_change
+        && !sess->pending_full_input_eval
+        && sess->last_inserted_relation == NULL
+        && sess->last_removed_relation == NULL
+        && !sess->delta_seeded
+        && !sess->retraction_seeded) {
+        return col_session_emit_snapshot(plan, sess, callback, user_data);
+    }
+
+    if (sess->total_iterations > 0
+        && (sess->pending_full_input_eval
+        || (sess->pending_input_change
+        && sess->last_inserted_relation == NULL))) {
+        col_session_clear_idb_rows(plan, sess);
+    }
 
     /* Phase 4 incremental skip: when last_inserted_relation is set, only
      * re-evaluate strata that transitively depend on the inserted relation.
@@ -2566,6 +2638,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     sess->delta_seeded = false;
     sess->pending_input_change = false;
     sess->pending_full_input_eval = false;
+    sess->snapshot_stable_valid = true;
 
     /* Issue #83: Update base_nrows for all relations after convergence.
      * This marks the current state as "stable" so the next incremental
@@ -2585,21 +2658,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
             col_rel_compact(r);
     }
 
-    /* Invoke callback for every tuple in every IDB relation */
-    for (uint32_t si = 0; si < plan->stratum_count; si++) {
-        const wl_plan_stratum_t *sp = &plan->strata[si];
-        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-            const char *rname = sp->relations[ri].name;
-            col_rel_t *r = session_find_rel(sess, rname);
-            if (!r || r->nrows == 0)
-                continue;
-            for (uint32_t row = 0; row < r->nrows; row++) {
-                callback(rname, col_rel_row(r, row), r->ncols,
-                    user_data);
-            }
-        }
-    }
-    return 0;
+    return col_session_emit_snapshot(plan, sess, callback, user_data);
 }
 
 /* Affected strata/rules detection moved to columnar/frontier.c;


### PR DESCRIPTION
## Summary
- record #809/#810 as not-planned decisions under the TDD-first direction outside this PR
- add a stable snapshot fast path so clean sessions enumerate cached IDB rows without re-running evaluation
- invalidate the fast path on input mutation and rebuild dirty full snapshots from cleared IDB state
- add regression coverage for repeated clean snapshots and post-remove snapshots

Fixes #811

## Review workflow
- Architect: accepted TDD-first scope and final commit
- Critic: accepted final commit after remove invalidation and stronger test
- Reviewer: accepted final commit; noted residual non-blocking risks around delta-callback retraction snapshots and filtered-IDB cache coverage

## Tests
- meson test -C build changelog_format tdd_decision_stats wirelog_easy --print-errorlogs
- uncrustify -c uncrustify.cfg --check tests/test_tdd_decision_stats.c wirelog/columnar/internal.h wirelog/columnar/session.c
- git diff --check

## Known local baseline
- On this Windows/MSVC build, session also crashes on current main with 0xc0000005 when my patch is stashed; treated as pre-existing and not caused by this PR.