### PR TITLE
build: pin nanoarrow wrap revision

### DIFF
--- a/scripts/ci/check-wrap-revisions.sh
+++ b/scripts/ci/check-wrap-revisions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # check-wrap-revisions.sh - Issue #715 release dependency pin guard.
 #
-# Reject Meson wrap files that depend on floating git branch names. Release
-# dependency wraps must be pinned to immutable revisions or checksum-verified
-# archives.
+# Reject Meson wrap files that are not reproducible. Release dependency
+# wraps must pin git dependencies to immutable commits and checksum archive
+# downloads.
 
 set -euo pipefail
 
@@ -11,27 +11,127 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
 fail=0
+
+trim() {
+    local s=$1
+    s=${s#"${s%%[![:space:]]*}"}
+    s=${s%"${s##*[![:space:]]}"}
+    printf '%s' "$s"
+}
+
+strip_inline_comment() {
+    local s=$1
+    s=${s%%#*}
+    trim "$s"
+}
+
+report_fail() {
+    if [ "$fail" -eq 0 ]; then
+        echo "check-wrap-revisions: FAIL: unreproducible wrap dependency found" >&2
+    fi
+    echo "  $1" >&2
+    fail=1
+}
+
+check_wrap() {
+    local wrap=$1
+    local rel=${wrap#$repo_root/}
+    local section=""
+    local section_line=0
+    local revision=""
+    local revision_line=0
+    local source_url_line=0
+    local source_hash=""
+    local patch_url_line=0
+    local patch_hash=""
+
+    finish_section() {
+        case "$section" in
+            wrap-git)
+                if [ -z "$revision" ]; then
+                    report_fail "$rel:$section_line: [wrap-git] missing revision"
+                elif ! [[ "$revision" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                    report_fail "$rel:$revision_line: revision must be a 40-hex commit, got '$revision'"
+                fi
+                ;;
+            wrap-file)
+                if [ "$source_url_line" -ne 0 ] && [ -z "$source_hash" ]; then
+                    report_fail "$rel:$source_url_line: source_url requires non-empty source_hash"
+                fi
+                if [ "$patch_url_line" -ne 0 ] && [ -z "$patch_hash" ]; then
+                    report_fail "$rel:$patch_url_line: patch_url requires non-empty patch_hash"
+                fi
+                ;;
+        esac
+    }
+
+    reset_section_state() {
+        revision=""
+        revision_line=0
+        source_url_line=0
+        source_hash=""
+        patch_url_line=0
+        patch_hash=""
+    }
+
+    local line_no=0
+    local line key value
+    while IFS= read -r line || [ -n "$line" ]; do
+        line_no=$((line_no + 1))
+        line=$(trim "$line")
+        [ -z "$line" ] && continue
+        [[ "$line" == \#* ]] && continue
+
+        if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+            local new_section=${BASH_REMATCH[1]}
+            finish_section
+            section=$new_section
+            section_line=$line_no
+            reset_section_state
+            continue
+        fi
+
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+            key=$(trim "${BASH_REMATCH[1]}")
+            value=$(strip_inline_comment "${BASH_REMATCH[2]}")
+            case "$section:$key" in
+                wrap-git:revision)
+                    revision=$value
+                    revision_line=$line_no
+                    ;;
+                wrap-file:source_url)
+                    if [ -n "$value" ]; then
+                        source_url_line=$line_no
+                    fi
+                    ;;
+                wrap-file:source_hash)
+                    source_hash=$value
+                    ;;
+                wrap-file:patch_url)
+                    if [ -n "$value" ]; then
+                        patch_url_line=$line_no
+                    fi
+                    ;;
+                wrap-file:patch_hash)
+                    patch_hash=$value
+                    ;;
+            esac
+        fi
+    done <"$wrap"
+
+    finish_section
+}
+
 for wrap in "$repo_root"/subprojects/*.wrap; do
     [ -e "$wrap" ] || continue
-    matches=$(mktemp)
-    if grep -nEi '^[[:space:]]*revision[[:space:]]*=[[:space:]]*(main|master)([[:space:]]*(#.*)?)?$' \
-            "$wrap" >"$matches"; then
-        if [ "$fail" -eq 0 ]; then
-            echo "check-wrap-revisions: FAIL: floating wrap revisions found" >&2
-        fi
-        while IFS= read -r match; do
-            echo "  ${wrap#$repo_root/}:$match" >&2
-        done <"$matches"
-        fail=1
-    fi
-    rm -f "$matches"
+    check_wrap "$wrap"
 done
 
 if [ "$fail" -ne 0 ]; then
     echo "" >&2
-    echo "Pin release dependency wraps to immutable commits or use" >&2
-    echo "checksum-verified wrap-file archives." >&2
+    echo "Pin [wrap-git] dependencies to 40-hex commits and provide" >&2
+    echo "source_hash/patch_hash for [wrap-file] archive URLs." >&2
     exit 1
 fi
 
-echo "check-wrap-revisions: OK; no revision=main/master in subprojects/*.wrap"
+echo "check-wrap-revisions: OK; release dependency wraps are reproducible"

--- a/scripts/ci/check-wrap-revisions.sh
+++ b/scripts/ci/check-wrap-revisions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check-wrap-revisions.sh - Issue #715 release dependency pin guard.
+#
+# Reject Meson wrap files that depend on floating git branch names. Release
+# dependency wraps must be pinned to immutable revisions or checksum-verified
+# archives.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+fail=0
+for wrap in "$repo_root"/subprojects/*.wrap; do
+    [ -e "$wrap" ] || continue
+    matches=$(mktemp)
+    if grep -nEi '^[[:space:]]*revision[[:space:]]*=[[:space:]]*(main|master)([[:space:]]*(#.*)?)?$' \
+            "$wrap" >"$matches"; then
+        if [ "$fail" -eq 0 ]; then
+            echo "check-wrap-revisions: FAIL: floating wrap revisions found" >&2
+        fi
+        while IFS= read -r match; do
+            echo "  ${wrap#$repo_root/}:$match" >&2
+        done <"$matches"
+        fail=1
+    fi
+    rm -f "$matches"
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "" >&2
+    echo "Pin release dependency wraps to immutable commits or use" >&2
+    echo "checksum-verified wrap-file archives." >&2
+    exit 1
+fi
+
+echo "check-wrap-revisions: OK; no revision=main/master in subprojects/*.wrap"

--- a/subprojects/nanoarrow.wrap
+++ b/subprojects/nanoarrow.wrap
@@ -1,7 +1,6 @@
 [wrap-git]
 url = https://github.com/apache/arrow-nanoarrow.git
-revision = main
-depth = 1
+revision = 8dcb55e735354ece7e1776d2d9577806cda3ee00
 
 [provide]
 nanoarrow = nanoarrow_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -617,9 +617,9 @@ if sh.found()
        suite: 'abi')
 endif
 
-# Issue #715: release dependency wraps must not float on main/master.
-# Wrap-file archives with source_hash/patch_hash (for example xxhash.wrap)
-# are allowed; git wraps must pin immutable revisions.
+# Issue #715: release dependency wraps must be reproducible.  Git wraps
+# must pin immutable 40-hex commits; wrap-file archive URLs must have
+# matching source_hash/patch_hash entries.
 if sh.found()
   test('wrap_revisions', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-wrap-revisions.sh'],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -617,6 +617,15 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #715: release dependency wraps must not float on main/master.
+# Wrap-file archives with source_hash/patch_hash (for example xxhash.wrap)
+# are allowed; git wraps must pin immutable revisions.
+if sh.found()
+  test('wrap_revisions', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-wrap-revisions.sh'],
+       suite: 'abi')
+endif
+
 # Issue #737: forbid new unanchored "Phase NX" labels in wirelog/ source.
 # Each Phase NX label must either carry an explicit issue cross-reference
 # on the same line ("#N", "Issue N", "US-N-NNN"), or be present in the


### PR DESCRIPTION
## Summary

- Pin `subprojects/nanoarrow.wrap` to immutable commit `8dcb55e735354ece7e1776d2d9577806cda3ee00` instead of floating on `main`.
- Add `wrap_revisions` ABI guard for reproducible Meson wraps: git wraps require 40-hex commits, wrap-file archive URLs require matching hashes.
- Register the guard in Meson so release dependency drift fails CI.

## Workflow Review

- Commit `b1c9412` reviewed immediately: no blockers; Architect/Critic agreed it can stand.
- Commit `9564062` reviewed immediately: no blockers; Architect/Critic agreed #715 is complete enough for PR/closure.

## Validation

- `git diff --check origin/main..HEAD`
- `bash -n scripts/ci/check-wrap-revisions.sh`
- `scripts/ci/check-wrap-revisions.sh`
- `meson setup --wipe build-715`
- `meson test -C build-715 wrap_revisions --print-errorlogs`
- `meson compile -C build-715`
- `git show --check --stat HEAD`

Closes #715
