### PR TITLE
Numerical safety: fail closed on arithmetic overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **Numerical safety fail-closed policy** (#822): columnar arithmetic
+  now rejects unrepresentable `int64` results instead of wrapping,
+  saturating, or leaking undefined behavior. Filters fail closed by
+  rejecting rows; MAP/head and REDUCE expression contexts propagate
+  `ERANGE`. The policy covers checked `+`, `-`, `*`, `/`, `%`,
+  `bshl`, `bshr`, checked `to_number()` range parsing, and `sum()`
+  accumulation, with the audit recorded in `docs/SEMANTICS.md`.
+
 ### Deprecated
 
 ### Removed

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -159,6 +159,75 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
 
 ---
 
+## Numerical fail-closed arithmetic (Status: Current)
+
+Tracked under #822. Milestone v0.43.
+
+### Rule
+
+Columnar expression evaluation is fail-closed for integer conditions
+that cannot be represented as an `int64_t` result:
+
+- `+`, `-`, and `*` use checked `int64_t` arithmetic.
+- `/` and `%` reject divide-by-zero and the `INT64_MIN / -1`
+  representability overflow.
+- `bshl` and `bshr` reject negative shift counts and shift counts
+  greater than or equal to 64.
+- `to_number()` inside columnar expressions rejects numeric prefixes
+  outside the `int64_t` range.  Non-numeric and empty strings remain a
+  successful conversion to `0`; numeric prefixes such as `"42abc"`
+  still parse the leading number.
+
+The failure mode depends on the operator context:
+
+- `FILTER` predicates reject the row and continue evaluation.
+- `MAP`/head expressions return `ERANGE` to the caller.
+- `REDUCE` aggregate expressions and `sum()` accumulation return
+  `ERANGE` to the caller.
+
+Bitwise `band`, `bor`, `bxor`, and `bnot` are total over the stored
+`int64_t` bit pattern.  Hash, CRC, crypto digest, HMAC, and UUID
+built-ins define their own folding or availability behavior and are not
+overflow-prone arithmetic operators under this rule.
+
+### Audit notes
+
+- `wirelog/columnar/ops.c` is the runtime enforcement point.  Both the
+  slow bytecode evaluator and compiled evaluator share checked
+  arithmetic helpers for `+`, `-`, `*`, `/`, `%`, `bshl`, and `bshr`.
+  The filter path fails closed by row rejection; MAP and REDUCE paths
+  propagate expression failure as `ERANGE`.
+- `wirelog/string_ops.c` keeps the legacy `string_ops_to_number()`
+  saturation behavior for direct internal callers, but exposes
+  `wl_string_ops_to_number_checked()` for columnar expression
+  evaluation.  The checked helper rejects `int64_t` range errors with
+  `ERANGE`.
+- `wirelog/passes/` rewrites and annotates IR but does not perform
+  runtime integer arithmetic for Datalog expression results.  The
+  serialized expression tags from `wirelog/exec_plan_gen.c` are
+  evaluated by the columnar runtime described above.
+- `col_op_reduce_weighted()` remains a weighted Z-set helper for signed
+  multiplicity accounting, not a Datalog arithmetic expression
+  evaluator.  It is outside the #822 user-expression fail-closed
+  contract.
+
+### Coverage
+
+`tests/test_arithmetic_overflow.c` covers overflow and invalid
+arithmetic in filters, MAP/head expressions, REDUCE aggregate
+expressions, `sum()` accumulation, shift bounds, and checked
+`to_number()` range errors.  `tests/test_string_ops.c` covers the
+checked and legacy `to_number()` contracts.
+
+### References
+
+- Issue #822 — numerical safety unified: overflow -> fail-closed.
+- `wirelog/columnar/ops.c` — runtime expression evaluators and REDUCE.
+- `wirelog/string_ops.c` — checked `to_number()` helper.
+- `tests/test_arithmetic_overflow.c` and `tests/test_string_ops.c`.
+
+---
+
 ## v0.40 API audit closure (Status: Current)
 
 The v0.40 API audit (epic #680, Risk-C and Blocker-B series catalogued

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -186,8 +186,8 @@ The failure mode depends on the operator context:
   `ERANGE` to the caller.
 
 Bitwise `band`, `bor`, `bxor`, and `bnot` are total over the stored
-`int64_t` bit pattern.  Hash, CRC, crypto digest, HMAC, and UUID
-built-ins define their own folding or availability behavior and are not
+`int64_t` bit pattern.  Hash, crypto digest, HMAC, and UUID built-ins
+define their own folding or availability behavior and are not
 overflow-prone arithmetic operators under this rule.
 
 ### Audit notes

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -199,21 +199,19 @@ Supported column types:
 digest/HMAC built-ins also return `int64` values: digest or HMAC
 bytes are folded with `XXH3_64bits()` and are not exposed as hex
 strings or byte arrays. With `mbedTLS=disabled`, the crypto built-ins
-parse and plan; when they are used to compute relation values, the
-runtime fallback value is `0`. Some predicate/filter paths, including
-top-level filters, may pass rows through on disabled-crypto evaluator
-errors, so disabled crypto calls must not be used in predicates or
-security checks.
+parse and plan; when they are used to compute relation values or
+predicates without crypto support, columnar expression evaluation fails
+closed. Filters reject the row, while MAP/head and REDUCE expression
+contexts return an evaluation error.
 
 ### UUID Functions
 
 `uuid4()`, `uuid5(namespace, name)`
 
 The UUID built-ins require mbedTLS for non-zero runtime output and
-return the first 8 UUID bytes as an `int64`, not formatted text. With
-`mbedTLS=disabled`, relation-value computations fall back to `0`;
-disabled UUID calls in predicate/filter expressions follow the same
-error-handling warning described for crypto hash functions.
+return the first 8 UUID bytes as an `int64`, not formatted text.
+Disabled UUID calls follow the same fail-closed behavior described for
+crypto hash functions.
 
 ### Comparison Operators
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2643,6 +2643,23 @@ test_expr_compile_exe = executable(
 
 test('expr_compile', test_expr_compile_exe)
 
+test_arithmetic_overflow_exe = executable(
+  'test_arithmetic_overflow',
+  files('test_arithmetic_overflow.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('arithmetic_overflow', test_arithmetic_overflow_exe)
+
 # ============================================================================
 # Pointer Swap Tests (Issue #300)
 # ============================================================================

--- a/tests/test_arithmetic_overflow.c
+++ b/tests/test_arithmetic_overflow.c
@@ -214,9 +214,9 @@ test_filter_invalid_shift_rejects_row(void)
 }
 
 static void
-test_map_head_overflow_fails_hard_or_emits_no_row(void)
+test_map_head_overflow_fails_hard(void)
 {
-    TEST("map head r(x+1) with INT64_MAX returns error or emits no rows");
+    TEST("map head r(x+1) with INT64_MAX returns ERANGE");
 
     const char *src =
         ".decl a(x: int64)\n"
@@ -226,14 +226,33 @@ test_map_head_overflow_fails_hard_or_emits_no_row(void)
 
     struct result_ctx out;
     int rc = run_snapshot(src, &out);
-    if (rc != ERANGE && rc != 0) {
+    if (rc != ERANGE) {
         char msg[64];
-        snprintf(msg, sizeof(msg), "expected ERANGE/0, got %d", rc);
+        snprintf(msg, sizeof(msg), "expected ERANGE, got %d", rc);
         FAIL(msg);
         return;
     }
-    if (rc == 0 && out.count != 0) {
-        FAIL("map emitted wrapped row on overflow");
+    PASS();
+}
+
+static void
+test_reduce_sum_accumulation_overflow_fails_hard(void)
+{
+    TEST("reduce agg sum accumulation overflows in same group");
+
+    const char *src =
+        ".decl a(g: int64, x: int64)\n"
+        "a(1, 9223372036854775807).\n"
+        "a(1, 1).\n"
+        ".decl r(g: int64, s: int64)\n"
+        "r(g, sum(x)) :- a(g, x).\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != ERANGE) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected ERANGE, got %d", rc);
+        FAIL(msg);
         return;
     }
     PASS();
@@ -294,7 +313,8 @@ main(void)
     test_filter_division_by_zero_rejects_row();
     test_filter_modulo_by_zero_rejects_row();
     test_filter_invalid_shift_rejects_row();
-    test_map_head_overflow_fails_hard_or_emits_no_row();
+    test_map_head_overflow_fails_hard();
+    test_reduce_sum_accumulation_overflow_fails_hard();
     test_slow_filter_to_number_expression_rejects_row();
     test_reduce_expression_overflow_fails_hard();
 

--- a/tests/test_arithmetic_overflow.c
+++ b/tests/test_arithmetic_overflow.c
@@ -283,6 +283,52 @@ test_slow_filter_to_number_expression_rejects_row(void)
 }
 
 static void
+test_filter_to_number_range_error_rejects_row(void)
+{
+    TEST("filter to_number out-of-range rejects row");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), to_number(\"9223372036854775808\") > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_map_to_number_range_error_fails_hard(void)
+{
+    TEST("map head to_number out-of-range returns ERANGE");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(z: int64)\n"
+        "r(to_number(\"9223372036854775808\")) :- a(x).\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != ERANGE) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected ERANGE, got %d", rc);
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
+static void
 test_reduce_expression_overflow_fails_hard(void)
 {
     TEST("reduce agg expression overflow returns error");
@@ -316,6 +362,8 @@ main(void)
     test_map_head_overflow_fails_hard();
     test_reduce_sum_accumulation_overflow_fails_hard();
     test_slow_filter_to_number_expression_rejects_row();
+    test_filter_to_number_range_error_rejects_row();
+    test_map_to_number_range_error_fails_hard();
     test_reduce_expression_overflow_fails_hard();
 
     printf("\n=== Results: %d/%d passed", tests_passed, tests_run);

--- a/tests/test_arithmetic_overflow.c
+++ b/tests/test_arithmetic_overflow.c
@@ -1,0 +1,307 @@
+/*
+ * test_arithmetic_overflow.c - arithmetic evaluator overflow hardening (Issue #822)
+ *
+ * Verifies that postfix arithmetic evaluation fails closed on overflow and
+ * division/modulus errors, and that overflow/invalid-arithmetic errors propagate
+ * through MAP and REDUCE operators.
+ */
+
+#define _GNU_SOURCE
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                      \
+        do {                               \
+            tests_run++;                    \
+            printf("  [TEST] %-60s", name); \
+            fflush(stdout);                 \
+        } while (0)
+
+#define PASS()             \
+        do {                   \
+            tests_passed++;    \
+            printf(" PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                          \
+        do {                                   \
+            tests_failed++;                     \
+            printf(" FAIL: %s\n", (msg));       \
+            return;                             \
+        } while (0)
+
+/* ------------------------------------------------------------------ */
+/* Snapshot helpers                                                   */
+/* ------------------------------------------------------------------ */
+
+#define MAX_ROWS  16
+#define MAX_NCOLS 4
+
+struct result_ctx {
+    int64_t rows[MAX_ROWS][MAX_NCOLS];
+    uint32_t ncols[MAX_ROWS];
+    uint32_t count;
+};
+
+static void
+capture_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    struct result_ctx *ctx = (struct result_ctx *)user_data;
+    if (ctx->count >= MAX_ROWS)
+        return;
+
+    uint32_t copied_cols = ncols < MAX_NCOLS ? ncols : MAX_NCOLS;
+    ctx->ncols[ctx->count] = copied_cols;
+    for (uint32_t i = 0; i < copied_cols; i++)
+        ctx->rows[ctx->count][i] = row[i];
+    ctx->count++;
+}
+
+static int
+run_snapshot(const char *src, struct result_ctx *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    if (wl_session_load_facts(sess, prog) != 0) {
+        wl_session_destroy(sess);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    int rc = wl_session_snapshot(sess, capture_rows, out);
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+static void
+test_filter_addition_overflow_rejects_row(void)
+{
+    TEST("compiled filter x + 1 > 0 rejects INT64_MAX");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(9223372036854775807).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), x + 1 > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_filter_division_by_zero_rejects_row(void)
+{
+    TEST("compiled filter x / 0 rejects row");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), x / 0 > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_filter_modulo_by_zero_rejects_row(void)
+{
+    TEST("compiled filter x % 0 rejects row");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), x % 0 > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_filter_invalid_shift_rejects_row(void)
+{
+    TEST("compiled filter x << 64 rejects row");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), bshl(x, 64) > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_map_head_overflow_fails_hard_or_emits_no_row(void)
+{
+    TEST("map head r(x+1) with INT64_MAX returns error or emits no rows");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(9223372036854775807).\n"
+        ".decl r(z: int64)\n"
+        "r(x + 1) :- a(x).\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != ERANGE && rc != 0) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected ERANGE/0, got %d", rc);
+        FAIL(msg);
+        return;
+    }
+    if (rc == 0 && out.count != 0) {
+        FAIL("map emitted wrapped row on overflow");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_slow_filter_to_number_expression_rejects_row(void)
+{
+    TEST("slow filter fallback via to_number handles overflow");
+
+    const char *src =
+        ".decl a(x: int64)\n"
+        "a(1).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), to_number(\"9223372036854775807\") + 1 > 0.\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != 0) {
+        FAIL("snapshot returned error");
+        return;
+    }
+    if (out.count != 0) {
+        FAIL("expected 0 rows");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_reduce_expression_overflow_fails_hard(void)
+{
+    TEST("reduce agg expression overflow returns error");
+
+    const char *src =
+        ".decl a(g: int64, x: int64)\n"
+        "a(1, 9223372036854775807).\n"
+        ".decl r(g: int64, s: int64)\n"
+        "r(g, sum(x + 1)) :- a(g, x).\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != ERANGE) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected ERANGE, got %d", rc);
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== Arithmetic Overflow Hardening Tests (Issue #822) ===\n\n");
+
+    test_filter_addition_overflow_rejects_row();
+    test_filter_division_by_zero_rejects_row();
+    test_filter_modulo_by_zero_rejects_row();
+    test_filter_invalid_shift_rejects_row();
+    test_map_head_overflow_fails_hard_or_emits_no_row();
+    test_slow_filter_to_number_expression_rejects_row();
+    test_reduce_expression_overflow_fails_hard();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+        printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_arithmetic_overflow.c
+++ b/tests/test_arithmetic_overflow.c
@@ -329,6 +329,28 @@ test_map_to_number_range_error_fails_hard(void)
 }
 
 static void
+test_reduce_to_number_range_error_fails_hard(void)
+{
+    TEST("reduce agg to_number out-of-range returns ERANGE");
+
+    const char *src =
+        ".decl a(g: int64)\n"
+        "a(1).\n"
+        ".decl r(g: int64, s: int64)\n"
+        "r(g, sum(to_number(\"9223372036854775808\"))) :- a(g).\n";
+
+    struct result_ctx out;
+    int rc = run_snapshot(src, &out);
+    if (rc != ERANGE) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "expected ERANGE, got %d", rc);
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
+static void
 test_reduce_expression_overflow_fails_hard(void)
 {
     TEST("reduce agg expression overflow returns error");
@@ -364,6 +386,7 @@ main(void)
     test_slow_filter_to_number_expression_rejects_row();
     test_filter_to_number_range_error_rejects_row();
     test_map_to_number_range_error_fails_hard();
+    test_reduce_to_number_range_error_fails_hard();
     test_reduce_expression_overflow_fails_hard();
 
     printf("\n=== Results: %d/%d passed", tests_passed, tests_run);

--- a/tests/test_cryptographic_hashes.c
+++ b/tests/test_cryptographic_hashes.c
@@ -17,7 +17,7 @@
  *     parse OK, plan OK.
  *     - mbedTLS enabled:  evaluate correctly and produce int64_t results.
  *     - mbedTLS disabled: evaluator hits error path (goto bad), snapshot
- *       still succeeds (rc=0) but tuple value is 0 (fallback).
+ *       fails closed and no tuple is emitted.
  *
  * Compilation guards:
  *   WL_MBEDTLS_ENABLED defined:   full determinism and integration tests.
@@ -148,7 +148,7 @@ run_program_full(const char *src, struct result_ctx *ctx)
 /*
  * sha256() and sha512() are fully implemented: lexer, parser, and backend.
  * These determinism tests are unconditional (run with or without mbedTLS).
- * Without mbedTLS, parse/plan succeed but snapshot emits tuple value 0 (fallback).
+ * Without mbedTLS, parse/plan succeed but snapshot fails closed.
  */
 static void
 test_sha256_determinism(void)
@@ -169,6 +169,19 @@ test_sha256_determinism(void)
     if (rc2 != 0) {
         FAIL("second evaluation failed (parse/plan/session error)");
     }
+#ifndef WL_MBEDTLS_ENABLED
+    if (ctx1.snapshot_rc == 0 || ctx2.snapshot_rc == 0) {
+        FAIL("expected fail-closed snapshot errors without mbedTLS");
+    }
+    if (ctx1.count != 0 || ctx2.count != 0) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 0 tuples each run, got %u and %u",
+            ctx1.count, ctx2.count);
+        FAIL(buf);
+    }
+    PASS();
+    return;
+#endif
     if (ctx1.count != 1 || ctx2.count != 1) {
         char buf[64];
         snprintf(buf, sizeof(buf), "expected 1 tuple each run, got %u and %u",
@@ -204,6 +217,19 @@ test_sha512_determinism(void)
     if (rc2 != 0) {
         FAIL("second evaluation failed (parse/plan/session error)");
     }
+#ifndef WL_MBEDTLS_ENABLED
+    if (ctx1.snapshot_rc == 0 || ctx2.snapshot_rc == 0) {
+        FAIL("expected fail-closed snapshot errors without mbedTLS");
+    }
+    if (ctx1.count != 0 || ctx2.count != 0) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 0 tuples each run, got %u and %u",
+            ctx1.count, ctx2.count);
+        FAIL(buf);
+    }
+    PASS();
+    return;
+#endif
     if (ctx1.count != 1 || ctx2.count != 1) {
         char buf[64];
         snprintf(buf, sizeof(buf), "expected 1 tuple each run, got %u and %u",
@@ -1033,12 +1059,12 @@ test_integration_hmac_sha256_datalog_rule(void)
 /* mbedTLS-disabled: runtime behavior tests                                */
 /*                                                                          */
 /* Crypto built-ins parse and plan successfully but hit the evaluator error */
-/* path (goto bad) at runtime. The snapshot still returns 0 (success) and   */
-/* emits 1 tuple, but the tuple value is 0 (fallback).                      */
+/* path (goto bad) at runtime. The snapshot returns an error and emits no   */
+/* tuple, matching the columnar fail-closed expression policy.              */
 /* ======================================================================== */
 
 static void
-test_unavailable_builtin_zero_fallback(const char *name, const char *src)
+test_unavailable_builtin_fails_closed(const char *name, const char *src)
 {
     TEST(name);
 
@@ -1047,22 +1073,15 @@ test_unavailable_builtin_zero_fallback(const char *name, const char *src)
     if (rc != 0) {
         FAIL("expected parse/plan/session to succeed even without mbedTLS");
     }
-    if (ctx.snapshot_rc != 0) {
+    if (ctx.snapshot_rc == 0) {
         char buf[64];
-        snprintf(buf, sizeof(buf), "snapshot_rc=%d, expected 0",
+        snprintf(buf, sizeof(buf), "snapshot_rc=%d, expected non-zero",
             ctx.snapshot_rc);
         FAIL(buf);
     }
-    if (ctx.count != 1) {
+    if (ctx.count != 0) {
         char buf[64];
-        snprintf(buf, sizeof(buf), "expected 1 tuple, got %u", ctx.count);
-        FAIL(buf);
-    }
-    if (ctx.col0[0] != 0) {
-        char buf[128];
-        snprintf(buf, sizeof(buf),
-            "expected fallback value 0 without mbedTLS, got %" PRId64,
-            ctx.col0[0]);
+        snprintf(buf, sizeof(buf), "expected 0 tuples, got %u", ctx.count);
         FAIL(buf);
     }
     PASS();
@@ -1075,8 +1094,8 @@ test_md5_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0).\n"
         ".decl r(z: int64)\n"
         "r(md5(x)) :- a(x).\n";
-    test_unavailable_builtin_zero_fallback(
-        "md5(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "md5(): without mbedTLS fails closed",
         src);
 }
 
@@ -1087,8 +1106,8 @@ test_sha1_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0).\n"
         ".decl r(z: int64)\n"
         "r(sha1(x)) :- a(x).\n";
-    test_unavailable_builtin_zero_fallback(
-        "sha1(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "sha1(): without mbedTLS fails closed",
         src);
 }
 
@@ -1099,8 +1118,8 @@ test_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0).\n"
         ".decl r(z: int64)\n"
         "r(sha256(x)) :- a(x).\n";
-    test_unavailable_builtin_zero_fallback(
-        "sha256(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "sha256(): without mbedTLS fails closed",
         src);
 }
 
@@ -1111,8 +1130,8 @@ test_sha512_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0).\n"
         ".decl r(z: int64)\n"
         "r(sha512(x)) :- a(x).\n";
-    test_unavailable_builtin_zero_fallback(
-        "sha512(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "sha512(): without mbedTLS fails closed",
         src);
 }
 
@@ -1123,8 +1142,8 @@ test_hmac_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0, 1).\n"
         ".decl r(z: int64)\n"
         "r(hmac_sha256(msg, key)) :- a(msg, key).\n";
-    test_unavailable_builtin_zero_fallback(
-        "hmac_sha256(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "hmac_sha256(): without mbedTLS fails closed",
         src);
 }
 
@@ -1135,8 +1154,8 @@ test_uuid4_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(0).\n"
         ".decl r(z: int64)\n"
         "r(uuid4()) :- a(x).\n";
-    test_unavailable_builtin_zero_fallback(
-        "uuid4(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "uuid4(): without mbedTLS fails closed",
         src);
 }
 
@@ -1147,8 +1166,8 @@ test_uuid5_evaluates_with_zero_fallback_no_mbedtls(void)
         "a(1234, 5678).\n"
         ".decl r(z: int64)\n"
         "r(uuid5(ns, name)) :- a(ns, name).\n";
-    test_unavailable_builtin_zero_fallback(
-        "uuid5(): without mbedTLS snapshot succeeds, tuple value is 0",
+    test_unavailable_builtin_fails_closed(
+        "uuid5(): without mbedTLS fails closed",
         src);
 }
 

--- a/tests/test_cryptographic_hashes.c
+++ b/tests/test_cryptographic_hashes.c
@@ -1088,7 +1088,7 @@ test_unavailable_builtin_fails_closed(const char *name, const char *src)
 }
 
 static void
-test_md5_evaluates_with_zero_fallback_no_mbedtls(void)
+test_md5_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(x: int64)\n"
         "a(0).\n"
@@ -1100,7 +1100,7 @@ test_md5_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_sha1_evaluates_with_zero_fallback_no_mbedtls(void)
+test_sha1_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(x: int64)\n"
         "a(0).\n"
@@ -1112,7 +1112,7 @@ test_sha1_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
+test_sha256_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(x: int64)\n"
         "a(0).\n"
@@ -1124,7 +1124,7 @@ test_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_sha512_evaluates_with_zero_fallback_no_mbedtls(void)
+test_sha512_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(x: int64)\n"
         "a(0).\n"
@@ -1136,7 +1136,7 @@ test_sha512_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_hmac_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
+test_hmac_sha256_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(msg: int64, key: int64)\n"
         "a(0, 1).\n"
@@ -1148,7 +1148,7 @@ test_hmac_sha256_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_uuid4_evaluates_with_zero_fallback_no_mbedtls(void)
+test_uuid4_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(x: int64)\n"
         "a(0).\n"
@@ -1160,7 +1160,7 @@ test_uuid4_evaluates_with_zero_fallback_no_mbedtls(void)
 }
 
 static void
-test_uuid5_evaluates_with_zero_fallback_no_mbedtls(void)
+test_uuid5_fails_closed_no_mbedtls(void)
 {
     const char *src = ".decl a(ns: int64, name: int64)\n"
         "a(1234, 5678).\n"
@@ -1238,13 +1238,13 @@ main(void)
         "DISABLED] ===\n\n");
 
     printf("--- Runtime Behavior Tests (mbedTLS unavailable) ---\n");
-    test_md5_evaluates_with_zero_fallback_no_mbedtls();
-    test_sha1_evaluates_with_zero_fallback_no_mbedtls();
-    test_sha256_evaluates_with_zero_fallback_no_mbedtls();
-    test_sha512_evaluates_with_zero_fallback_no_mbedtls();
-    test_hmac_sha256_evaluates_with_zero_fallback_no_mbedtls();
-    test_uuid4_evaluates_with_zero_fallback_no_mbedtls();
-    test_uuid5_evaluates_with_zero_fallback_no_mbedtls();
+    test_md5_fails_closed_no_mbedtls();
+    test_sha1_fails_closed_no_mbedtls();
+    test_sha256_fails_closed_no_mbedtls();
+    test_sha512_fails_closed_no_mbedtls();
+    test_hmac_sha256_fails_closed_no_mbedtls();
+    test_uuid4_fails_closed_no_mbedtls();
+    test_uuid5_fails_closed_no_mbedtls();
 #endif
 
     printf("\n--- sha256()/sha512() Determinism Tests (always run) ---\n");

--- a/tests/test_string_ops.c
+++ b/tests/test_string_ops.c
@@ -12,6 +12,7 @@
 #include "../wirelog/string_ops.h"
 #include "../wirelog/intern.h"
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1593,6 +1594,55 @@ test_to_number_empty(void)
     PASS();
 }
 
+static void
+test_to_number_checked_int64_bounds(void)
+{
+    TEST("to_number_checked: accepts int64 bounds");
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("create failed"); return;
+    }
+
+    int64_t max_id = wl_intern_put(intern, "9223372036854775807");
+    int64_t min_id = wl_intern_put(intern, "-9223372036854775808");
+    int64_t value = 0;
+    int rc = wl_string_ops_to_number_checked(max_id, intern, &value);
+    if (rc != 0 || value != INT64_MAX) {
+        wl_intern_free(intern);
+        FAIL("expected INT64_MAX success");
+        return;
+    }
+    rc = wl_string_ops_to_number_checked(min_id, intern, &value);
+    wl_intern_free(intern);
+    if (rc != 0 || value != INT64_MIN) {
+        FAIL("expected INT64_MIN success");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_to_number_checked_range_errors(void)
+{
+    TEST("to_number_checked: rejects out-of-range numeric prefixes");
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("create failed"); return;
+    }
+
+    int64_t pos_id = wl_intern_put(intern, "9223372036854775808");
+    int64_t neg_id = wl_intern_put(intern, "-9223372036854775809");
+    int64_t value = 123;
+    int pos_rc = wl_string_ops_to_number_checked(pos_id, intern, &value);
+    int neg_rc = wl_string_ops_to_number_checked(neg_id, intern, &value);
+    wl_intern_free(intern);
+    if (pos_rc != ERANGE || neg_rc != ERANGE) {
+        FAIL("expected ERANGE for both bounds");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* NULL intern error handling for all functions                            */
 /* ======================================================================== */
@@ -1765,6 +1815,8 @@ main(void)
     test_to_number_numeric_prefix();
     test_to_number_non_numeric();
     test_to_number_empty();
+    test_to_number_checked_int64_bounds();
+    test_to_number_checked_range_errors();
 
     printf("\n--- Error Handling ---\n");
     test_null_intern_all_functions();

--- a/tests/test_string_ops.c
+++ b/tests/test_string_ops.c
@@ -1643,6 +1643,27 @@ test_to_number_checked_range_errors(void)
     PASS();
 }
 
+static void
+test_to_number_legacy_range_return(void)
+{
+    TEST("to_number: legacy range errors saturate");
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("create failed"); return;
+    }
+
+    int64_t pos_id = wl_intern_put(intern, "9223372036854775808");
+    int64_t neg_id = wl_intern_put(intern, "-9223372036854775809");
+    int64_t pos = string_ops_to_number(pos_id, intern);
+    int64_t neg = string_ops_to_number(neg_id, intern);
+    wl_intern_free(intern);
+    if (pos != INT64_MAX || neg != INT64_MIN) {
+        FAIL("expected legacy INT64 saturation");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* NULL intern error handling for all functions                            */
 /* ======================================================================== */
@@ -1817,6 +1838,7 @@ main(void)
     test_to_number_empty();
     test_to_number_checked_int64_bounds();
     test_to_number_checked_range_errors();
+    test_to_number_legacy_range_return();
 
     printf("\n--- Error Handling ---\n");
     test_null_intern_all_functions();

--- a/tests/test_string_ops.c
+++ b/tests/test_string_ops.c
@@ -1725,6 +1725,11 @@ test_null_intern_all_functions(void)
         FAIL("to_number: expected 0");
         return;
     }
+    int64_t out = 123;
+    if (wl_string_ops_to_number_checked(0, NULL, &out) != EINVAL) {
+        FAIL("to_number_checked: expected EINVAL");
+        return;
+    }
 
     PASS();
 }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -168,6 +168,61 @@ filt_pop(filt_stack_t *s)
     return s->top != 0 ? s->vals[--s->top] : 0;
 }
 
