### PR TITLE
[codex] Declare mobile artifacts Tier-2 for 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ All notable changes to wirelog are documented in this file.
   name and its PR, main-monitoring, `release-1.x`, and release-tag
   roles without changing the default `mbedTLS=disabled` artifact
   posture (#849).
+- Added `docs/PLATFORM_SUPPORT.md` to classify Android/iOS release
+  artifacts as Tier-2 for 1.x, documenting that Android AAR/Prefab and
+  iOS XCFramework publication are deferred until explicit future
+  promotion work is completed.
 
 ## [0.41.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to wirelog are documented in this file.
 - Added `docs/PLATFORM_SUPPORT.md` to classify Android/iOS release
   artifacts as Tier-2 for 1.x, documenting that Android AAR/Prefab and
   iOS XCFramework publication are deferred until explicit future
-  promotion work is completed.
+  promotion work is completed (#697).
 
 ## [0.41.0] - 2026-05-20
 

--- a/docs/PLATFORM_SUPPORT.md
+++ b/docs/PLATFORM_SUPPORT.md
@@ -1,0 +1,33 @@
+# Platform Support and Release Artifacts Policy
+
+This policy defines what **Android** and **iOS** support means for the
+`1.x` series while release blockers remain scoped to buildability and test
+coverage.
+
+## Current status for 1.x
+
+For wirelog `1.x`, Android and iOS source cross-builds and basic smoke checks
+exist and remain supported. Release packaging for those platforms is explicitly
+**Tier-2** and deferred.
+
+## What is intentionally not required in 1.0 GA
+
+- No Android AAR/Prefab artifact is required.
+- No published iOS `wirelog.xcframework` is required.
+- Neither item is a release-blocking requirement for `1.0` GA.
+- #697 does not require these artifacts to ship in GA.
+
+## Required work before promotion
+
+Before any promotion of Android and iOS packaging beyond this policy, the
+following work is required:
+
+- Android: AAR/Prefab packaging in release artifacts.
+- iOS: XCFramework release artifact production.
+- Smoke-tested downstream consumer projects for Android/iOS.
+- Release automation for those package pipelines.
+
+## Known follow-ups (not #697 blockers)
+
+Issues #466, #470, #728, and #729 remain scheduled follow-up work and are
+not blockers for #697 completion.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -30,6 +30,9 @@ publication procedure) and is referenced by **#687** (v1.0.0 GA
 epic) which lists "CHANGELOG `[1.0.0]` section merged" as an exit
 condition without specifying the publication side.
 
+- Platform artifact policies for **Android** and **iOS** are tracked in
+  [`docs/PLATFORM_SUPPORT.md`](PLATFORM_SUPPORT.md).
+
 ---
 
 ## 1. Release-note template


### PR DESCRIPTION
## Summary
- add docs/PLATFORM_SUPPORT.md declaring Android/iOS packaged release artifacts Tier-2 for 1.x
- document that Android AAR/Prefab and iOS XCFramework publication are not 1.0 GA blockers
- link the policy from the release process and record the decision in the changelog

Closes #697

## Validation
- rg -n "Android|iOS|Tier-2|1\.x|AAR|XCFramework|#697" docs/ CHANGELOG.md
- . .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md
- meson test -C builddir changelog_format release_template --print-errorlogs
- meson test -C builddir release_template --print-errorlogs
- git diff --check