### PR TITLE
docs: draft v0.43 benchmark speedup notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ All notable changes to wirelog are documented in this file.
 - **Stable snapshot fast path** (#811): clean sessions now read cached
   materialized IDB rows directly on repeated snapshots instead of
   re-running TDD evaluation when no input or retraction state is pending.
+- **v0.43 benchmark speedup notes draft** (#794, #512, #791): added
+  the portfolio speedup draft with issue #794 timing deltas, changed-commit
+  provenance, and memory-trade-off context:
+  [docs/release-notes/v0.43.md](docs/release-notes/v0.43.md).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to wirelog are documented in this file.
   materialized IDB rows directly on repeated snapshots instead of
   re-running TDD evaluation when no input or retraction state is pending.
 - **v0.43 benchmark speedup notes draft** (#794, #512, #791): added
-  the portfolio speedup draft with issue #794 timing deltas, changed-commit
+  the portfolio speedup draft with #512 timing deltas, changed-commit
   provenance, and memory-trade-off context:
   [docs/release-notes/v0.43.md](docs/release-notes/v0.43.md).
 

--- a/docs/release-notes/v0.43.md
+++ b/docs/release-notes/v0.43.md
@@ -1,0 +1,37 @@
+# wirelog v0.43 benchmark speedup notes
+
+The measured benchmark portfolio shows a broad 40-60% speedup pattern on the
+memory-heavy workloads, with the heaviest analyses benefiting the most from the
+v0.43 memory-parallelism work.
+
+All timing numbers in this draft are authoritative from issue `#512`, and this
+unit does not rerun benchmarks.
+
+## #794 benchmark results
+
+| Benchmark | Before | After | Relative | Delta |
+|-----------|--------|-------|----------|-------|
+| TC | 11.7ms | 8.5ms | 1.38x | -27% |
+| Andersen | 3.8ms | 3.3ms | 1.15x | -13% |
+| Dyck-2 | 20.5ms | 10.3ms | 1.99x | -50% |
+| CSPA | 2.07s | 0.88s | 2.35x | -58% |
+| Galen | 43.4ms | 24.6ms | 1.76x | -43% |
+| Polonius | 7.0ms | 4.6ms | 1.52x | -34% |
+| DDISASM | 6.9ms | 3.3ms | 2.09x | -52% |
+| CRDT | 19.2s | 8.72s | 2.20x | -55% |
+| DOOP (Windows) | 184.3s | 73.3s | 2.51x | -60% |
+| DOOP (Linux) | 184.3s | 54.6s | 3.37x | -70% |
+
+## What changed
+
+- `208dab6` — Parallelize eligible nonrecursive relation plans.
+- `0107ad0` — Parallelize differential keyed joins.
+- `30a8635` — Optimize CRDT keyed probes and cap TDD width.
+- `#791` follow-on commits:
+  - `d1f755e` — perf: bump narrow-join cardinality cap from 5 to 3 avg cols.
+  - `ea5bdd2` — fix: gate in-loop join backpressure to worker sessions only.
+
+## Memory trade-off note
+
+DOOP peak RSS increased from 7.2 GB to 9.0 GB on Windows and 12.5 GB on Linux,
+which is the explicit trade-off to the larger runtime speedup for this workload.

--- a/docs/release-notes/v0.43.md
+++ b/docs/release-notes/v0.43.md
@@ -4,10 +4,10 @@ The measured benchmark portfolio shows a broad 40-60% speedup pattern on the
 memory-heavy workloads, with the heaviest analyses benefiting the most from the
 v0.43 memory-parallelism work.
 
-All timing numbers in this draft are authoritative from issue `#512`, and this
+All timing numbers in this draft are authoritative from issue #512, and this
 unit does not rerun benchmarks.
 
-## #794 benchmark results
+## Benchmarked results summary
 
 | Benchmark | Before | After | Relative | Delta |
 |-----------|--------|-------|----------|-------|
@@ -19,19 +19,19 @@ unit does not rerun benchmarks.
 | Polonius | 7.0ms | 4.6ms | 1.52x | -34% |
 | DDISASM | 6.9ms | 3.3ms | 2.09x | -52% |
 | CRDT | 19.2s | 8.72s | 2.20x | -55% |
-| DOOP (Windows) | 184.3s | 73.3s | 2.51x | -60% |
-| DOOP (Linux) | 184.3s | 54.6s | 3.37x | -70% |
+| DOOP (zxing, Windows) | 184.3s | 73.3s | 2.51x | -60% |
+| DOOP (zxing, Linux) | 184.3s | 54.6s | 3.37x | -70% |
 
 ## What changed
 
 - `208dab6` — Parallelize eligible nonrecursive relation plans.
 - `0107ad0` — Parallelize differential keyed joins.
 - `30a8635` — Optimize CRDT keyed probes and cap TDD width.
-- `#791` follow-on commits:
+- #791 follow-on commits:
   - `d1f755e` — perf: bump narrow-join cardinality cap from 5 to 3 avg cols.
   - `ea5bdd2` — fix: gate in-loop join backpressure to worker sessions only.
 
 ## Memory trade-off note
 
-DOOP peak RSS increased from 7.2 GB to 9.0 GB on Windows and 12.5 GB on Linux,
+DOOP peak RSS increased from 7.2 GB to 9.0 GB on DOOP (zxing, Windows) and 12.5 GB on DOOP (zxing, Linux),
 which is the explicit trade-off to the larger runtime speedup for this workload.


### PR DESCRIPTION
## Summary
- add a v0.43 release-note draft for the benchmark portfolio speedups tracked by #794
- include the #512 timing table, #791 attribution, and DOOP memory trade-off note
- cross-link the draft from CHANGELOG.md [Unreleased] / Performance

Closes #794

## Validation
- git diff --check origin/main..HEAD
- source .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md
- meson test -C build changelog_format release_template

## Review Workflow
- Implementer commits: 8f9f29c, 8170dc0
- Reviewer found one provenance wording blocker on 8f9f29c; fixed in 8170dc0
- Architect and Critic verified no blocking feedback remains
