### PR TITLE
[codex] Close optimizer equivalence conformance gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,21 @@ All notable changes to wirelog are documented in this file.
   multi-worker execution.  The easy-side parity annotations now point
   at the live paired advanced tests instead of a closed #785 follow-up,
   and `scripts/ci/check-test-parity.py` continues to pass.
+- **Optimizer-equivalence conformance matrix** (#700):
+  `tests/test_optimizer_equivalence.c` now exercises the 16 combinations
+  of Magic Sets, SIP, Logic Fusion, and JPP over join, recursive, and
+  aggregate programs, comparing result Z-sets against the all-enabled
+  baseline.  Magic Sets remains outside the public `wirelog_opt_pass_t`
+  enum for v0.43; the matrix names the internal `wl_*_apply` symbols
+  directly.
+- **Config-aware optimizer pipeline wiring** (#700):
+  the CLI and easy facade now call the shared `wirelog_optimize()` path
+  instead of invoking optimizer passes directly, so public optimizer config
+  behavior is exercised by user-facing pipelines.
+- **Observable aggregate-skip counters** (#700):
+  Magic Sets, SIP, Logic Fusion, and JPP stats now expose
+  `skipped_aggregate`, and aggregate IR trees are skipped instead of being
+  rewritten by passes that cannot safely transform them yet.
 - **Platform ABI advisory test registration** (#788, #681):
   the macOS advisory export check is registered only on Darwin hosts
   and the Windows advisory export check only on Windows hosts.  This
@@ -259,26 +274,11 @@ All notable changes to wirelog are documented in this file.
 ### Documentation
 
 - **`docs/SEMANTICS.md` optimizer-equivalence conformance section** (#700):
-  records the scope decision to slip Blocker B13 closure to v0.43.  Defines
-  the optimizer-equivalence matrix (4 passes × on/off = 16 toggle
-  combinations; Magic Sets via `wl_magic_sets_apply_with_demands`, SIP via
-  `wl_sip_apply`, Logic Fusion via `wl_fusion_apply`, JPP via
-  `wl_jpp_apply`; result Z-sets must equal the all-enabled baseline).
-  Documents current state: harness absent; `wirelog_opt_config_t` at
-  `wirelog/wirelog-optimizer.h:71-79` and `wirelog_optimize_with_config`
-  at `:134-137` declared but never consumed; pipelines at
-  `cli/driver.c:365-368` and `wirelog-easy.c:139-159` unconditionally
-  invoke all four passes.  Defines "all-free adornment" (Magic Sets skip
-  path at `magic_sets.c:571-575` when `bound_mask == 0`) and
-  "aggregate-skip" (Magic Sets returns 0 for AGGREGATE rules at
-  `magic_sets.c:251-275`; SIP/Fusion/JPP have no equivalent).  Records
-  taxonomy mismatch: "Magic Sets" absent from public `wirelog_opt_pass_t`
-  enum.  v0.43 plan: wire toggle config into driver + easy pipelines,
-  add `WIRELOG_OPT_MAGIC_SETS` or adopt `wl_*_apply` axis,
-  add `tests/test_optimizer_equivalence.c` (16 combos × N programs),
-  introduce new `skipped_aggregate` counters in Magic Sets, SIP, Fusion,
-  and JPP (counter does not yet exist; model after `skipped_all_free` at
-  `magic_sets.c:551`).
+  now records the implemented v0.43 conformance state: matrix harness
+  present, CLI/easy facade wired through the config-aware optimizer facade,
+  Subsumption treated as canonicalization outside the toggle axis, Magic Sets
+  kept off the public pass enum, and aggregate-skip behavior observable
+  across all four matrix passes.
 
 - **README Performance section: clarify `--repeat 5` methodology** (#736):
   fixes the stale `repeat=1` label on line 63 (now reads `--repeat 5`

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -202,7 +202,7 @@ manifest, branch-protection, signing) is tracked under v0.41+ blockers
 
 ---
 
-## Optimizer-equivalence conformance (Status: Future)
+## Optimizer-equivalence conformance (Status: Implemented)
 
 Tracked under #700. Milestone v0.43.
 
@@ -221,30 +221,23 @@ entry-point symbols are:
 | Logic Fusion | `wl_fusion_apply` |
 | JPP (Join-Project-Plan) | `wl_jpp_apply` |
 
-### Current state (v0.42)
+### Current state (v0.43)
 
-- **Harness absent.** No test in `tests/` or `scripts/` runs the matrix.
-  The equivalence property is unchecked at CI time.
-- **Toggle API declared but never consumed.** `wirelog_opt_config_t` at
-  `wirelog/wirelog-optimizer.h:71-79` exposes boolean fields
-  `enable_logic_fusion`, `enable_join_ordering`, `enable_semijoin`, and
-  `enable_subplan_sharing`. The paired entry point
-  `wirelog_optimize_with_config` is declared at `:134-137`. Neither is
-  called by any pass in `wirelog/passes/` or by any host application code.
-- **Unconditional pipelines.** The driver pipeline at
-  `wirelog/cli/driver.c:365-368` and the easy-facade pipeline at
-  `wirelog/wirelog-easy.c:139-159` unconditionally invoke all four pass
-  entry points. There is no runtime path today to disable a single pass.
-  Note: `wl_subsumption_apply` (called at `wirelog/cli/driver.c:364`,
-  before the four passes) is treated as canonicalization, not an optimizer
-  pass, and is not part of the toggle axis.
-- **Taxonomy mismatch.** The public enum `wirelog_opt_pass_t` at
+- **Harness present.** `tests/test_optimizer_equivalence.c` runs the 16-way
+  matrix over join, recursive, and aggregate programs and is registered as
+  `meson test --suite optimizer`.
+- **Toggle API consumed.** `wirelog_optimize_with_config` is the shared
+  optimizer facade for public callers. The CLI and easy facade call
+  `wirelog_optimize()`, which funnels through the config-aware path.
+- **Subsumption is canonicalization.** `wl_subsumption_apply` still runs
+  before the toggle axis and is intentionally not treated as an optimizer
+  pass in the matrix.
+- **Taxonomy decision.** The public enum `wirelog_opt_pass_t` at
   `wirelog/wirelog-optimizer.h:57-64` lists
   `WIRELOG_OPT_LOGIC_FUSION / WIRELOG_OPT_JOIN_PROJECT_PLAN /
   WIRELOG_OPT_SEMIJOIN / WIRELOG_OPT_SUBPLAN_SHARING /
-  WIRELOG_OPT_BOOLEAN_SPEC`. "Magic Sets" is absent from the enum despite
-  `wl_magic_sets_apply_with_demands` being a first-class pass in the
-  pipeline.
+  WIRELOG_OPT_BOOLEAN_SPEC`. Magic Sets remains outside that public enum for
+  v0.43; the matrix names the internal `wl_*_apply` symbols directly.
 
 ### Definition of "all-free adornment"
 
@@ -259,46 +252,17 @@ path.
 ### Definition of "aggregate-skip"
 
 When a pass encounters an AGGREGATE node it cannot safely rewrite, it must
-skip that rule entirely without miscompiling. Currently only Magic Sets
-implements this notion: `wirelog/passes/magic_sets.c:251-275` returns 0
-(skip) when the head-extraction routine encounters an AGGREGATE rule,
-leaving the rule untouched. SIP, Logic Fusion, and JPP have no aggregate
-detection and no equivalent skip path; their behavior on AGGREGATE rules is
-unspecified and untested.
+skip that rule entirely without miscompiling. Magic Sets, SIP, Logic Fusion,
+and JPP expose `skipped_aggregate` counters in their internal stats structs.
+The matrix test verifies those counters and asserts that Magic Sets leaves an
+aggregate demand untransformed.
 
-### Taxonomy reconciliation
+### v0.43 closure
 
-"Magic Sets" must be surfaced in the public API in one of two ways:
-
-1. Add `WIRELOG_OPT_MAGIC_SETS` to `wirelog_opt_pass_t` and wire it into
-   `wirelog_opt_config_t`.
-2. Express the matrix axis in terms of `wl_*_apply` symbols directly,
-   leaving the enum for the four currently-listed passes.
-
-Option 2 is preferred for clarity: the matrix test file can reference
-`wl_magic_sets_apply_with_demands` directly without requiring a new public
-enum value in a v0.43 minor release.
-
-### Path to residue = 0 in v0.43
-
-1. **Wire `wirelog_opt_config_t` into the driver and easy pipelines** —
-   replace the four unconditional call sites at `cli/driver.c:365-368` and
-   `wirelog-easy.c:139-159` with guarded calls that consult the config
-   struct. Estimated effort: 1 day.
-2. **Add `WIRELOG_OPT_MAGIC_SETS` to `wirelog_opt_pass_t`** — OR adopt
-   option 2 above and document the decision in this section.
-3. **Add `tests/test_optimizer_equivalence.c`** — drive 10–20 representative
-   programs through all 16 toggle combinations, diff result Z-sets against
-   the all-enabled baseline, and register the test under
-   `meson test --suite optimizer`.
-4. **Introduce a new `skipped_aggregate` counter in Magic Sets, SIP, Logic
-   Fusion, and JPP** — this counter does not yet exist in any pass.
-   Model it after the existing `skipped_all_free` pattern at
-   `wirelog/passes/magic_sets.c:551` and increment it whenever the pass
-   detects an AGGREGATE node it cannot handle (mirroring the silent-skip
-   already present in Magic Sets at `wirelog/passes/magic_sets.c:251-275`).
-   Once added, aggregate-skip behavior becomes observable and testable across
-   all four passes.
+The v0.43 implementation keeps Magic Sets off the public
+`wirelog_opt_pass_t` enum and expresses the conformance axis in terms of the
+internal `wl_*_apply` symbols. This avoids a public enum expansion while still
+testing the actual optimizer pipeline.
 
 ### References
 
@@ -306,8 +270,6 @@ enum value in a v0.43 minor release.
 - `wirelog/wirelog-optimizer.h:71-79` — `wirelog_opt_config_t` struct.
 - `wirelog/wirelog-optimizer.h:134-137` — `wirelog_optimize_with_config` declaration.
 - `wirelog/passes/magic_sets.c:251-275` — aggregate-skip in Magic Sets head extraction.
-- `wirelog/passes/magic_sets.c:551` — `skipped_all_free` counter (pattern to mirror for the new `skipped_aggregate` counter).
 - `wirelog/passes/magic_sets.c:571-575` — all-free adornment skip path.
-- `wirelog/cli/driver.c:365-368` — unconditional four-pass pipeline.
-- `wirelog/wirelog-easy.c:139-159` — unconditional four-pass pipeline (easy facade).
+- `tests/test_optimizer_equivalence.c` — 16-combination equivalence matrix.
 - `stable-release-plan.md` — v0.43 milestone scope.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -655,6 +655,23 @@ workqueue_src = files(
   '../wirelog/workqueue.c',
 )
 
+test_optimizer_equivalence_exe = executable(
+  'test_optimizer_equivalence',
+  files('test_optimizer_equivalence.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('optimizer_equivalence', test_optimizer_equivalence_exe, suite: 'optimizer')
+
 test_plan_gen_exe = executable(
   'test_plan_gen',
   files('test_plan_gen.c'),
@@ -3826,6 +3843,7 @@ test_wirelog_easy_exe = executable(
   thread_src,
   workqueue_src,
   '../wirelog/wirelog-easy.c',
+  '../wirelog/api_facade.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
@@ -3845,6 +3863,7 @@ test_wirelog_easy_inline_facts_exe = executable(
   thread_src,
   workqueue_src,
   '../wirelog/wirelog-easy.c',
+  '../wirelog/api_facade.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
@@ -3864,6 +3883,7 @@ test_wirelog_advanced_exe = executable(
   thread_src,
   workqueue_src,
   '../wirelog/wirelog-easy.c',
+  '../wirelog/api_facade.c',
   '../wirelog/wirelog_advanced.c',
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1837,6 +1837,7 @@ test('multi_stratum_rule_frontier', test_multi_stratum_rule_frontier_exe)
 
 driver_src = files(
   '../wirelog/cli/driver.c',
+  '../wirelog/api_facade.c',
 )
 
 test_cli_exe = executable(

--- a/tests/test_optimizer_equivalence.c
+++ b/tests/test_optimizer_equivalence.c
@@ -1,0 +1,308 @@
+/*
+ * test_optimizer_equivalence.c - Optimizer pass equivalence matrix (#700).
+ *
+ * The matrix treats Subsumption as canonicalization and toggles the four
+ * optimizer axes documented in docs/SEMANTICS.md: Magic Sets, SIP, Logic
+ * Fusion, and JPP.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/ir/program.h"
+#include "../wirelog/ir/stratify.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/magic_sets.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/passes/subsumption.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define MAX_ROWS 128
+#define MAX_COLS 4
+
+typedef struct {
+    const char *relation;
+    uint32_t ncols;
+    int64_t rows[MAX_ROWS][MAX_COLS];
+    uint32_t count;
+    bool overflow;
+} row_set_t;
+
+typedef struct {
+    bool magic_sets;
+    bool sip;
+    bool fusion;
+    bool jpp;
+} opt_flags_t;
+
+static void
+collect_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    row_set_t *set = (row_set_t *)user_data;
+    if (!relation || strcmp(relation, set->relation) != 0)
+        return;
+    if (ncols > MAX_COLS || set->count >= MAX_ROWS) {
+        set->overflow = true;
+        return;
+    }
+    set->ncols = ncols;
+    for (uint32_t i = 0; i < ncols; i++)
+        set->rows[set->count][i] = row[i];
+    set->count++;
+}
+
+static bool
+row_set_contains(const row_set_t *set, const int64_t *row)
+{
+    for (uint32_t r = 0; r < set->count; r++) {
+        bool match = true;
+        for (uint32_t c = 0; c < set->ncols; c++) {
+            if (set->rows[r][c] != row[c]) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return true;
+    }
+    return false;
+}
+
+static bool
+row_sets_equal(const row_set_t *a, const row_set_t *b)
+{
+    if (a->overflow || b->overflow || a->count != b->count
+        || a->ncols != b->ncols)
+        return false;
+    for (uint32_t i = 0; i < a->count; i++) {
+        if (!row_set_contains(b, a->rows[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool
+apply_optimizer_matrix(wirelog_program_t *prog, opt_flags_t flags)
+{
+    if (wl_subsumption_apply(prog, NULL) != 0)
+        return false;
+    if (flags.fusion && wl_fusion_apply(prog, NULL) != 0)
+        return false;
+    if (flags.jpp && wl_jpp_apply(prog, NULL) != 0)
+        return false;
+    if (flags.sip && wl_sip_apply(prog, NULL) != 0)
+        return false;
+    if (flags.magic_sets) {
+        int rc;
+        if (prog->demand_count > 0) {
+            rc = wl_magic_sets_apply_with_demands(prog, prog->demands,
+                    prog->demand_count, NULL);
+        } else {
+            rc = wl_magic_sets_apply(prog, NULL);
+        }
+        if (rc != 0)
+            return false;
+        if (prog->magic_sets_applied) {
+            if (wl_ir_program_rebuild_relation_irs(prog) != 0)
+                return false;
+            wl_ir_program_free_strata(prog);
+            if (wl_ir_stratify_program(prog) != 0)
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool
+run_program(const char *src, const char *relation, opt_flags_t flags,
+    row_set_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->relation = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return false;
+    if (!apply_optimizer_matrix(prog, flags)) {
+        wirelog_program_free(prog);
+        return false;
+    }
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
+        return false;
+    }
+
+    wl_session_t *session = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc == 0)
+        rc = wl_session_load_facts(session, prog);
+    if (rc == 0)
+        rc = wl_session_snapshot(session, collect_rows, out);
+
+    if (session)
+        wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc == 0 && !out->overflow;
+}
+
+static int
+check_matrix_case(const char *name, const char *src, const char *relation)
+{
+    opt_flags_t baseline_flags = {
+        .magic_sets = true,
+        .sip = true,
+        .fusion = true,
+        .jpp = true,
+    };
+    row_set_t baseline;
+    if (!run_program(src, relation, baseline_flags, &baseline)) {
+        printf("%s baseline ... FAIL\n", name);
+        return 1;
+    }
+
+    for (uint32_t mask = 0; mask < 16; mask++) {
+        opt_flags_t flags = {
+            .magic_sets = (mask & 0x1) != 0,
+            .sip = (mask & 0x2) != 0,
+            .fusion = (mask & 0x4) != 0,
+            .jpp = (mask & 0x8) != 0,
+        };
+        row_set_t actual;
+        if (!run_program(src, relation, flags, &actual)
+            || !row_sets_equal(&baseline, &actual)) {
+            printf("%s mask=0x%x ... FAIL\n", name, mask);
+            return 1;
+        }
+    }
+
+    printf("%s ... PASS\n", name);
+    return 0;
+}
+
+static wirelog_program_t *
+parse_aggregate_program(void)
+{
+    static const char *src =
+        ".decl val(g: int32, v: int32)\n"
+        ".decl minv(g: int32, v: int32)\n"
+        ".output minv\n"
+        ".query minv(b, f) .\n"
+        "val(1, 5).\n"
+        "val(1, 3).\n"
+        "val(2, 7).\n"
+        "minv(g, min(v)) :- val(g, v).\n";
+    wirelog_error_t err = WIRELOG_OK;
+    return wirelog_parse_string(src, &err);
+}
+
+static int
+test_aggregate_skip_stats(void)
+{
+    wirelog_program_t *prog = parse_aggregate_program();
+    if (!prog)
+        return 1;
+    wl_fusion_stats_t fusion = { 0 };
+    int failed = wl_fusion_apply(prog, &fusion) != 0
+        || fusion.skipped_aggregate == 0;
+    wirelog_program_free(prog);
+    if (failed) {
+        printf("aggregate skip: fusion ... FAIL\n");
+        return 1;
+    }
+
+    prog = parse_aggregate_program();
+    if (!prog)
+        return 1;
+    wl_jpp_stats_t jpp = { 0 };
+    failed = wl_jpp_apply(prog, &jpp) != 0 || jpp.skipped_aggregate == 0;
+    wirelog_program_free(prog);
+    if (failed) {
+        printf("aggregate skip: jpp ... FAIL\n");
+        return 1;
+    }
+
+    prog = parse_aggregate_program();
+    if (!prog)
+        return 1;
+    wl_sip_stats_t sip = { 0 };
+    failed = wl_sip_apply(prog, &sip) != 0 || sip.skipped_aggregate == 0;
+    wirelog_program_free(prog);
+    if (failed) {
+        printf("aggregate skip: sip ... FAIL\n");
+        return 1;
+    }
+
+    prog = parse_aggregate_program();
+    if (!prog)
+        return 1;
+    uint32_t relation_count_before = prog->relation_count;
+    wl_magic_sets_stats_t magic = { 0 };
+    failed = wl_magic_sets_apply_with_demands(prog, prog->demands,
+            prog->demand_count, &magic)
+        != 0
+        || magic.skipped_aggregate == 0 || prog->magic_sets_applied
+        || prog->relation_count != relation_count_before;
+    wirelog_program_free(prog);
+    if (failed) {
+        printf("aggregate skip: magic_sets ... FAIL\n");
+        return 1;
+    }
+
+    printf("aggregate skip stats ... PASS\n");
+    return 0;
+}
+
+int
+main(void)
+{
+    static const char *join_src =
+        ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl out(x: int32, z: int32)\n"
+        ".output out\n"
+        "a(1, 10).\n"
+        "a(2, 20).\n"
+        "b(10, 100).\n"
+        "b(20, 200).\n"
+        "b(30, 300).\n"
+        "out(x, z) :- a(x, y), b(y, z).\n";
+    static const char *recursive_src =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl path(x: int32, y: int32)\n"
+        ".output path\n"
+        "edge(1, 2).\n"
+        "edge(2, 3).\n"
+        "edge(3, 4).\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, y) :- edge(x, z), path(z, y).\n";
+    static const char *aggregate_src =
+        ".decl val(g: int32, v: int32)\n"
+        ".decl minv(g: int32, v: int32)\n"
+        ".output minv\n"
+        "val(1, 5).\n"
+        "val(1, 3).\n"
+        "val(2, 7).\n"
+        "minv(g, min(v)) :- val(g, v).\n";
+
+    int failed = 0;
+    failed += check_matrix_case("optimizer matrix: join", join_src, "out");
+    failed += check_matrix_case("optimizer matrix: recursive", recursive_src,
+            "path");
+    failed += check_matrix_case("optimizer matrix: aggregate", aggregate_src,
+            "minv");
+    failed += test_aggregate_skip_stats();
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/test_optimizer_equivalence.c
+++ b/tests/test_optimizer_equivalence.c
@@ -314,78 +314,6 @@ check_matrix_case(const char *name, const char *src, const char *relation,
 }
 
 static int
-check_matrix_case_magic_only(const char *name, const char *src,
-    const char *relation, matrix_expectation_t expect)
-{
-    opt_flags_t baseline_flags = {
-        .magic_sets = true,
-        .sip = true,
-        .fusion = true,
-        .jpp = true,
-    };
-    row_set_t baseline;
-    wl_fusion_stats_t fusion = { 0 };
-    wl_sip_stats_t sip = { 0 };
-    wl_jpp_stats_t jpp = { 0 };
-    wl_magic_sets_stats_t magic = { 0 };
-    bool magic_applied = false;
-
-    if (!run_program_with_stats(src, relation, baseline_flags, &baseline,
-        &fusion,
-        &sip, &jpp, &magic, &magic_applied)) {
-        printf("%s baseline ... FAIL\n", name);
-        return 1;
-    }
-
-    if (expect.expect_fusion_activity && fusion.fusions_applied == 0) {
-        printf("%s baseline ... FAIL (fusion not active)\n", name);
-        return 1;
-    }
-    if (expect.expect_sip_activity && sip.semijoins_inserted == 0) {
-        printf("%s baseline ... FAIL (SIP not active)\n", name);
-        return 1;
-    }
-    if (expect.expect_jpp_activity
-        && jpp.joins_reordered == 0
-        && jpp.projections_inserted == 0) {
-        printf("%s baseline ... FAIL (JPP not active)\n", name);
-        return 1;
-    }
-    if (expect.expect_magic_active
-        && (!magic_applied || magic.adorned_predicates == 0
-        || magic.magic_rules_generated == 0)) {
-        printf("%s baseline ... FAIL (Magic Sets not active)\n", name);
-        return 1;
-    }
-    if (expect.expect_magic_noop
-        && (magic_applied || magic.adorned_predicates != 0
-        || magic.magic_rules_generated != 0
-        || magic.original_rules_modified != 0)) {
-        printf("%s baseline ... FAIL (Magic Sets should be all-free/no-op)\n",
-            name);
-        return 1;
-    }
-
-    for (uint32_t mask = 1; mask < 16; mask += 2) {
-        opt_flags_t flags = {
-            .magic_sets = (mask & 0x1) != 0,
-            .sip = (mask & 0x2) != 0,
-            .fusion = (mask & 0x4) != 0,
-            .jpp = (mask & 0x8) != 0,
-        };
-        row_set_t actual;
-        if (!run_program(src, relation, flags, &actual)
-            || !row_sets_equal(&baseline, &actual)) {
-            printf("%s mask=0x%x ... FAIL\n", name, mask);
-            return 1;
-        }
-    }
-
-    printf("%s ... PASS\n", name);
-    return 0;
-}
-
-static int
 test_row_set_multiset_equality(void)
 {
     row_set_t expected = { 0 };
@@ -577,18 +505,20 @@ main(void)
         "c(7, 8).\n"
         "out(x, z) :- a(x, y), c(w, z), b(y, w).\n";
     static const char *bounded_magic_src =
-        ".decl p(x: int32, y: int32)\n"
         ".decl edge(x: int32, y: int32)\n"
         ".decl q(x: int32, y: int32)\n"
-        ".output p\n"
+        ".decl r(x: int32, y: int32)\n"
+        ".output q\n"
         ".query q(b, f) .\n"
-        "p(1, 10).\n"
-        "p(2, 20).\n"
+        ".query r(b, f) .\n"
+        "q(1, 1).\n"
+        "q(1, 2).\n"
         "edge(1, 2).\n"
         "edge(2, 3).\n"
         "edge(3, 4).\n"
-        "q(x, y) :- edge(x, y).\n"
-        "q(x, y) :- edge(x, z), q(z, y).\n";
+        "q(1, y) :- q(1, z), edge(z, y).\n"
+        "r(x, y) :- q(x, y).\n"
+        "r(x, y) :- edge(x, z), r(z, y).\n";
     static const char *all_free_magic_src =
         ".decl af(x: int32, y: int32)\n"
         ".decl out(x: int32, y: int32)\n"
@@ -619,7 +549,7 @@ main(void)
             expect_sip);
     failed += check_matrix_case("optimizer matrix: jpp", jpp_src, "out",
             expect_jpp);
-    failed += check_matrix_case_magic_only("optimizer matrix: bounded magic",
+    failed += check_matrix_case("optimizer matrix: bounded magic",
             bounded_magic_src,
             "q", expect_magic);
     failed += check_matrix_case("optimizer matrix: all-free magic skip",

--- a/tests/test_optimizer_equivalence.c
+++ b/tests/test_optimizer_equivalence.c
@@ -314,6 +314,78 @@ check_matrix_case(const char *name, const char *src, const char *relation,
 }
 
 static int
+check_matrix_case_magic_only(const char *name, const char *src,
+    const char *relation, matrix_expectation_t expect)
+{
+    opt_flags_t baseline_flags = {
+        .magic_sets = true,
+        .sip = true,
+        .fusion = true,
+        .jpp = true,
+    };
+    row_set_t baseline;
+    wl_fusion_stats_t fusion = { 0 };
+    wl_sip_stats_t sip = { 0 };
+    wl_jpp_stats_t jpp = { 0 };
+    wl_magic_sets_stats_t magic = { 0 };
+    bool magic_applied = false;
+
+    if (!run_program_with_stats(src, relation, baseline_flags, &baseline,
+        &fusion,
+        &sip, &jpp, &magic, &magic_applied)) {
+        printf("%s baseline ... FAIL\n", name);
+        return 1;
+    }
+
+    if (expect.expect_fusion_activity && fusion.fusions_applied == 0) {
+        printf("%s baseline ... FAIL (fusion not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_sip_activity && sip.semijoins_inserted == 0) {
+        printf("%s baseline ... FAIL (SIP not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_jpp_activity
+        && jpp.joins_reordered == 0
+        && jpp.projections_inserted == 0) {
+        printf("%s baseline ... FAIL (JPP not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_magic_active
+        && (!magic_applied || magic.adorned_predicates == 0
+        || magic.magic_rules_generated == 0)) {
+        printf("%s baseline ... FAIL (Magic Sets not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_magic_noop
+        && (magic_applied || magic.adorned_predicates != 0
+        || magic.magic_rules_generated != 0
+        || magic.original_rules_modified != 0)) {
+        printf("%s baseline ... FAIL (Magic Sets should be all-free/no-op)\n",
+            name);
+        return 1;
+    }
+
+    for (uint32_t mask = 1; mask < 16; mask += 2) {
+        opt_flags_t flags = {
+            .magic_sets = (mask & 0x1) != 0,
+            .sip = (mask & 0x2) != 0,
+            .fusion = (mask & 0x4) != 0,
+            .jpp = (mask & 0x8) != 0,
+        };
+        row_set_t actual;
+        if (!run_program(src, relation, flags, &actual)
+            || !row_sets_equal(&baseline, &actual)) {
+            printf("%s mask=0x%x ... FAIL\n", name, mask);
+            return 1;
+        }
+    }
+
+    printf("%s ... PASS\n", name);
+    return 0;
+}
+
+static int
 test_row_set_multiset_equality(void)
 {
     row_set_t expected = { 0 };
@@ -547,9 +619,9 @@ main(void)
             expect_sip);
     failed += check_matrix_case("optimizer matrix: jpp", jpp_src, "out",
             expect_jpp);
-    failed += check_matrix_case("optimizer matrix: bounded magic",
+    failed += check_matrix_case_magic_only("optimizer matrix: bounded magic",
             bounded_magic_src,
-            "p", expect_magic);
+            "q", expect_magic);
     failed += check_matrix_case("optimizer matrix: all-free magic skip",
             all_free_magic_src, "out", expect_noop_magic);
     failed += test_row_set_multiset_equality();

--- a/tests/test_optimizer_equivalence.c
+++ b/tests/test_optimizer_equivalence.c
@@ -42,6 +42,14 @@ typedef struct {
     bool jpp;
 } opt_flags_t;
 
+typedef struct {
+    bool expect_fusion_activity;
+    bool expect_sip_activity;
+    bool expect_jpp_activity;
+    bool expect_magic_active;
+    bool expect_magic_noop;
+} matrix_expectation_t;
+
 static void
 collect_rows(const char *relation, const int64_t *row, uint32_t ncols,
     void *user_data)
@@ -60,56 +68,73 @@ collect_rows(const char *relation, const int64_t *row, uint32_t ncols,
 }
 
 static bool
-row_set_contains(const row_set_t *set, const int64_t *row)
-{
-    for (uint32_t r = 0; r < set->count; r++) {
-        bool match = true;
-        for (uint32_t c = 0; c < set->ncols; c++) {
-            if (set->rows[r][c] != row[c]) {
-                match = false;
-                break;
-            }
-        }
-        if (match)
-            return true;
-    }
-    return false;
-}
-
-static bool
 row_sets_equal(const row_set_t *a, const row_set_t *b)
 {
     if (a->overflow || b->overflow || a->count != b->count
         || a->ncols != b->ncols)
         return false;
-    for (uint32_t i = 0; i < a->count; i++) {
-        if (!row_set_contains(b, a->rows[i]))
+
+    bool matched[MAX_ROWS] = { false };
+    for (uint32_t a_row = 0; a_row < a->count; a_row++) {
+        bool found = false;
+        for (uint32_t b_row = 0; b_row < b->count; b_row++) {
+            if (matched[b_row])
+                continue;
+            bool match = true;
+            for (uint32_t c = 0; c < a->ncols; c++) {
+                if (a->rows[a_row][c] != b->rows[b_row][c]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                matched[b_row] = true;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
             return false;
     }
     return true;
 }
 
 static bool
-apply_optimizer_matrix(wirelog_program_t *prog, opt_flags_t flags)
+apply_optimizer_matrix_with_stats(wirelog_program_t *prog, opt_flags_t flags,
+    wl_fusion_stats_t *fusion, wl_sip_stats_t *sip, wl_jpp_stats_t *jpp,
+    wl_magic_sets_stats_t *magic, bool *magic_applied)
 {
+    if (fusion)
+        memset(fusion, 0, sizeof(*fusion));
+    if (sip)
+        memset(sip, 0, sizeof(*sip));
+    if (jpp)
+        memset(jpp, 0, sizeof(*jpp));
+    if (magic)
+        memset(magic, 0, sizeof(*magic));
+    if (magic_applied)
+        *magic_applied = false;
+
     if (wl_subsumption_apply(prog, NULL) != 0)
         return false;
-    if (flags.fusion && wl_fusion_apply(prog, NULL) != 0)
+    if (flags.fusion && wl_fusion_apply(prog, fusion) != 0)
         return false;
-    if (flags.jpp && wl_jpp_apply(prog, NULL) != 0)
+    if (flags.jpp && wl_jpp_apply(prog, jpp) != 0)
         return false;
-    if (flags.sip && wl_sip_apply(prog, NULL) != 0)
+    if (flags.sip && wl_sip_apply(prog, sip) != 0)
         return false;
     if (flags.magic_sets) {
         int rc;
         if (prog->demand_count > 0) {
             rc = wl_magic_sets_apply_with_demands(prog, prog->demands,
-                    prog->demand_count, NULL);
+                    prog->demand_count, magic);
         } else {
-            rc = wl_magic_sets_apply(prog, NULL);
+            rc = wl_magic_sets_apply(prog, magic);
         }
         if (rc != 0)
             return false;
+        if (magic_applied)
+            *magic_applied = prog->magic_sets_applied;
         if (prog->magic_sets_applied) {
             if (wl_ir_program_rebuild_relation_irs(prog) != 0)
                 return false;
@@ -122,6 +147,14 @@ apply_optimizer_matrix(wirelog_program_t *prog, opt_flags_t flags)
 }
 
 static bool
+apply_optimizer_matrix(wirelog_program_t *prog, opt_flags_t flags)
+{
+    return apply_optimizer_matrix_with_stats(prog, flags, NULL, NULL, NULL,
+               NULL,
+               NULL);
+}
+
+static bool
 run_program(const char *src, const char *relation, opt_flags_t flags,
     row_set_t *out)
 {
@@ -130,8 +163,9 @@ run_program(const char *src, const char *relation, opt_flags_t flags,
 
     wirelog_error_t err = WIRELOG_OK;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
-    if (!prog)
+    if (!prog) {
         return false;
+    }
     if (!apply_optimizer_matrix(prog, flags)) {
         wirelog_program_free(prog);
         return false;
@@ -158,8 +192,58 @@ run_program(const char *src, const char *relation, opt_flags_t flags,
     return rc == 0 && !out->overflow;
 }
 
+static bool
+run_program_with_stats(const char *src, const char *relation, opt_flags_t flags,
+    row_set_t *out, wl_fusion_stats_t *fusion, wl_sip_stats_t *sip,
+    wl_jpp_stats_t *jpp, wl_magic_sets_stats_t *magic,
+    bool *magic_applied)
+{
+    memset(out, 0, sizeof(*out));
+    out->relation = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        return false;
+    }
+
+    if (!apply_optimizer_matrix_with_stats(prog, flags, fusion, sip, jpp, magic,
+        magic_applied)) {
+        wirelog_program_free(prog);
+        return false;
+    }
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
+        return false;
+    }
+
+    wl_session_t *session = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc == 0)
+        rc = wl_session_load_facts(session, prog);
+    if (rc == 0)
+        rc = wl_session_snapshot(session, collect_rows, out);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        if (session)
+            wl_session_destroy(session);
+        wl_plan_free(plan);
+        return false;
+    }
+
+    if (session)
+        wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc == 0 && !out->overflow;
+}
+
 static int
-check_matrix_case(const char *name, const char *src, const char *relation)
+check_matrix_case(const char *name, const char *src, const char *relation,
+    matrix_expectation_t expect)
 {
     opt_flags_t baseline_flags = {
         .magic_sets = true,
@@ -168,8 +252,45 @@ check_matrix_case(const char *name, const char *src, const char *relation)
         .jpp = true,
     };
     row_set_t baseline;
-    if (!run_program(src, relation, baseline_flags, &baseline)) {
+    wl_fusion_stats_t fusion = { 0 };
+    wl_sip_stats_t sip = { 0 };
+    wl_jpp_stats_t jpp = { 0 };
+    wl_magic_sets_stats_t magic = { 0 };
+    bool magic_applied = false;
+
+    if (!run_program_with_stats(src, relation, baseline_flags, &baseline,
+        &fusion,
+        &sip, &jpp, &magic, &magic_applied)) {
         printf("%s baseline ... FAIL\n", name);
+        return 1;
+    }
+
+    if (expect.expect_fusion_activity && fusion.fusions_applied == 0) {
+        printf("%s baseline ... FAIL (fusion not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_sip_activity && sip.semijoins_inserted == 0) {
+        printf("%s baseline ... FAIL (SIP not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_jpp_activity
+        && jpp.joins_reordered == 0
+        && jpp.projections_inserted == 0) {
+        printf("%s baseline ... FAIL (JPP not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_magic_active
+        && (!magic_applied || magic.adorned_predicates == 0
+        || magic.magic_rules_generated == 0)) {
+        printf("%s baseline ... FAIL (Magic Sets not active)\n", name);
+        return 1;
+    }
+    if (expect.expect_magic_noop
+        && (magic_applied || magic.adorned_predicates != 0
+        || magic.magic_rules_generated != 0
+        || magic.original_rules_modified != 0)) {
+        printf("%s baseline ... FAIL (Magic Sets should be all-free/no-op)\n",
+            name);
         return 1;
     }
 
@@ -189,6 +310,56 @@ check_matrix_case(const char *name, const char *src, const char *relation)
     }
 
     printf("%s ... PASS\n", name);
+    return 0;
+}
+
+static int
+test_row_set_multiset_equality(void)
+{
+    row_set_t expected = { 0 };
+    row_set_t reordered = { 0 };
+    row_set_t mismatch = { 0 };
+
+    expected.relation = "r";
+    reordered.relation = "r";
+    mismatch.relation = "r";
+    expected.ncols = 2;
+    reordered.ncols = 2;
+    mismatch.ncols = 2;
+
+    expected.rows[0][0] = 1;
+    expected.rows[0][1] = 2;
+    expected.rows[1][0] = 1;
+    expected.rows[1][1] = 2;
+    expected.rows[2][0] = 3;
+    expected.rows[2][1] = 4;
+    expected.count = 3;
+
+    reordered.rows[0][0] = 1;
+    reordered.rows[0][1] = 2;
+    reordered.rows[1][0] = 3;
+    reordered.rows[1][1] = 4;
+    reordered.rows[2][0] = 1;
+    reordered.rows[2][1] = 2;
+    reordered.count = 3;
+
+    mismatch.rows[0][0] = 1;
+    mismatch.rows[0][1] = 2;
+    mismatch.rows[1][0] = 3;
+    mismatch.rows[1][1] = 4;
+    mismatch.count = 2;
+
+    if (!row_sets_equal(&expected, &reordered)) {
+        printf("multiset row compare ... FAIL\n");
+        return 1;
+    }
+
+    if (row_sets_equal(&expected, &mismatch)) {
+        printf("multiset row compare ... FAIL (duplicates ignored)\n");
+        return 1;
+    }
+
+    printf("multiset row compare ... PASS\n");
     return 0;
 }
 
@@ -296,13 +467,92 @@ main(void)
         "val(1, 3).\n"
         "val(2, 7).\n"
         "minv(g, min(v)) :- val(g, v).\n";
+    static const char *fusion_src =
+        ".decl a(x: int32, y: int32)\n"
+        ".decl out(x: int32)\n"
+        ".output out\n"
+        "a(1, 10).\n"
+        "a(2, 20).\n"
+        "out(x) :- a(x, y), y > 0.\n";
+    static const char *sip_src =
+        ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl c(z: int32, w: int32)\n"
+        ".decl out(x: int32, w: int32)\n"
+        ".output out\n"
+        "a(1, 2).\n"
+        "a(2, 3).\n"
+        "a(3, 4).\n"
+        "b(2, 5).\n"
+        "b(3, 6).\n"
+        "b(4, 7).\n"
+        "c(5, 10).\n"
+        "c(6, 11).\n"
+        "c(7, 12).\n"
+        "out(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+    static const char *jpp_src =
+        ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl c(w: int32, z: int32)\n"
+        ".decl out(x: int32, z: int32)\n"
+        ".output out\n"
+        "a(1, 2).\n"
+        "a(1, 3).\n"
+        "b(2, 4).\n"
+        "b(3, 5).\n"
+        "b(4, 6).\n"
+        "c(6, 7).\n"
+        "c(7, 8).\n"
+        "out(x, z) :- a(x, y), c(w, z), b(y, w).\n";
+    static const char *bounded_magic_src =
+        ".decl p(x: int32, y: int32)\n"
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl q(x: int32, y: int32)\n"
+        ".output p\n"
+        ".query q(b, f) .\n"
+        "p(1, 10).\n"
+        "p(2, 20).\n"
+        "edge(1, 2).\n"
+        "edge(2, 3).\n"
+        "edge(3, 4).\n"
+        "q(x, y) :- edge(x, y).\n"
+        "q(x, y) :- edge(x, z), q(z, y).\n";
+    static const char *all_free_magic_src =
+        ".decl af(x: int32, y: int32)\n"
+        ".decl out(x: int32, y: int32)\n"
+        ".output out\n"
+        ".query af(f, f) .\n"
+        "out(x, y) :- af(x, y).\n"
+        "af(1, 10).\n"
+        "af(2, 20).\n"
+        "af(2, 20).\n";
 
     int failed = 0;
-    failed += check_matrix_case("optimizer matrix: join", join_src, "out");
+    matrix_expectation_t expect_none = { 0, 0, 0, 0, 1 };
+    matrix_expectation_t expect_fusion = { 1, 0, 0, 0, 0 };
+    matrix_expectation_t expect_sip = { 0, 1, 0, 0, 0 };
+    matrix_expectation_t expect_jpp = { 0, 0, 1, 0, 0 };
+    matrix_expectation_t expect_noop_magic = { 0, 0, 0, 0, 1 };
+    matrix_expectation_t expect_magic = { 0, 0, 0, 1, 0 };
+
+    failed += check_matrix_case("optimizer matrix: join", join_src, "out",
+            expect_none);
     failed += check_matrix_case("optimizer matrix: recursive", recursive_src,
-            "path");
+            "path", expect_none);
     failed += check_matrix_case("optimizer matrix: aggregate", aggregate_src,
-            "minv");
+            "minv", expect_none);
+    failed += check_matrix_case("optimizer matrix: fusion", fusion_src, "out",
+            expect_fusion);
+    failed += check_matrix_case("optimizer matrix: sip", sip_src, "out",
+            expect_sip);
+    failed += check_matrix_case("optimizer matrix: jpp", jpp_src, "out",
+            expect_jpp);
+    failed += check_matrix_case("optimizer matrix: bounded magic",
+            bounded_magic_src,
+            "p", expect_magic);
+    failed += check_matrix_case("optimizer matrix: all-free magic skip",
+            all_free_magic_src, "out", expect_noop_magic);
+    failed += test_row_set_multiset_equality();
     failed += test_aggregate_skip_stats();
     return failed == 0 ? 0 : 1;
 }

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -77,6 +77,49 @@ test_optimizer_api(void)
 }
 
 static int
+test_optimizer_config_disable_passes(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "edge(1,2).\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "parse failed err=%d\n", err);
+        return 1;
+    }
+
+    wirelog_opt_config_t config = wirelog_optimizer_get_default_config();
+    config.enable_logic_fusion = false;
+    config.enable_join_ordering = false;
+    config.enable_semijoin = false;
+    config.enable_subplan_sharing = false;
+    config.enable_boolean_spec = false;
+
+    if (!wirelog_optimize_with_config(program, &config, &err)
+        || err != WIRELOG_OK) {
+        fprintf(stderr, "optimize_with_config failed err=%d\n", err);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_opt_stats_t stats = { 0 };
+    if (!wirelog_optimizer_get_stats(program, &stats)
+        || stats.passes_applied != 0) {
+        fprintf(stderr, "disabled optimizer config applied %" PRIu32
+            " pass(es)\n",
+            stats.passes_applied);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_program_free(program);
+    return 0;
+}
+
+static int
 test_executor_result_api(void)
 {
     const char *src =
@@ -136,6 +179,7 @@ main(void)
     int failures = 0;
     failures += test_utility_api();
     failures += test_optimizer_api();
+    failures += test_optimizer_config_disable_passes();
     failures += test_executor_result_api();
     if (failures == 0)
         printf("test_wirelog_public_api: OK\n");

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -15,12 +15,6 @@
 #include "../exec_plan_gen.h"
 #include "../intern.h"
 #include "../ir/program.h"
-#include "../ir/stratify.h"
-#include "../passes/fusion.h"
-#include "../passes/jpp.h"
-#include "../passes/magic_sets.h"
-#include "../passes/sip.h"
-#include "../passes/subsumption.h"
 #include "../session.h"
 #include "../session_facts.h"
 #include "../wirelog.h"
@@ -361,18 +355,10 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
     }
 
     /* 2. Optimize */
-    wl_subsumption_apply(prog, NULL);
-    wl_fusion_apply(prog, NULL);
-    wl_jpp_apply(prog, NULL);
-    wl_sip_apply(prog, NULL);
-    wl_magic_sets_apply_with_demands(prog, prog->demands, prog->demand_count,
-        NULL);
-
-    /* 2a. Rebuild relation IR and re-stratify after magic sets */
-    if (prog->magic_sets_applied) {
-        wl_ir_program_rebuild_relation_irs(prog);
-        wl_ir_program_free_strata(prog);
-        wl_ir_stratify_program(prog);
+    if (!wirelog_optimize(prog, &err)) {
+        fprintf(stderr, "Optimization failed: err=%d\n", err);
+        wirelog_program_free(prog);
+        return -1;
     }
 
     /* 3. Generate execution plan */

--- a/wirelog/passes/fusion.c
+++ b/wirelog/passes/fusion.c
@@ -26,6 +26,7 @@
 #include "../ir/ir.h"
 #include "../ir/program.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -55,6 +56,20 @@ count_all_nodes(const struct wirelog_program *prog)
         total += wl_fusion_count_nodes(prog->relation_irs[i]);
     }
     return total;
+}
+
+static bool
+contains_aggregate(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return false;
+    if (node->type == WIRELOG_IR_AGGREGATE)
+        return true;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (contains_aggregate(node->children[i]))
+            return true;
+    }
+    return false;
 }
 
 /* ======================================================================== */
@@ -145,16 +160,22 @@ wl_fusion_apply(struct wirelog_program *prog, wl_fusion_stats_t *stats)
             stats->nodes_before = 0;
             stats->nodes_after = 0;
             stats->fusions_applied = 0;
+            stats->skipped_aggregate = 0;
         }
         return 0;
     }
 
     uint32_t nodes_before = count_all_nodes(prog);
     uint32_t total_fusions = 0;
+    uint32_t skipped_aggregate = 0;
 
     /* Walk each relation's merged IR tree */
     for (uint32_t i = 0; i < prog->relation_count; i++) {
         if (prog->relation_irs[i]) {
+            if (contains_aggregate(prog->relation_irs[i])) {
+                skipped_aggregate++;
+                continue;
+            }
             total_fusions += try_fuse_node(&prog->relation_irs[i]);
         }
     }
@@ -165,6 +186,7 @@ wl_fusion_apply(struct wirelog_program *prog, wl_fusion_stats_t *stats)
         stats->nodes_before = nodes_before;
         stats->nodes_after = nodes_after;
         stats->fusions_applied = total_fusions;
+        stats->skipped_aggregate = skipped_aggregate;
     }
 
     return 0;

--- a/wirelog/passes/fusion.h
+++ b/wirelog/passes/fusion.h
@@ -48,11 +48,13 @@ struct wirelog_ir_node;
  * @nodes_before:       Total IR nodes before fusion.
  * @nodes_after:        Total IR nodes after fusion.
  * @fusions_applied:    Number of FLATMAP fusions performed.
+ * @skipped_aggregate:  IR trees skipped because they contain AGGREGATE.
  */
 typedef struct {
     uint32_t nodes_before;
     uint32_t nodes_after;
     uint32_t fusions_applied;
+    uint32_t skipped_aggregate;
 } wl_fusion_stats_t;
 
 /* ======================================================================== */

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -909,6 +909,20 @@ optimize_tree(wirelog_ir_node_t *ir, uint32_t *chains_examined,
     *projections_inserted += result.projections_inserted;
 }
 
+static bool
+contains_aggregate(const wirelog_ir_node_t *ir)
+{
+    if (!ir)
+        return false;
+    if (ir->type == WIRELOG_IR_AGGREGATE)
+        return true;
+    for (uint32_t i = 0; i < ir->child_count; i++) {
+        if (contains_aggregate(ir->children[i]))
+            return true;
+    }
+    return false;
+}
+
 /* ======================================================================== */
 /* Public API                                                               */
 /* ======================================================================== */
@@ -924,6 +938,7 @@ wl_jpp_apply(struct wirelog_program *prog, wl_jpp_stats_t *stats)
             stats->joins_reordered = 0;
             stats->projections_inserted = 0;
             stats->chains_examined = 0;
+            stats->skipped_aggregate = 0;
         }
         return 0;
     }
@@ -931,6 +946,7 @@ wl_jpp_apply(struct wirelog_program *prog, wl_jpp_stats_t *stats)
     uint32_t chains_examined = 0;
     uint32_t joins_reordered = 0;
     uint32_t projections_inserted = 0;
+    uint32_t skipped_aggregate = 0;
 
     /* Build de-duplicated IDB relation name list for EDB tie-breaking.
      * A relation is IDB iff it appears as the head of at least one rule. */
@@ -958,6 +974,10 @@ wl_jpp_apply(struct wirelog_program *prog, wl_jpp_stats_t *stats)
     }
 
     for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (contains_aggregate(prog->relation_irs[i])) {
+            skipped_aggregate++;
+            continue;
+        }
         optimize_tree(prog->relation_irs[i], &chains_examined, &joins_reordered,
             &projections_inserted, idb_names, idb_count);
     }
@@ -968,6 +988,7 @@ wl_jpp_apply(struct wirelog_program *prog, wl_jpp_stats_t *stats)
         stats->joins_reordered = joins_reordered;
         stats->projections_inserted = projections_inserted;
         stats->chains_examined = chains_examined;
+        stats->skipped_aggregate = skipped_aggregate;
     }
 
     return 0;

--- a/wirelog/passes/jpp.h
+++ b/wirelog/passes/jpp.h
@@ -44,11 +44,13 @@ struct wirelog_ir_node;
  * @joins_reordered:       Number of join chains that were reordered.
  * @projections_inserted:  Number of intermediate PROJECT nodes inserted.
  * @chains_examined:       Total join chains examined.
+ * @skipped_aggregate:     IR trees skipped because they contain AGGREGATE.
  */
 typedef struct {
     uint32_t joins_reordered;
     uint32_t projections_inserted;
     uint32_t chains_examined;
+    uint32_t skipped_aggregate;
 } wl_jpp_stats_t;
 
 /* ======================================================================== */

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -172,6 +172,22 @@ is_idb(const struct wirelog_program *prog, const char *rel_name)
     return false;
 }
 
+static bool
+relation_has_aggregate_rule(const struct wirelog_program *prog,
+    const char *rel_name)
+{
+    if (!prog || !rel_name)
+        return false;
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (prog->rules[i].head_relation
+            && strcmp(prog->rules[i].head_relation, rel_name) == 0
+            && prog->rules[i].ir_root
+            && prog->rules[i].ir_root->type == WIRELOG_IR_AGGREGATE)
+            return true;
+    }
+    return false;
+}
+
 static uint32_t
 get_arity(const struct wirelog_program *prog, const char *rel_name)
 {
@@ -550,6 +566,7 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
         stats->original_rules_modified = 0;
         stats->skipped_all_free = 0;
         stats->arity_mismatch_skipped = 0;
+        stats->skipped_aggregate = 0;
     }
 
     /* === Phase 1: Seed the worklist from explicit demands === */
@@ -572,6 +589,12 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
             if (stats)
                 stats->skipped_all_free++;
             continue; /* All-free optimization: skip */
+        }
+
+        if (relation_has_aggregate_rule(prog, d->relation_name)) {
+            if (stats)
+                stats->skipped_aggregate++;
+            continue;
         }
 
         uint32_t arity = d->arity;
@@ -632,6 +655,12 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
                     goto next_atom;
 
                 if (is_idb(prog, atom->rel_name)) {
+                    if (relation_has_aggregate_rule(prog, atom->rel_name)) {
+                        if (stats)
+                            stats->skipped_aggregate++;
+                        goto next_atom;
+                    }
+
                     /* Compute adornment of this IDB body atom */
                     uint64_t atom_mask = 0;
                     for (uint32_t ci = 0; ci < atom->col_count && ci < 64;

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -46,6 +46,8 @@ struct wirelog_program;
  * @original_rules_modified: Original rules with magic guards inserted.
  * @skipped_all_free:       Adorned predicates skipped (all-free adornment).
  * @arity_mismatch_skipped: Demands skipped due to adornment count/arity mismatch.
+ * @skipped_aggregate:     Aggregate rules skipped because Magic Sets cannot
+ *                         safely insert magic guards into them yet.
  */
 typedef struct {
     uint32_t demand_roots;
@@ -54,6 +56,7 @@ typedef struct {
     uint32_t original_rules_modified;
     uint32_t skipped_all_free;
     uint32_t arity_mismatch_skipped;
+    uint32_t skipped_aggregate;
 } wl_magic_sets_stats_t;
 
 /* ======================================================================== */

--- a/wirelog/passes/sip.c
+++ b/wirelog/passes/sip.c
@@ -32,6 +32,7 @@
 #include "../ir/ir.h"
 #include "../ir/program.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -124,10 +125,24 @@ count_join_depth(const wirelog_ir_node_t *node)
             node = (node->child_count > 0) ? node->children[0] : NULL;
         /* Skip over any PROJECT inserted by JPP between joins */
         while (node && node->type == WIRELOG_IR_PROJECT
-               && node->child_count > 0)
+            && node->child_count > 0)
             node = node->children[0];
     }
     return depth;
+}
+
+static bool
+contains_aggregate(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return false;
+    if (node->type == WIRELOG_IR_AGGREGATE)
+        return true;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (contains_aggregate(node->children[i]))
+            return true;
+    }
+    return false;
 }
 
 /* ======================================================================== */
@@ -288,6 +303,7 @@ wl_sip_apply(struct wirelog_program *prog, wl_sip_stats_t *stats)
         stats->semijoins_inserted = 0;
         stats->chains_examined = 0;
         stats->demand_semijoins_inserted = 0;
+        stats->skipped_aggregate = 0;
     }
 
     if (!prog->relation_irs)
@@ -295,6 +311,11 @@ wl_sip_apply(struct wirelog_program *prog, wl_sip_stats_t *stats)
 
     for (uint32_t i = 0; i < prog->relation_count; i++) {
         if (prog->relation_irs[i]) {
+            if (contains_aggregate(prog->relation_irs[i])) {
+                if (stats)
+                    stats->skipped_aggregate++;
+                continue;
+            }
             int rc = sip_process_tree(prog->relation_irs[i], stats);
             if (rc != 0)
                 return rc;

--- a/wirelog/passes/sip.h
+++ b/wirelog/passes/sip.h
@@ -43,11 +43,13 @@ struct wirelog_program;
  * @demand_semijoins_inserted: Number of demand SEMIJOIN nodes inserted for
  *                             2-atom joins with recursive left scans
  *                             (demand-driven filtering, Issue #192).
+ * @skipped_aggregate:         IR trees skipped because they contain AGGREGATE.
  */
 typedef struct {
     uint32_t semijoins_inserted;
     uint32_t chains_examined;
     uint32_t demand_semijoins_inserted;
+    uint32_t skipped_aggregate;
 } wl_sip_stats_t;
 
 /**

--- a/wirelog/wirelog-easy.c
+++ b/wirelog/wirelog-easy.c
@@ -26,9 +26,6 @@
 #include "wirelog/exec_plan.h"
 #include "wirelog/exec_plan_gen.h"
 #include "wirelog/intern.h"
-#include "wirelog/passes/fusion.h"
-#include "wirelog/passes/jpp.h"
-#include "wirelog/passes/sip.h"
 #include "wirelog/session.h"
 #include "wirelog/session_facts.h"
 #include "wirelog/wirelog-parser.h"
@@ -87,11 +84,9 @@ ensure_plan_built(wirelog_easy_session_t *s, uint32_t num_workers)
 
     /* Issue #718: seed inline `.dl` facts into the freshly built session
      * so snapshots and IDB derivations observe them.  This mirrors the
-     * fact-load step of the CLI driver's session-build sequence
-     * (cli/driver.c:397); the wider optimizer pipeline alignment
-     * between wirelog_easy (fusion + jpp + sip) and the CLI (which also
-     * runs subsumption + magic_sets) is tracked separately and is not
-     * in scope here.  The load runs exactly once on the lazy
+     * fact-load step of the CLI driver's session-build sequence.  The
+     * optimizer pipeline is shared with the CLI via wirelog_optimize().
+     * The load runs exactly once on the lazy
      * plan/session boundary, before any host delta callback can be
      * installed, so col_session_insert takes the non-incremental path:
      * no spurious static deltas on the first step() and no outer-epoch
@@ -131,31 +126,11 @@ wirelog_easy_open_opts(const char *dl_src, const wirelog_easy_open_opts_t *opts,
     if (!prog)
         return (err != WIRELOG_OK) ? err : WIRELOG_ERR_PARSE;
 
-    /* Optimizer passes return 0 on success and negative rc on failure
-     * (see passes/fusion.h, passes/jpp.h, passes/sip.h).  A silent
-     * discard would leave the caller to discover the failure at plan
-     * build time with a misleading WIRELOG_ERR_EXEC; surface the real
-     * cause up front instead. */
-    int pass_rc = wl_fusion_apply(prog, NULL);
-    if (pass_rc != 0) {
-        fprintf(stderr,
-            "wirelog_easy_open: wl_fusion_apply failed (rc=%d)\n", pass_rc);
+    err = WIRELOG_OK;
+    if (!wirelog_optimize(prog, &err)) {
+        fprintf(stderr, "wirelog_easy_open: optimize failed (err=%d)\n", err);
         wirelog_program_free(prog);
-        return WIRELOG_ERR_EXEC;
-    }
-    pass_rc = wl_jpp_apply(prog, NULL);
-    if (pass_rc != 0) {
-        fprintf(stderr,
-            "wirelog_easy_open: wl_jpp_apply failed (rc=%d)\n", pass_rc);
-        wirelog_program_free(prog);
-        return WIRELOG_ERR_EXEC;
-    }
-    pass_rc = wl_sip_apply(prog, NULL);
-    if (pass_rc != 0) {
-        fprintf(stderr,
-            "wirelog_easy_open: wl_sip_apply failed (rc=%d)\n", pass_rc);
-        wirelog_program_free(prog);
-        return WIRELOG_ERR_EXEC;
+        return (err != WIRELOG_OK) ? err : WIRELOG_ERR_EXEC;
     }
 
     wirelog_easy_session_t *s
@@ -259,7 +234,8 @@ wirelog_easy_make_compound(wirelog_easy_session_t *s, const char *functor,
 /* ======================================================================== */
 
 wirelog_error_t
-wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation,
+    const int64_t *row,
     uint32_t ncols)
 {
     if (!s || !relation || !row)
@@ -272,7 +248,8 @@ wirelog_easy_insert(wirelog_easy_session_t *s, const char *relation, const int64
 }
 
 wirelog_error_t
-wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64_t *row,
+wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation,
+    const int64_t *row,
     uint32_t ncols)
 {
     if (!s || !relation || !row)
@@ -289,7 +266,8 @@ wirelog_easy_remove(wirelog_easy_session_t *s, const char *relation, const int64
 /* ======================================================================== */
 
 static wirelog_error_t
-collect_sym_row(wirelog_easy_session_t *s, va_list ap, int64_t *row, uint32_t *ncols)
+collect_sym_row(wirelog_easy_session_t *s, va_list ap, int64_t *row,
+    uint32_t *ncols)
 {
     uint32_t n = 0;
     while (n < WIRELOG_EASY_MAX_COLS) {
@@ -381,7 +359,8 @@ column_is_string(wirelog_column_type_t t)
 }
 
 void
-wirelog_easy_print_delta(const char *relation, const int64_t *row, uint32_t ncols,
+wirelog_easy_print_delta(const char *relation, const int64_t *row,
+    uint32_t ncols,
     int32_t diff, void *user_data)
 {
     wirelog_easy_session_t *s = (wirelog_easy_session_t *)user_data;
@@ -453,7 +432,8 @@ static void
 snapshot_trampoline(const char *relation, const int64_t *row, uint32_t ncols,
     void *user_data)
 {
-    wirelog_easy_snapshot_filter_t *f = (wirelog_easy_snapshot_filter_t *)user_data;
+    wirelog_easy_snapshot_filter_t *f =
+        (wirelog_easy_snapshot_filter_t *)user_data;
     if (!relation || !f || !f->wanted)
         return;
     if (strcmp(relation, f->wanted) != 0)

--- a/wirelog/wirelog-easy.h
+++ b/wirelog/wirelog-easy.h
@@ -133,8 +133,8 @@ wirelog_easy_open_opts(const char *dl_src,
  * @dl_src: Datalog source text (must not be NULL).
  * @out:    (out) Receives the new session handle on success.
  *
- * Parse @dl_src, run the standard optimizer passes (fusion, jpp, sip), and
- * return a session handle.  The execution plan and underlying session are
+ * Parse @dl_src, run the standard optimizer pipeline, and return a session
+ * handle.  The execution plan and underlying session are
  * built lazily on the first call to wirelog_easy_insert/remove/step/set_delta_cb.
  * Symbol interning via wirelog_easy_intern() may happen before or after that
  * first step-class call; the intern table is shared through the whole


### PR DESCRIPTION
## Summary

Closes #700.

- routes CLI and easy facade optimization through the shared config-aware `wirelog_optimize()` path
- adds an optimizer-equivalence matrix test for Magic Sets, SIP, Logic Fusion, and JPP across all 16 on/off combinations
- strengthens the matrix with pass-activity assertions, bounded/all-free Magic Sets coverage, aggregate-skip assertions, and multiplicity-aware row comparison
- exposes `skipped_aggregate` stats for Magic Sets, SIP, Logic Fusion, and JPP
- updates #700 documentation/changelog state for v0.43

## Validation

```bash
meson test -C builddir fusion jpp sip magic_sets wirelog_public_api optimizer_equivalence wirelog_easy wirelog_easy_inline_facts wirelog_advanced cli cli_watch cli_delta standalone_include_wirelog_easy standalone_include_wirelog_optimizer public_api_macro --print-errorlogs
```

Result: `15/15 OK`.

Also checked:

```bash
git diff --check origin/main..HEAD
```

## Workflow Review

Implementation-workflow gates completed:

- Implementer atomic commits created for the initial #700 closure, CLI test link fix, matrix strengthening, and bounded Magic fixture correction.
- Reviewer blocked the CLI link regression and two bounded Magic false-positive cases; each blocker was fixed in a follow-up atomic commit.
- Architect and Critic verified the final reviewer outcomes and agreed the units can stand.

