### PR TITLE
release: prepare 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ All notable changes to wirelog are documented in this file.
 - Documented the required-check policy for mbedTLS-enabled validation,
   including the stable `mbedtls-enabled / ubuntu-latest / gcc` check
   name and its PR, main-monitoring, `release-1.x`, and release-tag
-  roles without changing the default `mbedtls=disabled` artifact
+  roles without changing the default `mbedTLS=disabled` artifact
   posture (#849).
 - Added `docs/PLATFORM_SUPPORT.md` to classify Android/iOS release
   artifacts as Tier-2 for 1.x, documenting that Android AAR/Prefab and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.43.0] - 2026-05-24
+
+### Added
+
 - Added a dedicated `mbedtls-enabled / ubuntu-latest / gcc` CI leg
   that configures with `-DmbedTLS=enabled`, verifies
   `WL_MBEDTLS_ENABLED=1`, and runs `cryptographic_hashes` so optional
@@ -35,11 +53,13 @@ All notable changes to wirelog are documented in this file.
 - **Recursive aggregation conformance for columnar MIN/MAX** (#692):
   REDUCE plan ops now carry aggregate expressions, so recursive
   aggregates evaluate `min(l)` / `max(d + w)` instead of falling back to
-  a positional input column.  Recursive MIN/MAX IDBs are canonicalized
-  after sequential fixed-point convergence and TDD final merge so
-  dominated aggregate rows are removed from snapshots.  Adds
-  `recursive_agg_conformance` coverage for CC-min, SSSP-max, and
-  stratified COUNT at workers 1, 4, 8, and 16.
+  a positional input column. This release includes the #852 recursive
+  aggregation fix recorded under #859 while preserving #692 context.
+  Recursive MIN/MAX IDBs are canonicalized after sequential
+  fixed-point convergence and TDD final merge so dominated aggregate
+  rows are removed from snapshots. Adds `recursive_agg_conformance`
+  coverage for CC-min, SSSP-max, and stratified COUNT at workers 1,
+  4, 8, and 16.
 
 ### Performance
 
@@ -48,8 +68,9 @@ All notable changes to wirelog are documented in this file.
   re-running TDD evaluation when no input or retraction state is pending.
 - **CSPA W=1 perf gate** (#818): added `test_cspa_perf_gate` as a
   dedicated static `cspa-fast` regression guard for `W=1` using 9-trial
-  median timing, 20,381-tuple/6-iteration correctness sentinels, and the
-  shared `WIRELOG_PERF_GATE` / `WIRELOG_PERF_REQUIRE` control flow.
+  median timing, 20,381-tuple/6-iteration correctness sentinels, and
+  the shared `WIRELOG_PERF_GATE` / `WIRELOG_PERF_REQUIRE` control
+  flow.
 - **v0.43 benchmark speedup notes draft** (#794, #512, #791): added
   the portfolio speedup draft with #512 timing deltas, changed-commit
   provenance, and memory-trade-off context:
@@ -62,16 +83,16 @@ All notable changes to wirelog are documented in this file.
 - Documented the required-check policy for mbedTLS-enabled validation,
   including the stable `mbedtls-enabled / ubuntu-latest / gcc` check
   name and its PR, main-monitoring, `release-1.x`, and release-tag
-  roles without changing the default `mbedTLS=disabled` artifact
+  roles without changing the default `mbedtls=disabled` artifact
   posture (#849).
 - Added `docs/PLATFORM_SUPPORT.md` to classify Android/iOS release
   artifacts as Tier-2 for 1.x, documenting that Android AAR/Prefab and
   iOS XCFramework publication are deferred until explicit future
   promotion work is completed (#697).
-- Added `docs/ios.md` with iOS integration guidance for `wirelog.xcframework`
-  consumption, Swift callback registration with trailing `user_data`,
-  simulator architecture handling, and App Store/tooling constraints for
-  #470.
+- Added `docs/ios.md` with iOS integration guidance for
+  `wirelog.xcframework` consumption, Swift callback registration with
+  trailing `user_data`, simulator architecture handling, and
+  App Store/tooling constraints for #470.
 - Added `docs/android.md` with Android integration guidance for
   AAR/Prefab consumption patterns, JNI thread attachment patterns,
   `Context.getFilesDir()` path handling, and Android CI/alignment

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,30 @@
 # Migration Guide
 
-**Last Updated:** 2026-05-20
+**Last Updated:** 2026-05-24
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.41 -> 0.43
+
+Version `0.43.0` follows `0.41.0` directly; `0.42` was skipped
+by maintainer decision for #859. No source-level migration steps are
+required for applications already on the 0.41 public API surface.
+
+- **Overflow handling is fail-closed for numerical operations.**  Columnar
+  numeric operators now return hard errors on overflow/underflow and
+  reject rows that cannot be represented safely (`ERANGE`), including
+  checked `sum()` and `to_number()` parsing paths.
+- **Recursive aggregation output is now canonicalized deterministically.**
+  Recursive columnar MIN/MAX behavior now consistently follows the fixed
+  MIN/MAX residue semantics and the associated conformance checks from
+  #692/#859/#852.
+- **Platform artifacts remain Tier-2/deferred for 0.43.**  Android AAR/
+  Prefab and iOS XCFramework publication continues to be deferred in
+  `docs/PLATFORM_SUPPORT.md`; there is no published binary-artifact policy
+  change in this point release.
 
 ## 0.40 -> 0.41
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.41.99',
+  version: '0.43.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary
- prepare v0.43.0 release metadata by moving current CHANGELOG entries into `## [0.43.0] - 2026-05-24`
- reset `[Unreleased]` headings and bump Meson `project_version` to `0.43.0`
- add `0.41 -> 0.43` migration notes, including skipped v0.42 and #852/#859 provenance

Prepares #859 and #683. Does not close #859; that issue should close only after the `v0.43.0` tag and GitHub Release exist.

## Implementation workflow
- Architect and Critic agreed the next atomic unit is release-prep PR metadata, not direct tagging.
- Implementer commit `62b36a5` prepared the release metadata.
- Reviewer found one blocker: invalid `mbedtls=disabled` option spelling in release notes.
- Architect and Critic agreed it was blocking.
- Implementer commit `c32f85c` fixed the spelling to `mbedTLS=disabled`.
- Reviewer, Architect, and Critic verified no blockers remain.

## Validation
- `git diff --check`
- `. .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md`
- `meson setup build-release-prep --wipe`
- `meson test -C build-release-prep changelog_format version_sync release_template --print-errorlogs`
- `./scripts/release/extract-changelog-section.sh 0.43.0`
