### PR TITLE
docs: add Android guide and asset adapter example

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,6 +44,8 @@ on:
     paths:
       - 'meson.build'
       - 'meson_options.txt'
+      - 'docs/android.md'
+      - 'examples/android/**'
       - 'wirelog/**'
       - 'cross/**'
       - 'scripts/ci/check-android-alignment.sh'
@@ -54,6 +56,8 @@ on:
     paths:
       - 'meson.build'
       - 'meson_options.txt'
+      - 'docs/android.md'
+      - 'examples/android/**'
       - 'wirelog/**'
       - 'cross/**'
       - 'scripts/ci/check-android-alignment.sh'
@@ -122,6 +126,31 @@ jobs:
 
       - name: Build
         run: meson compile -C build-android-arm64
+
+      - name: Compile asset adapter reference (arm64-v8a, compile-only)
+        run: |
+          set -x
+          NDK_PATH='${{ steps.setup-ndk.outputs.ndk-path }}'
+          CLANG="$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+          "$CLANG" \
+            -Wall \
+            -fPIC \
+            -shared \
+            -I"$PWD" \
+            -I"$PWD/build-android-arm64" \
+            -I"$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include" \
+            -I"$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/aarch64-linux-android" \
+            "$PWD/examples/android/asset_adapter/asset_adapter.c" \
+            "$PWD/build-android-arm64/libwirelog.so" \
+            -L"$PWD/build-android-arm64" \
+            -lwirelog \
+            -landroid \
+            -llog \
+            -o "$PWD/build-android-arm64/libasset_adapter.so"
+
+          file "$PWD/build-android-arm64/libasset_adapter.so"
+          readelf -h "$PWD/build-android-arm64/libasset_adapter.so"
+          readelf -lW "$PWD/build-android-arm64/libasset_adapter.so"
 
       - name: Hard gate -- assert 16 KB PT_LOAD alignment
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -136,6 +136,7 @@ jobs:
             -Wall \
             -fPIC \
             -shared \
+            -Wl,-z,max-page-size=16384 \
             -I"$PWD" \
             -I"$PWD/build-android-arm64" \
             -I"$NDK_PATH/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include" \
@@ -151,6 +152,7 @@ jobs:
           file "$PWD/build-android-arm64/libasset_adapter.so"
           readelf -h "$PWD/build-android-arm64/libasset_adapter.so"
           readelf -lW "$PWD/build-android-arm64/libasset_adapter.so"
+          bash scripts/ci/check-android-alignment.sh build-android-arm64/libasset_adapter.so
 
       - name: Hard gate -- assert 16 KB PT_LOAD alignment
         run: |
@@ -165,6 +167,7 @@ jobs:
           name: readelf-arm64-on-fail
           path: |
             build-android-arm64/libwirelog.so
+            build-android-arm64/libasset_adapter.so
             build-android-arm64/meson-logs/meson-log.txt
           retention-days: 7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ All notable changes to wirelog are documented in this file.
   consumption, Swift callback registration with trailing `user_data`,
   simulator architecture handling, and App Store/tooling constraints for
   #470.