+/* Checked int64 arithmetic helpers shared by both slow and compiled evaluators. */
+static int
+wl_checked_add_int64(int64_t a, int64_t b, int64_t *out)
+{
+    return __builtin_add_overflow(a, b, out) ? ERANGE : 0;
+}
+
+static int
+wl_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
+{
+    return __builtin_sub_overflow(a, b, out) ? ERANGE : 0;
+}
+
+static int
+wl_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
+{
+    return __builtin_mul_overflow(a, b, out) ? ERANGE : 0;
+}
+
+static int
+wl_checked_div_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b == 0 || (a == INT64_MIN && b == -1))
+        return ERANGE;
+    *out = a / b;
+    return 0;
+}
+
+static int
+wl_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b == 0 || (a == INT64_MIN && b == -1))
+        return ERANGE;
+    *out = a % b;
+    return 0;
+}
+
+static int
+wl_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b < 0 || b >= 64)
+        return ERANGE;
+    *out = (int64_t)((uint64_t)a << (uint32_t)b);
+    return 0;
+}
+
+static int
+wl_checked_shr_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b < 0 || b >= 64)
+        return ERANGE;
+    *out = a >> (uint32_t)b;
+    return 0;
+}
+
 /*
  * col_eval_expr_run:
  * Core postfix expression evaluator. Runs the bytecode against a row and
@@ -252,27 +307,42 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         /* Arithmetic */
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a + b);
+            int64_t v;
+            if (wl_checked_add_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a - b);
+            int64_t v;
+            if (wl_checked_sub_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a * b);
+            int64_t v;
+            if (wl_checked_mul_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, b != 0 ? a / b : 0);
+            int64_t v;
+            if (wl_checked_div_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, b != 0 ? a % b : 0);
+            int64_t v;
+            if (wl_checked_mod_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_BAND: {
@@ -297,12 +367,18 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         }
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a << b);
+            int64_t v;
+            if (wl_checked_shl_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a >> b);
+            int64_t v;
+            if (wl_checked_shr_int64(a, b, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_HASH: {
@@ -610,22 +686,20 @@ col_eval_filter_row(const uint8_t *buf, uint32_t size, const int64_t *row,
 {
     int64_t val;
     int err = col_eval_expr_run(buf, size, row, ncols, &val, intern);
-    return err ? 1 : (val != 0 ? 1 : 0); /* on error: pass row through */
+    return err ? 0 : (val != 0 ? 1 : 0);
 }
 
 /*
  * col_eval_expr_i64:
- * Evaluate the postfix expression buffer and return the computed int64 value.
+ * Evaluate the postfix expression buffer and write the computed value to out_val.
  * Used by MAP operations to compute head argument expressions.
- * Returns 0 on empty expression or evaluation error.
+ * Returns 0 on success, non-zero on empty expression or evaluation error.
  */
-static int64_t
+static int
 col_eval_expr_i64(const uint8_t *buf, uint32_t size, const int64_t *row,
-    uint32_t ncols, wl_intern_t *intern)
+    uint32_t ncols, int64_t *out_val, wl_intern_t *intern)
 {
-    int64_t val;
-    col_eval_expr_run(buf, size, row, ncols, &val, intern);
-    return val;
+    return col_eval_expr_run(buf, size, row, ncols, out_val, intern);
 }
 
 /* ======================================================================== */
@@ -811,27 +885,52 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
             break;
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a + b);
+            int64_t v;
+            if (wl_checked_add_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a - b);
+            int64_t v;
+            if (wl_checked_sub_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a * b);
+            int64_t v;
+            if (wl_checked_mul_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, b != 0 ? a / b : 0);
+            int64_t v;
+            if (wl_checked_div_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, b != 0 ? a % b : 0);
+            int64_t v;
+            if (wl_checked_mod_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_BAND: {
@@ -856,12 +955,22 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         }
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a << b);
+            int64_t v;
+            if (wl_checked_shl_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a >> b);
+            int64_t v;
+            if (wl_checked_shr_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            filt_push(&s, v);
             break;
         }
         case WL_PLAN_EXPR_CMP_EQ: {
@@ -1122,13 +1231,37 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                 && op->map_exprs[c].size > 0) {
                 if (ce_map && c < ce_map_count && ce_map[c]) {
                     int64_t val = 0;
-                    col_eval_expr_compiled(ce_map[c], row, e.rel->ncols,
-                        &val);
+                    if (col_eval_expr_compiled(ce_map[c], row, e.rel->ncols,
+                        &val) != 0) {
+                        if (ce_map) {
+                            for (uint32_t i = 0; i < ce_map_count; i++)
+                                col_expr_compiled_free(ce_map[i]);
+                            free(ce_map);
+                        }
+                        free(tmp);
+                        col_rel_destroy(out);
+                        if (e.owned)
+                            col_rel_destroy(e.rel);
+                        return ERANGE;
+                    }
                     tmp[c] = val;
                 } else {
-                    tmp[c] = col_eval_expr_i64(op->map_exprs[c].data,
-                            op->map_exprs[c].size, row,
-                            e.rel->ncols, sess->intern);
+                    int64_t val = 0;
+                    if (col_eval_expr_i64(op->map_exprs[c].data,
+                        op->map_exprs[c].size, row, e.rel->ncols,
+                        &val, sess->intern) != 0) {
+                        if (ce_map) {
+                            for (uint32_t i = 0; i < ce_map_count; i++)
+                                col_expr_compiled_free(ce_map[i]);
+                            free(ce_map);
+                        }
+                        free(tmp);
+                        col_rel_destroy(out);
+                        if (e.owned)
+                            col_rel_destroy(e.rel);
+                        return ERANGE;
+                    }
+                    tmp[c] = val;
                 }
             } else {
                 uint32_t src = op->project_indices ? op->project_indices[c] : c;
@@ -1629,7 +1762,7 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
             int64_t val = 0;
             pass = (col_eval_expr_compiled(ce, row, e.rel->ncols, &val) == 0)
                        ? (val != 0 ? 1 : 0)
-                       : 1; /* on error: pass row through */
+                       : 0; /* on error: reject row */
         } else {
             pass = col_eval_filter_row(buf, bsz, row, e.rel->ncols,
                     sess->intern);
@@ -6118,9 +6251,27 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                 int64_t val = 0;
                 if (col_eval_expr_compiled(agg_ce, row, in->ncols, &val) == 0)
                     agg_val = val;
+                else {
+                    col_expr_compiled_free(agg_ce);
+                    free(tmp);
+                    col_rel_destroy(out);
+                    if (e.owned)
+                        col_rel_destroy(in);
+                    return ERANGE;
+                }
             } else {
-                agg_val = col_eval_expr_i64(op->agg_expr.data,
-                        op->agg_expr.size, row, in->ncols, sess->intern);
+                int64_t val = 0;
+                if (col_eval_expr_i64(op->agg_expr.data, op->agg_expr.size,
+                    row, in->ncols, &val, sess->intern) == 0) {
+                    agg_val = val;
+                } else {
+                    col_expr_compiled_free(agg_ce);
+                    free(tmp);
+                    col_rel_destroy(out);
+                    if (e.owned)
+                        col_rel_destroy(in);
+                    return ERANGE;
+                }
             }
         }
 

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -169,24 +169,27 @@ filt_pop(filt_stack_t *s)
 }
 
 static inline uint64_t