+- Added `docs/android.md` with Android integration guidance for
+  AAR/Prefab consumption patterns, JNI thread attachment patterns,
+  `Context.getFilesDir()` path handling, and Android CI/alignment
+  requirements for #466.
 
 ## [0.41.0] - 2026-05-20
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,0 +1,187 @@
+# Android Integration
+
+This document is the issue-#466 Android integration recipe for
+`libwirelog.so` consumption and custom I/O adapter embedding.
+
+## Packaging and distribution status
+
+`wirelog` ships Android cross-compilation and source-integration support.
+It does not currently publish artifacts to Maven Central or JitPack.
+For now, consumption is:
+
+- source inclusion with local build tooling, or
+- consuming a local prefab `aar` you generate in your build pipeline.
+
+Do not expect hosted `aar`/`prefab` coordinates from this repository at
+this version.
+
+## AAR / Prefab consumption pattern
+
+The current v0.43 surface supports integration through Gradle/CMake
+linkage and JNI; if you already produce a local Prefab-capable `.aar`,
+consume it as a local artifact:
+
+```gradle
+dependencies {
+    implementation(files("libs/wirelog-prefab-release.aar"))
+}
+```
+
+If you do not have an `.aar`, include wirelog as a native source
+dependency and run the documented Android cross build in CI-compatible mode.
+The supported cross-build entries are:
+
+- `cross/android-arm64.ini`
+- `cross/android-x86_64.ini`
+
+`armv7` is intentionally unsupported; wirelog's Android release policy is
+64-bit only.
+
+## Build compatibility contract
+
+- API level: minimum `21` (per shipped cross-files).
+- Page alignment:
+  - `cross/android-arm64.ini` builds with the `aarch64` toolchain.
+  - `meson build -Dandroid=true` adds
+    `-Wl,-z,max-page-size=16384` for arm64-v8a.
+- Toolchain pin: NDK `r27c` is pinned in `cross/android-arm64.ini`
+  and `cross/android-x86_64.ini` as `ndk = '/opt/android-ndk-r27c'`.
+
+The Android hard gate in CI enforces this alignment for arm64-v8a
+artifacts before merge; this protects Play Store-upload constraints where
+misaligned arm64 binaries can be rejected on API 35+.
+
+## Register an adapter from JNI
+
+Use the current public API names (`wirelog_io_register_adapter`,
+`wirelog_io_find_adapter`, `wirelog_io_last_error`).
+
+```c
+#include <android/log.h>
+#include <jni.h>
+#include <wirelog/io/io_adapter.h>
+#include <wirelog/wirelog.h>
+
+typedef struct {
+    JavaVM* vm;
+    jstring context_key;
+} app_jni_state_t;
+
+static app_jni_state_t g_app_state;
+
+static int android_asset_read(
+    wirelog_io_ctx_t* ctx,
+    int64_t** out_data,
+    uint32_t* out_nrows,
+    void* user_data
+) {
+    app_jni_state_t* state = (app_jni_state_t*)user_data;
+    if (!state || !state->vm) {
+        return -1;
+    }
+
+    JNIEnv* env = NULL;
+    bool attached = false;
+    int rc = (*state->vm)->GetEnv((void**)&env, JNI_VERSION_1_6);
+    if (rc != JNI_OK) {
+        if ((*state->vm)->AttachCurrentThread(
+                state->vm,
+                (void**)&env,
+                NULL
+            ) != 0) {
+            return -1;
+        }
+        attached = true;
+    }
+
+    // Resolve input params and fill out_data/out_nrows here.
+    (void)ctx;
+    (void)out_data;
+    (void)out_nrows;
+    (void)state;
+
+    if (attached) {
+        (*state->vm)->DetachCurrentThread(state->vm);
+    }
+    return 0;
+}
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM* vm, void* reserved)
+{
+    (void)reserved;
+    g_app_state.vm = vm;
+    g_app_state.context_key = NULL;
+
+    static wirelog_io_adapter_t adapter = {
+        .abi_version = WIRELOG_IO_ABI_VERSION,
+        .scheme = "android_asset",
+        .description = "Android-local asset adapter",
+        .read = android_asset_read,
+        .validate = NULL,
+        .user_data = NULL,
+    };
+    adapter.user_data = &g_app_state;
+
+    if (wirelog_io_register_adapter(&adapter) != 0) {
+        return JNI_ERR;
+    }
+    return JNI_VERSION_1_6;
+}
+```
+
+### App side path handling
+
+Android apps should resolve custom payloads through app storage, not URI
+schemes that look like file paths.
+
+- `android_asset://` is an adapter scheme, not a filesystem path.
+- Convert packaged assets to app-private storage first, then pass
+  filesystem paths from `Context.getFilesDir()`.
+
+From Kotlin:
+
+```kotlin
+val assetDir: File = context.filesDir
+val csvPath = File(assetDir, "seed/input.csv").absolutePath
+// Pass csvPath via io params in your .input directive.
+```
+
+## JNI/threading contract
+
+The native adapter callback may run on wirelog worker threads.
+Any JNI call site must follow:
+
+- call `AttachCurrentThread()` before using `JNIEnv*` on a worker
+  thread not created by Java,
+- keep the attached `JNIEnv*` only for that callback scope,
+- pair each successful attachment with `DetachCurrentThread()` before return.
+
+For callbacks that do not require JNI, keep work native only to reduce
+JNI transitions.
+
+Also confine each `wirelog_session_t` / easy-session handle to one
+execution context. If multiple threads/tasks need one handle, serialize
+those calls externally with a lock or single-thread executor.
+
+## Session and resource cleanup
+
+Because `wirelog` is embedded into the app process, avoid keeping session
+handles global across unrelated work queues without external serialization.
+
+For clean shutdown, unregister adapter handles before library unload in
+native finalization paths.
+
+## Follow-up work
+
+`examples/android/asset_adapter` is planned for #466 follow-up.
+It is not part of this atomic unit.
+
+## Cross references
+
+- `cross/android-arm64.ini`
+- `cross/android-x86_64.ini`
+- `docs/cross-compile-android.md`
+- `docs/io-adapters.md`
+- `wirelog/io/io_adapter.h`
+- `.github/workflows/android.yml`