-wl_abs_u64(int64_t v)
+wl_columnar_ops_abs_u64(int64_t v)
 {
     return v < 0 ? (uint64_t)0 - (uint64_t)v : (uint64_t)v;
 }
 
-/* Use compiler-builtins where available; otherwise use explicit range checks. */
-#if (defined(__has_builtin) && (__has_builtin(__builtin_add_overflow) \
+/* Use compiler builtins where available; otherwise use explicit range checks. */
+#if defined(__GNUC__) || defined(__clang__)
+#define WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN 1
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow) \
     && __has_builtin(__builtin_sub_overflow) \
-    && __has_builtin(__builtin_mul_overflow))) || defined(__GNUC__) \
-    || defined(__clang__)
-#define WL_HAVE_INT64_OVERFLOW_BUILTIN 1
+    && __has_builtin(__builtin_mul_overflow)
+#define WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN 1
+#endif
 #endif
 
 /* Checked int64 arithmetic helpers shared by both slow and compiled evaluators. */
 static int
-wl_checked_add_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_add_int64(int64_t a, int64_t b, int64_t *out)
 {
-#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
+#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_add_overflow(a, b, out) ? ERANGE : 0;
 #else
     if (b > 0) {
@@ -202,9 +205,9 @@ wl_checked_add_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
 {
-#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
+#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_sub_overflow(a, b, out) ? ERANGE : 0;
 #else
     if (b > 0) {
@@ -220,9 +223,9 @@ wl_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
 {
-#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
+#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_mul_overflow(a, b, out) ? ERANGE : 0;
 #else
     if (a == 0 || b == 0) {
@@ -232,8 +235,8 @@ wl_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
     if ((a == -1 && b == INT64_MIN) || (b == -1 && a == INT64_MIN))
         return ERANGE;
 
-    uint64_t ua = wl_abs_u64(a);
-    uint64_t ub = wl_abs_u64(b);
+    uint64_t ua = wl_columnar_ops_abs_u64(a);
+    uint64_t ub = wl_columnar_ops_abs_u64(b);
     if ((a < 0) == (b < 0)) {
         if (ua > (uint64_t)INT64_MAX / ub)
             return ERANGE;
@@ -247,7 +250,7 @@ wl_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_div_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_div_int64(int64_t a, int64_t b, int64_t *out)
 {
     if (b == 0 || (a == INT64_MIN && b == -1))
         return ERANGE;
@@ -256,7 +259,7 @@ wl_checked_div_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
 {
     if (b == 0 || (a == INT64_MIN && b == -1))
         return ERANGE;
@@ -265,7 +268,7 @@ wl_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
 {
     if (b < 0 || b >= 64)
         return ERANGE;
@@ -274,7 +277,7 @@ wl_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
 }
 
 static int
-wl_checked_shr_int64(int64_t a, int64_t b, int64_t *out)
+wl_columnar_ops_checked_shr_int64(int64_t a, int64_t b, int64_t *out)
 {
     if (b < 0 || b >= 64)
         return ERANGE;
@@ -367,7 +370,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_add_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_add_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -375,7 +378,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_sub_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_sub_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -383,7 +386,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_mul_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_mul_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -391,7 +394,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_div_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_div_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -399,7 +402,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_mod_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_mod_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -427,7 +430,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_shl_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_shl_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -435,7 +438,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_shr_int64(a, b, &v) != 0)
+            if (wl_columnar_ops_checked_shr_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -945,7 +948,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_add_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_add_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -955,7 +958,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_sub_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_sub_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -965,7 +968,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_mul_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_mul_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -975,7 +978,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_div_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_div_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -985,7 +988,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_mod_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_mod_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1015,7 +1018,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_shl_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_shl_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1025,7 +1028,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_checked_shr_int64(a, b, &v) != 0) {
+            if (wl_columnar_ops_checked_shr_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -6354,7 +6357,8 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                 case WIRELOG_AGG_SUM:
                 {
                     int64_t next;
-                    if (wl_checked_add_int64(cur, agg_val, &next) != 0) {
+                    if (wl_columnar_ops_checked_add_int64(cur, agg_val,
+                        &next) != 0) {
                         col_expr_compiled_free(agg_ce);
                         free(tmp);
                         col_rel_destroy(out);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -674,7 +674,10 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         }
         case WL_PLAN_EXPR_STR_FN_TO_NUMBER: {
             int64_t a = filt_pop(&s);
-            filt_push(&s, intern ? string_ops_to_number(a, intern) : 0);
+            int64_t v;
+            if (!intern || wl_string_ops_to_number_checked(a, intern, &v) != 0)
+                goto bad;
+            filt_push(&s, v);
             break;
         }
 

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -168,23 +168,82 @@ filt_pop(filt_stack_t *s)
     return s->top != 0 ? s->vals[--s->top] : 0;
 }
 
+static inline uint64_t
+wl_abs_u64(int64_t v)
+{
+    return v < 0 ? (uint64_t)0 - (uint64_t)v : (uint64_t)v;
+}
+
+/* Use compiler-builtins where available; otherwise use explicit range checks. */
+#if (defined(__has_builtin) && (__has_builtin(__builtin_add_overflow) \
+    && __has_builtin(__builtin_sub_overflow) \
+    && __has_builtin(__builtin_mul_overflow))) || defined(__GNUC__) \
+    || defined(__clang__)
+#define WL_HAVE_INT64_OVERFLOW_BUILTIN 1
+#endif
+
 /* Checked int64 arithmetic helpers shared by both slow and compiled evaluators. */
 static int
 wl_checked_add_int64(int64_t a, int64_t b, int64_t *out)
 {
+#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_add_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (b > 0) {
+        if (a > INT64_MAX - b)
+            return ERANGE;
+    } else {
+        if (a < INT64_MIN - b)
+            return ERANGE;
+    }
+    *out = a + b;
+    return 0;
+#endif
 }
 
 static int
 wl_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
 {
+#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_sub_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (b > 0) {
+        if (a < INT64_MIN + b)
+            return ERANGE;
+    } else {
+        if (a > INT64_MAX + b)
+            return ERANGE;
+    }
+    *out = a - b;
+    return 0;
+#endif
 }
 
 static int
 wl_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
 {
+#if defined(WL_HAVE_INT64_OVERFLOW_BUILTIN)
     return __builtin_mul_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (a == 0 || b == 0) {
+        *out = 0;
+        return 0;
+    }
+    if ((a == -1 && b == INT64_MIN) || (b == -1 && a == INT64_MIN))
+        return ERANGE;
+
+    uint64_t ua = wl_abs_u64(a);
+    uint64_t ub = wl_abs_u64(b);
+    if ((a < 0) == (b < 0)) {
+        if (ua > (uint64_t)INT64_MAX / ub)
+            return ERANGE;
+    } else {
+        if (ua > ((uint64_t)INT64_MAX + 1ULL) / ub)
+            return ERANGE;
+    }
+    *out = a * b;
+    return 0;
+#endif
 }
 
 static int
@@ -6293,8 +6352,19 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     col_rel_set(out, o, gc, cur + 1);
                     break;
                 case WIRELOG_AGG_SUM:
-                    col_rel_set(out, o, gc, cur + agg_val);
-                    break;
+                {
+                    int64_t next;
+                    if (wl_checked_add_int64(cur, agg_val, &next) != 0) {
+                        col_expr_compiled_free(agg_ce);
+                        free(tmp);
+                        col_rel_destroy(out);
+                        if (e.owned)
+                            col_rel_destroy(in);
+                        return ERANGE;
+                    }
+                    col_rel_set(out, o, gc, next);
+                }
+                break;
                 case WIRELOG_AGG_MIN:
                     if (agg_val < cur)
                         col_rel_set(out, o, gc, agg_val);

--- a/wirelog/string_ops.c
+++ b/wirelog/string_ops.c
@@ -11,6 +11,7 @@
 
 #include "string_ops.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -489,13 +490,18 @@ string_ops_to_string(int64_t num, wl_intern_t *intern)
 }
 
 /**
- * string_ops_to_number:
+ * wl_string_ops_to_number_checked:
  * Parse interned string @id as a base-10 integer.
- * Parses a numeric prefix; returns 0 if the string has no valid numeric prefix.
+ * Parses a numeric prefix; returns 0 and writes 0 if the string has no valid
+ * numeric prefix. Returns ERANGE when the numeric prefix is outside int64_t.
  */
-int64_t
-string_ops_to_number(int64_t id, wl_intern_t *intern)
+int
+wl_string_ops_to_number_checked(int64_t id, wl_intern_t *intern, int64_t *out)
 {
+    if (out)
+        *out = 0;
+    if (!out)
+        return EINVAL;
     if (!intern)
         return 0;
 
@@ -504,9 +510,28 @@ string_ops_to_number(int64_t id, wl_intern_t *intern)
         return 0;
 
     char *endptr = NULL;
-    int64_t val = (int64_t)strtoll(str, &endptr, 10);
+    errno = 0;
+    intmax_t val = strtoimax(str, &endptr, 10);
     if (endptr == str)
         return 0; /* no valid numeric prefix */
+    if (errno == ERANGE || val < INT64_MIN || val > INT64_MAX)
+        return ERANGE;
 
+    *out = (int64_t)val;
+    return 0;
+}
+
+/**
+ * string_ops_to_number:
+ * Parse interned string @id as a base-10 integer.
+ * Parses a numeric prefix; returns 0 if the string has no valid numeric prefix
+ * or cannot be represented as int64_t.
+ */
+int64_t
+string_ops_to_number(int64_t id, wl_intern_t *intern)
+{
+    int64_t val = 0;
+    if (wl_string_ops_to_number_checked(id, intern, &val) != 0)
+        return 0;
     return val;
 }

--- a/wirelog/string_ops.c
+++ b/wirelog/string_ops.c
@@ -503,7 +503,7 @@ wl_string_ops_to_number_checked(int64_t id, wl_intern_t *intern, int64_t *out)
     if (!out)
         return EINVAL;
     if (!intern)
-        return 0;
+        return EINVAL;
 
     const char *str = wl_intern_reverse(intern, id);
     if (!str || !*str)
@@ -530,8 +530,17 @@ wl_string_ops_to_number_checked(int64_t id, wl_intern_t *intern, int64_t *out)
 int64_t
 string_ops_to_number(int64_t id, wl_intern_t *intern)
 {
-    int64_t val = 0;
-    if (wl_string_ops_to_number_checked(id, intern, &val) != 0)
+    if (!intern)
         return 0;
+
+    const char *str = wl_intern_reverse(intern, id);
+    if (!str || !*str)
+        return 0;
+
+    char *endptr = NULL;
+    int64_t val = (int64_t)strtoll(str, &endptr, 10);
+    if (endptr == str)
+        return 0; /* no valid numeric prefix */
+
     return val;
 }

--- a/wirelog/string_ops.c
+++ b/wirelog/string_ops.c
@@ -524,8 +524,8 @@ wl_string_ops_to_number_checked(int64_t id, wl_intern_t *intern, int64_t *out)
 /**
  * string_ops_to_number:
  * Parse interned string @id as a base-10 integer.
- * Parses a numeric prefix; returns 0 if the string has no valid numeric prefix
- * or cannot be represented as int64_t.
+ * Parses a numeric prefix; returns 0 if the string has no valid numeric prefix.
+ * Out-of-range prefixes preserve the legacy strtoll saturation result.
  */
 int64_t
 string_ops_to_number(int64_t id, wl_intern_t *intern)

--- a/wirelog/string_ops.h
+++ b/wirelog/string_ops.h
@@ -36,6 +36,8 @@ int64_t string_ops_str_replace(int64_t id, int64_t old_id, int64_t new_id,
     wl_intern_t *intern);
 int64_t string_ops_trim(int64_t id, wl_intern_t *intern);
 int64_t string_ops_to_string(int64_t num, wl_intern_t *intern);
+int wl_string_ops_to_number_checked(int64_t id, wl_intern_t *intern,
+    int64_t *out);
 int64_t string_ops_to_number(int64_t id, wl_intern_t *intern);
 
 #endif /* WIRELOG_STRING_OPS_H */


### PR DESCRIPTION
## Summary

Closes #822.

- add shared checked int64 arithmetic for columnar expression evaluation
- fail filters closed on expression errors and propagate `ERANGE` from MAP/REDUCE expression contexts
- check REDUCE `sum()` accumulation overflow
- make columnar `to_number()` reject out-of-range numeric prefixes while preserving legacy `string_ops_to_number()` saturation behavior for direct internal callers
- document the #822 fail-closed policy/audit in `docs/SEMANTICS.md` and update the changelog
- align disabled-mbedTLS crypto/UUID tests and syntax docs with fail-closed evaluator behavior

## Validation

- `meson test -C builddir cryptographic_hashes changelog_format semantics_future release_template string_ops arithmetic_overflow string_eval expr_compile bitwise_eval join_overflow --print-errorlogs`
- `meson test -C builddir --suite abi --print-errorlogs`
- `git diff --check origin/main..HEAD`

## Scope Notes

- `col_op_reduce_weighted()` remains a weighted Z-set multiplicity helper and is documented as outside the #822 user-expression fail-closed contract.
- COUNT is not overclaimed as checked arithmetic; current COUNT is bounded by `uint32_t nrows` in the active representation.