--- a/docs/android.md
+++ b/docs/android.md
@@ -91,7 +91,6 @@ Use the current public API names (`wirelog_io_register_adapter`,
 
 typedef struct {
     JavaVM* vm;
-    jstring context_key;
 } app_jni_state_t;
 
 static app_jni_state_t g_app_state;
@@ -138,7 +137,6 @@ JNI_OnLoad(JavaVM* vm, void* reserved)
 {
     (void)reserved;
     g_app_state.vm = vm;
-    g_app_state.context_key = NULL;
 
     static wirelog_io_adapter_t adapter = {
         .abi_version = WIRELOG_IO_ABI_VERSION,
@@ -165,7 +163,7 @@ JNI_OnLoad(JavaVM* vm, void* reserved)
 
 ### App side path handling
 
-Built-in adapters (for example `io=\"csv\"`) expect real filesystem paths.
+Built-in adapters (for example `io="csv"`) expect real filesystem paths.
 Copy packaged assets to app-private storage and pass absolute paths to
 input params:
 
@@ -177,7 +175,7 @@ val csvPath = File(assetDir, "seed/input.csv").absolutePath
 // Pass csvPath via io params in your .input directive.
 ```
 
-Planned/custom `io=\"android_asset\"` adapters are scheme-based.
+Planned/custom `io="android_asset"` adapters are scheme-based.
 In that design, the `filename` value is interpreted through
 `AAssetManager` and is not a direct filesystem path. In that case,
 `android_asset://...` is a scheme marker, not a local file path.
@@ -185,8 +183,8 @@ In that design, the `filename` value is interpreted through
 ## JNI/threading contract
 
 The native adapter callback in this integration path runs synchronously from
-`wirelog_session_load_input_files()` / `wl_session_load_input_files()` on the
-invoking thread. It is not automatically dispatched onto wirelog worker
+`wirelog_load_input_files()` on the invoking thread. It is not automatically
+dispatched onto wirelog worker
 threads.
 
 When calling JNI from the callback, follow:

--- a/docs/android.md
+++ b/docs/android.md
@@ -108,11 +108,11 @@ static int android_asset_read(
 
     JNIEnv* env = NULL;
     bool attached = false;
-    int rc = (*state->vm)->GetEnv((void**)&env, JNI_VERSION_1_6);
+    int rc = (*state->vm)->GetEnv(state->vm, (void**)&env, JNI_VERSION_1_6);
     if (rc != JNI_OK) {
         if ((*state->vm)->AttachCurrentThread(
                 state->vm,
-                (void**)&env,
+                &env,
                 NULL
             ) != 0) {
             return -1;

--- a/docs/android.md
+++ b/docs/android.md
@@ -213,10 +213,13 @@ native finalization paths using:
 wirelog_io_unregister_adapter("android_asset");
 ```
 
-## Follow-up work
+## Reference implementation
 
-`examples/android/asset_adapter` is planned for #466 follow-up.
-It is not part of this atomic unit.
+Use `examples/android/asset_adapter` as the reference implementation for a full
+`android_asset` adapter backed by `AAssetManager`, including native JNI state
+setup and `.input` usage.
+
+- [Asset adapter example README](../examples/android/asset_adapter/README.md)
 
 ## Cross references
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -17,14 +17,31 @@ this version.
 
 ## AAR / Prefab consumption pattern
 
-The current v0.43 surface supports integration through Gradle/CMake
-linkage and JNI; if you already produce a local Prefab-capable `.aar`,
-consume it as a local artifact:
+The current v0.43 surface ships cross-build/source support only; it does not
+publish hosted Maven/JitPack artifacts. If you already produce a local
+Prefab-capable `.aar`, consume it as a local artifact:
 
 ```gradle
+android {
+    // Keep prefab generation enabled for native dependencies.
+    buildFeatures {
+        prefab true
+    }
+}
+
 dependencies {
     implementation(files("libs/wirelog-prefab-release.aar"))
 }
+
+// If the .aar does not include a CMake package, skip this and use
+// your own CMake wiring.
+```
+
+From `CMakeLists.txt`:
+
+```cmake
+find_package(wirelog REQUIRED CONFIG)
+target_link_libraries(mynativelib PRIVATE wirelog::wirelog)
 ```
 
 If you do not have an `.aar`, include wirelog as a native source
@@ -39,11 +56,20 @@ The supported cross-build entries are:
 
 ## Build compatibility contract
 
-- API level: minimum `21` (per shipped cross-files).
-- Page alignment:
+- API level and target policy:
+  - Native NDK API floor is `21` (from the cross-files).
+  - Current Play distribution requirements for new apps/updates submitted from
+    Aug 31 2025 on are API 35+ (Android 15); Wear/Auto/TV may have exception
+    paths.
+- Page-size and alignment:
   - `cross/android-arm64.ini` builds with the `aarch64` toolchain.
-  - `meson build -Dandroid=true` adds
+  - `meson build -Dandroid=true` applies
     `-Wl,-z,max-page-size=16384` for arm64-v8a.
+  - CI validates arm64 PT_LOAD alignment with readelf-backed checks.
+  - Android NDK guidance can also include
+    `-Wl,-z,common-page-size=16384`; if your app applies it, align your
+    entire native surface accordingly and validate every native library in your
+    APK/AAB against current Android guidance.
 - Toolchain pin: NDK `r27c` is pinned in `cross/android-arm64.ini`
   and `cross/android-x86_64.ini` as `ndk = '/opt/android-ndk-r27c'`.
 
@@ -58,6 +84,7 @@ Use the current public API names (`wirelog_io_register_adapter`,
 
 ```c
 #include <android/log.h>
+#include <stdbool.h>
 #include <jni.h>
 #include <wirelog/io/io_adapter.h>
 #include <wirelog/wirelog.h>
@@ -124,6 +151,12 @@ JNI_OnLoad(JavaVM* vm, void* reserved)
     adapter.user_data = &g_app_state;
 
     if (wirelog_io_register_adapter(&adapter) != 0) {
+        __android_log_print(
+            ANDROID_LOG_ERROR,
+            "wirelog",
+            "adapter register failed: %s",
+            wirelog_io_last_error()
+        );
         return JNI_ERR;
     }
     return JNI_VERSION_1_6;
@@ -132,12 +165,9 @@ JNI_OnLoad(JavaVM* vm, void* reserved)
 
 ### App side path handling
 
-Android apps should resolve custom payloads through app storage, not URI
-schemes that look like file paths.
-
-- `android_asset://` is an adapter scheme, not a filesystem path.
-- Convert packaged assets to app-private storage first, then pass
-  filesystem paths from `Context.getFilesDir()`.
+Built-in adapters (for example `io=\"csv\"`) expect real filesystem paths.
+Copy packaged assets to app-private storage and pass absolute paths to
+input params:
 
 From Kotlin:
 
@@ -147,13 +177,22 @@ val csvPath = File(assetDir, "seed/input.csv").absolutePath
 // Pass csvPath via io params in your .input directive.
 ```
 
+Planned/custom `io=\"android_asset\"` adapters are scheme-based.
+In that design, the `filename` value is interpreted through
+`AAssetManager` and is not a direct filesystem path. In that case,
+`android_asset://...` is a scheme marker, not a local file path.
+
 ## JNI/threading contract
 
-The native adapter callback may run on wirelog worker threads.
-Any JNI call site must follow:
+The native adapter callback in this integration path runs synchronously from
+`wirelog_session_load_input_files()` / `wl_session_load_input_files()` on the
+invoking thread. It is not automatically dispatched onto wirelog worker
+threads.
 
-- call `AttachCurrentThread()` before using `JNIEnv*` on a worker
-  thread not created by Java,
+When calling JNI from the callback, follow:
+
+- call `GetEnv()` to detect whether the thread is attached,
+- call `AttachCurrentThread()` only if the thread is not already attached,
 - keep the attached `JNIEnv*` only for that callback scope,
 - pair each successful attachment with `DetachCurrentThread()` before return.
 
@@ -170,7 +209,11 @@ Because `wirelog` is embedded into the app process, avoid keeping session
 handles global across unrelated work queues without external serialization.
 
 For clean shutdown, unregister adapter handles before library unload in
-native finalization paths.
+native finalization paths using:
+
+```c
+wirelog_io_unregister_adapter("android_asset");
+```
 
 ## Follow-up work
 

--- a/examples/android/asset_adapter/CMakeLists.txt
+++ b/examples/android/asset_adapter/CMakeLists.txt
@@ -1,0 +1,12 @@
+find_package(wirelog REQUIRED CONFIG)
+
+add_library(asset_adapter SHARED
+    asset_adapter.c
+)
+
+target_link_libraries(asset_adapter
+    PRIVATE
+        wirelog::wirelog
+        android
+        log
+)

--- a/examples/android/asset_adapter/CMakeLists.txt
+++ b/examples/android/asset_adapter/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.22)
+project(asset_adapter LANGUAGES C)
+
 find_package(wirelog REQUIRED CONFIG)
 
 add_library(asset_adapter SHARED

--- a/examples/android/asset_adapter/README.md
+++ b/examples/android/asset_adapter/README.md
@@ -25,6 +25,8 @@ parses comma/newline separated `int64` rows.
 a tiny Java/JNI bridge:
 
 ```java
+package com.wirelog.asset;
+
 public final class AssetAdapter {
     static {
         System.loadLibrary("asset_adapter");
@@ -46,6 +48,9 @@ payload alongside the `JavaVM*`.
 ## CMake usage
 
 ```cmake
+cmake_minimum_required(VERSION 3.22)
+project(asset_adapter LANGUAGES C)
+
 find_package(wirelog REQUIRED CONFIG)
 
 add_library(asset_adapter SHARED
@@ -59,9 +64,27 @@ target_link_libraries(asset_adapter
 )
 ```
 
-## `.input` usage
+## `.decl` + `.input`
 
 In your Wirelog program:
+
+```wire
+.decl seed_file(value: int64, label: int64)
+.input R(io="android_asset", filename="seed/input.csv")
+.output sum: sum(seed_file.value)
+```
+
+## Asset payload
+
+Store this CSV in `assets/seed/input.csv`:
+
+```text
+1,10
+2,20
+3,30
+```
+
+Each non-empty line maps to one row in the schema passed to your query.
 
 ```wire
 .input R(io="android_asset", filename="seed/input.csv")

--- a/examples/android/asset_adapter/README.md
+++ b/examples/android/asset_adapter/README.md
@@ -33,6 +33,7 @@ public final class AssetAdapter {
     }
 
     public static native void setAssetManager(android.content.res.AssetManager manager);
+    public static native void unregister();
 }
 ```
 
@@ -40,6 +41,8 @@ Call from Java/Kotlin before the first `wirelog` run:
 
 ```kotlin
 AssetAdapter.setAssetManager(context.assets)
+// On shutdown (optional):
+// AssetAdapter.unregister()
 ```
 
 This stores an `AAssetManager*` in native state as the adapter `user_data`
@@ -70,8 +73,8 @@ In your Wirelog program:
 
 ```wire
 .decl seed_file(value: int64, label: int64)
-.input R(io="android_asset", filename="seed/input.csv")
-.output sum: sum(seed_file.value)
+.input seed_file(io="android_asset", filename="seed/input.csv")
+.output seed_file
 ```
 
 ## Asset payload
@@ -85,10 +88,6 @@ Store this CSV in `assets/seed/input.csv`:
 ```
 
 Each non-empty line maps to one row in the schema passed to your query.
-
-```wire
-.input R(io="android_asset", filename="seed/input.csv")
-```
 
 Each non-empty line in `seed/input.csv` must contain one value per
 `wirelog_io_ctx_num_cols()` column, all `int64`.

--- a/examples/android/asset_adapter/README.md
+++ b/examples/android/asset_adapter/README.md
@@ -1,0 +1,77 @@
+# Android Asset Adapter Example
+
+This example demonstrates a minimal `android_asset` I/O adapter backed by
+`AAssetManager`. It uses only the public `wirelog` registration API:
+
+- `wirelog_io_register_adapter`
+- `wirelog_io_unregister_adapter`
+- `wirelog_io_ctx_param`
+- `wirelog_io_ctx_num_cols`
+- `wirelog_io_ctx_col_type`
+- `wirelog_io_last_error`
+
+The adapter reads assets declared via `io="android_asset"` in `.input` and
+parses comma/newline separated `int64` rows.
+
+## Integration flow
+
+1. Build the shared library from CMake (`asset_adapter`) and package as part
+   of your app.
+2. In JNI `OnLoad`, the adapter is registered.
+3. Call the generated setter once at startup to provide
+   `android.content.res.AssetManager`.
+
+`JNI_OnLoad` cannot receive an `AssetManager` object directly. The example uses
+a tiny Java/JNI bridge:
+
+```java
+public final class AssetAdapter {
+    static {
+        System.loadLibrary("asset_adapter");
+    }
+
+    public static native void setAssetManager(android.content.res.AssetManager manager);
+}
+```
+
+Call from Java/Kotlin before the first `wirelog` run:
+
+```kotlin
+AssetAdapter.setAssetManager(context.assets)
+```
+
+This stores an `AAssetManager*` in native state as the adapter `user_data`
+payload alongside the `JavaVM*`.
+
+## CMake usage
+
+```cmake
+find_package(wirelog REQUIRED CONFIG)
+
+add_library(asset_adapter SHARED
+    asset_adapter.c
+)
+
+target_link_libraries(asset_adapter
+    PRIVATE wirelog::wirelog
+    PRIVATE android
+    PRIVATE log
+)
+```
+
+## `.input` usage
+
+In your Wirelog program:
+
+```wire
+.input R(io="android_asset", filename="seed/input.csv")
+```
+
+Each non-empty line in `seed/input.csv` must contain one value per
+`wirelog_io_ctx_num_cols()` column, all `int64`.
+
+## Validation
+
+The sample is intended as a reference implementation for Android integration.
+If your workstation does not have Android NDK/CMake configured for this build
+target, skip execution and treat this as compile-time reference documentation.

--- a/examples/android/asset_adapter/asset_adapter.c
+++ b/examples/android/asset_adapter/asset_adapter.c
@@ -37,12 +37,14 @@ clear_asset_manager_state(void)
     bool vm_attached = false;
 
     if (g_adapter_state.vm != NULL) {
-        jint get_env_status = (*g_adapter_state.vm)->GetEnv((void **)&env,
-                JNI_VERSION_1_6);
+        jint get_env_status = (*g_adapter_state.vm)->GetEnv(
+            g_adapter_state.vm,
+            (void **)&env,
+            JNI_VERSION_1_6);
         if (get_env_status == JNI_EDETACHED) {
             if ((*g_adapter_state.vm)->AttachCurrentThread(
                     g_adapter_state.vm,
-                    (void **)&env,
+                    &env,
                     NULL) == JNI_OK) {
                 vm_attached = true;
             } else {

--- a/examples/android/asset_adapter/asset_adapter.c
+++ b/examples/android/asset_adapter/asset_adapter.c
@@ -1,0 +1,305 @@
+#include <android/log.h>
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+#include <jni.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wirelog/io/io_adapter.h>
+#include <wirelog/wirelog.h>
+
+#define LOG_TAG "wirelog-asset-adapter"
+#define INITIAL_ROW_CAPACITY 64
+
+typedef struct {
+    JavaVM *vm;
+    AAssetManager *asset_manager;
+} app_adapter_state_t;
+
+static app_adapter_state_t g_adapter_state;
+
+static void
+log_error(const char *message)
+{
+    __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s", message);
+}
+
+static bool
+all_columns_are_int64(wirelog_io_ctx_t *ctx)
+{
+    uint32_t ncols = wirelog_io_ctx_num_cols(ctx);
+    for (uint32_t i = 0; i < ncols; ++i) {
+        if (wirelog_io_ctx_col_type(ctx, i) != WIRELOG_TYPE_INT64) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static int
+android_asset_validate(wirelog_io_ctx_t *ctx, char *errbuf, size_t errbuf_len,
+    void *user_data)
+{
+    app_adapter_state_t *state = (app_adapter_state_t *)user_data;
+    if (!state || !state->asset_manager) {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len,
+                "asset adapter not configured with an AssetManager");
+        }
+        return -1;
+    }
+
+    const char *filename = wirelog_io_ctx_param(ctx, "filename");
+    if (!filename || filename[0] == '\0') {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len, "missing required io param: filename");
+        }
+        return -1;
+    }
+
+    if (!all_columns_are_int64(ctx)) {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len,
+                "wirelog-android adapter currently supports only int64 columns");
+        }
+        return -1;
+    }
+
+    return 0;
+}
+
+static void
+free_rows(int64_t *parsed_rows)
+{
+    free(parsed_rows);
+}
+
+static int
+append_value(int64_t *row_values, uint32_t ncols, uint32_t row_idx,
+    uint32_t col_idx,
+    const char *token, size_t token_len, char *errbuf, size_t errbuf_len)
+{
+    char copy[32];
+    if (token_len == 0 || token_len >= sizeof(copy)) {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len, "invalid int64 token in input data");
+        }
+        return -1;
+    }
+
+    memcpy(copy, token, token_len);
+    copy[token_len] = '\0';
+
+    char *tail = NULL;
+    row_values[row_idx * ncols + col_idx] = strtoll(copy, &tail, 10);
+    if (!tail || *tail != '\0') {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len, "non-integer token: %s", copy);
+        }
+        return -1;
+    }
+    return 0;
+}
+
+static int
+android_asset_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
+    uint32_t *out_nrows,
+    void *user_data)
+{
+    app_adapter_state_t *state = (app_adapter_state_t *)user_data;
+    if (!state || !state->asset_manager) {
+        log_error("asset adapter not configured with an AssetManager");
+        return -1;
+    }
+
+    const char *filename = wirelog_io_ctx_param(ctx, "filename");
+    if (!filename || filename[0] == '\0') {
+        log_error("missing required io param: filename");
+        return -1;
+    }
+
+    if (!all_columns_are_int64(ctx)) {
+        log_error(
+            "wirelog-android adapter currently supports only int64 columns");
+        return -1;
+    }
+
+    uint32_t ncols = wirelog_io_ctx_num_cols(ctx);
+    if (ncols == 0) {
+        log_error("invalid schema: expected at least one int64 column");
+        return -1;
+    }
+
+    AAsset *asset = AAssetManager_open(state->asset_manager, filename,
+            AASSET_MODE_STREAMING);
+    if (!asset) {
+        __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+            "unable to open asset: %s", filename);
+        return -1;
+    }
+
+    size_t byte_count = (size_t)AAsset_getLength64(asset);
+    if (byte_count == 0) {
+        AAsset_close(asset);
+        *out_data = NULL;
+        *out_nrows = 0;
+        return 0;
+    }
+
+    char *text = (char *)malloc(byte_count + 1);
+    if (!text) {
+        AAsset_close(asset);
+        log_error("out of memory while reading asset");
+        return -1;
+    }
+
+    size_t read_bytes = AAsset_read(asset, text, byte_count);
+    AAsset_close(asset);
+    if (read_bytes != byte_count) {
+        free(text);
+        log_error("failed to read full asset payload");
+        return -1;
+    }
+    text[byte_count] = '\0';
+
+    size_t row_capacity = INITIAL_ROW_CAPACITY;
+    size_t rows = 0;
+    int64_t *parsed_rows = (int64_t *)malloc(row_capacity * ncols *
+            sizeof(int64_t));
+    if (!parsed_rows) {
+        free(text);
+        log_error("out of memory while allocating row buffer");
+        return -1;
+    }
+
+    char *line_save = NULL;
+    for (char *line = strtok_r(text, "\r\n", &line_save);
+        line != NULL;
+        line = strtok_r(NULL, "\r\n", &line_save)) {
+
+        bool has_non_ws = false;
+        for (const char *scan = line; *scan != '\0'; ++scan) {
+            if (*scan != ' ' && *scan != '\t') {
+                has_non_ws = true;
+                break;
+            }
+        }
+        if (!has_non_ws) {
+            continue;
+        }
+
+        if (rows == row_capacity) {
+            size_t next_capacity = row_capacity * 2;
+            int64_t *grown = (int64_t *)realloc(
+                parsed_rows,
+                next_capacity * ncols * sizeof(int64_t));
+            if (!grown) {
+                free_rows(parsed_rows);
+                free(text);
+                log_error("out of memory while growing row buffer");
+                return -1;
+            }
+            parsed_rows = grown;
+            row_capacity = next_capacity;
+        }
+
+        uint32_t col_idx = 0;
+        char token_error[96] = {0};
+        char *token_save = NULL;
+        for (char *token = strtok_r(line, ",", &token_save);
+            token != NULL;
+            token = strtok_r(NULL, ",", &token_save), ++col_idx) {
+
+            if (col_idx >= ncols) {
+                free_rows(parsed_rows);
+                free(text);
+                __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+                    "too many columns in row %zu", rows);
+                return -1;
+            }
+
+            while (*token == ' ' || *token == '\t') {
+                ++token;
+            }
+            char *token_end = token + strlen(token);
+            while (token_end > token &&
+                ((token_end[-1] == ' ') || (token_end[-1] == '\t'))) {
+                --token_end;
+            }
+
+            if (append_value(parsed_rows, ncols, (uint32_t)rows, col_idx,
+                token, (size_t)(token_end - token), token_error,
+                sizeof(token_error)) != 0) {
+                free_rows(parsed_rows);
+                free(text);
+                log_error(token_error);
+                return -1;
+            }
+        }
+
+        if (col_idx != ncols) {
+            free_rows(parsed_rows);
+            free(text);
+            log_error("row column count does not match schema");
+            return -1;
+        }
+        ++rows;
+    }
+
+    free(text);
+
+    if ((uint64_t)rows > UINT32_MAX) {
+        free_rows(parsed_rows);
+        log_error("too many rows for API return type");
+        return -1;
+    }
+
+    *out_data = parsed_rows;
+    *out_nrows = (uint32_t)rows;
+    return 0;
+}
+
+static wirelog_io_adapter_t g_asset_adapter = {
+    .abi_version = WIRELOG_IO_ABI_VERSION,
+    .scheme = "android_asset",
+    .description = "Android AAsset-backed CSV adapter",
+    .read = android_asset_read,
+    .validate = android_asset_validate,
+    .user_data = &g_adapter_state,
+};
+
+JNIEXPORT void JNICALL
+Java_com_wirelog_asset_AssetAdapter_setAssetManager(JNIEnv *env, jclass clazz,
+    jobject java_asset_manager)
+{
+    (void)clazz;
+    g_adapter_state.asset_manager = AAssetManager_fromJava(env,
+            java_asset_manager);
+}
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    (void)reserved;
+    g_adapter_state.vm = vm;
+    g_adapter_state.asset_manager = NULL;
+
+    if (wirelog_io_register_adapter(&g_asset_adapter) != 0) {
+        __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+            "wirelog_io_register_adapter failed: %s",
+            wirelog_io_last_error());
+        return JNI_ERR;
+    }
+    return JNI_VERSION_1_6;
+}
+
+JNIEXPORT void JNICALL
+Java_com_wirelog_asset_AssetAdapter_unregister(JNIEnv *env, jclass clazz)
+{
+    (void)env;
+    (void)clazz;
+    wirelog_io_unregister_adapter("android_asset");
+}

--- a/examples/android/asset_adapter/asset_adapter.c
+++ b/examples/android/asset_adapter/asset_adapter.c
@@ -33,6 +33,7 @@ static void
 clear_asset_manager_state(void)
 {
     JNIEnv *env = NULL;
+    jobject old_manager = g_adapter_state.java_asset_manager;
     bool vm_attached = false;
 
     if (g_adapter_state.vm != NULL) {
@@ -54,13 +55,12 @@ clear_asset_manager_state(void)
         }
     }
 
-    if (env != NULL && g_adapter_state.java_asset_manager != NULL) {
-        (*env)->DeleteGlobalRef(env, g_adapter_state.java_asset_manager);
+    if (env != NULL && old_manager != NULL) {
+        (*env)->DeleteGlobalRef(env, old_manager);
         g_adapter_state.java_asset_manager = NULL;
-    } else if (g_adapter_state.java_asset_manager != NULL) {
+    } else if (old_manager != NULL) {
         __android_log_print(ANDROID_LOG_WARN, LOG_TAG,
             "cannot clear old AssetManager global ref: JNIEnv unavailable");
-        g_adapter_state.java_asset_manager = NULL;
     }
 
     if (vm_attached) {

--- a/examples/android/asset_adapter/asset_adapter.c
+++ b/examples/android/asset_adapter/asset_adapter.c
@@ -1,6 +1,7 @@
 #include <android/log.h>
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
+#include <errno.h>
 #include <jni.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -16,6 +17,7 @@
 
 typedef struct {
     JavaVM *vm;
+    jobject java_asset_manager;
     AAssetManager *asset_manager;
 } app_adapter_state_t;
 
@@ -25,6 +27,74 @@ static void
 log_error(const char *message)
 {
     __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s", message);
+}
+
+static void
+clear_asset_manager_state(void)
+{
+    JNIEnv *env = NULL;
+    bool vm_attached = false;
+
+    if (g_adapter_state.vm != NULL) {
+        jint get_env_status = (*g_adapter_state.vm)->GetEnv((void **)&env,
+                JNI_VERSION_1_6);
+        if (get_env_status == JNI_EDETACHED) {
+            if ((*g_adapter_state.vm)->AttachCurrentThread(
+                    g_adapter_state.vm,
+                    (void **)&env,
+                    NULL) == JNI_OK) {
+                vm_attached = true;
+            } else {
+                __android_log_print(ANDROID_LOG_WARN, LOG_TAG,
+                    "cannot clear old AssetManager global ref: failed to attach");
+            }
+        } else if (get_env_status != JNI_OK) {
+            __android_log_print(ANDROID_LOG_WARN, LOG_TAG,
+                "cannot clear old AssetManager global ref: GetEnv failed");
+        }
+    }
+
+    if (env != NULL && g_adapter_state.java_asset_manager != NULL) {
+        (*env)->DeleteGlobalRef(env, g_adapter_state.java_asset_manager);
+        g_adapter_state.java_asset_manager = NULL;
+    } else if (g_adapter_state.java_asset_manager != NULL) {
+        __android_log_print(ANDROID_LOG_WARN, LOG_TAG,
+            "cannot clear old AssetManager global ref: JNIEnv unavailable");
+        g_adapter_state.java_asset_manager = NULL;
+    }
+
+    if (vm_attached) {
+        (*g_adapter_state.vm)->DetachCurrentThread(g_adapter_state.vm);
+    }
+
+    g_adapter_state.asset_manager = NULL;
+}
+
+static void
+set_asset_manager(JNIEnv *env, jobject java_asset_manager)
+{
+    clear_asset_manager_state();
+    if (java_asset_manager == NULL) {
+        log_error("received NULL AssetManager");
+        return;
+    }
+
+    jobject global_manager = (*env)->NewGlobalRef(env, java_asset_manager);
+    if (global_manager == NULL) {
+        log_error("failed to create global ref for AssetManager");
+        return;
+    }
+
+    AAssetManager *asset_manager = AAssetManager_fromJava(env,
+            java_asset_manager);
+    if (asset_manager == NULL) {
+        (*env)->DeleteGlobalRef(env, global_manager);
+        log_error("failed to convert Java AssetManager to native");
+        return;
+    }
+
+    g_adapter_state.java_asset_manager = global_manager;
+    g_adapter_state.asset_manager = asset_manager;
 }
 
 static bool
@@ -94,13 +164,42 @@ append_value(int64_t *row_values, uint32_t ncols, uint32_t row_idx,
     copy[token_len] = '\0';
 
     char *tail = NULL;
-    row_values[row_idx * ncols + col_idx] = strtoll(copy, &tail, 10);
+    errno = 0;
+    long long value = strtoll(copy, &tail, 10);
+    if (errno == ERANGE) {
+        if (errbuf_len > 0) {
+            snprintf(errbuf, errbuf_len,
+                "int64 token out of range: %s", copy);
+        }
+        return -1;
+    }
     if (!tail || *tail != '\0') {
         if (errbuf_len > 0) {
             snprintf(errbuf, errbuf_len, "non-integer token: %s", copy);
         }
         return -1;
     }
+    row_values[row_idx * ncols + col_idx] = value;
+    return 0;
+}
+
+static int
+read_asset_fully(AAsset *asset, char *buffer, size_t byte_count)
+{
+    size_t read_total = 0;
+    while (read_total < byte_count) {
+        int64_t chunk = AAsset_read(asset, buffer + read_total,
+                byte_count - read_total);
+        if (chunk < 0) {
+            return -1;
+        }
+        if (chunk == 0) {
+            return -1;
+        }
+
+        read_total += (size_t)chunk;
+    }
+
     return 0;
 }
 
@@ -156,13 +255,13 @@ android_asset_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
         return -1;
     }
 
-    size_t read_bytes = AAsset_read(asset, text, byte_count);
-    AAsset_close(asset);
-    if (read_bytes != byte_count) {
+    if (read_asset_fully(asset, text, byte_count) != 0) {
         free(text);
+        AAsset_close(asset);
         log_error("failed to read full asset payload");
         return -1;
     }
+    AAsset_close(asset);
     text[byte_count] = '\0';
 
     size_t row_capacity = INITIAL_ROW_CAPACITY;
@@ -276,8 +375,7 @@ Java_com_wirelog_asset_AssetAdapter_setAssetManager(JNIEnv *env, jclass clazz,
     jobject java_asset_manager)
 {
     (void)clazz;
-    g_adapter_state.asset_manager = AAssetManager_fromJava(env,
-            java_asset_manager);
+    set_asset_manager(env, java_asset_manager);
 }
 
 JNIEXPORT jint JNICALL
@@ -286,6 +384,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     (void)reserved;
     g_adapter_state.vm = vm;
     g_adapter_state.asset_manager = NULL;
+    g_adapter_state.java_asset_manager = NULL;
 
     if (wirelog_io_register_adapter(&g_asset_adapter) != 0) {
         __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
@@ -301,5 +400,15 @@ Java_com_wirelog_asset_AssetAdapter_unregister(JNIEnv *env, jclass clazz)
 {
     (void)env;
     (void)clazz;
+    clear_asset_manager_state();
+    wirelog_io_unregister_adapter("android_asset");
+}
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM *vm, void *reserved)
+{
+    (void)reserved;
+    g_adapter_state.vm = vm;
+    clear_asset_manager_state();
     wirelog_io_unregister_adapter("android_asset");
 }


### PR DESCRIPTION
## Summary
- add docs/android.md covering Android AAR/Prefab integration, JNI adapter registration, path handling, threading, API/NDK policy, and 16 KB alignment
- add examples/android/asset_adapter with an AAssetManager-backed android_asset adapter, CMake reference, and end-to-end README
- update Android CI to run for docs/android.md and examples/android/** changes, compile the asset adapter for arm64-v8a, and gate its 16 KB PT_LOAD alignment

Closes #466

## Validation
- git diff --check origin/main..HEAD
- npx --yes markdownlint-cli docs/android.md examples/android/asset_adapter/README.md
- source .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md
- meson test -C build changelog_format release_template
- rg -n 'wl_io_|WL_IO_|wirelog_session_load_input_files|jstring context_key|io=\\\\"' docs/android.md examples/android/asset_adapter .github/workflows/android.yml (no matches)\n\n## Workflow Review\n- Android guide commits: 19c201f, 9a52e8e, bc1ea64\n- Asset adapter commits: 4cf0b11, 4f6a1b3, c19d31b\n- CI compile/alignment commits: 2f367a7, 7d1fb95\n- Reviewer feedback was handled; Architect and Critic verified no blocking feedback remains\n\n## Known Scope\n- Android runtime/emulator validation is out of scope for #466.\n- CI compiles the example directly with NDK clang rather than executing the example CMake package path.\n