### PR TITLE
fuzz: add libFuzzer soak evidence workflow

### DIFF
--- a/.github/workflows/fuzz-evidence.yml
+++ b/.github/workflows/fuzz-evidence.yml
@@ -24,22 +24,37 @@ on:
         required: true
         default: '["ubuntu-latest"]'
         type: string
+      timeout_minutes:
+        description: Job timeout in minutes; separate from per-target libFuzzer duration
+        required: true
+        default: "360"
+        type: string
 
 jobs:
   fuzz-evidence:
     name: libFuzzer evidence
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     env:
       FUZZ_TARGET: ${{ inputs.target }}
       FUZZ_DURATION: ${{ inputs.duration }}
       FUZZ_RUNS_ON: ${{ inputs.runs_on }}
+      FUZZ_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
 
     steps:
-      - name: Validate runner and duration
+      - name: Validate runner, duration, and timeout
         shell: bash
         run: |
+          readonly hosted_limit_minutes=360
+          readonly buffer_minutes=60
+
           if [[ ! "$FUZZ_DURATION" =~ ^[0-9]+([smh])?$ ]]; then
             echo "duration must be an integer number of seconds or use s/m/h suffix: $FUZZ_DURATION" >&2
+            exit 1
+          fi
+
+          if [[ ! "$FUZZ_TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]]; then
+            echo "timeout_minutes must be a positive integer: $FUZZ_TIMEOUT_MINUTES" >&2
             exit 1
           fi
 
@@ -51,9 +66,23 @@ jobs:
             s|"") seconds=$value ;;
           esac
 
+          if [ "$FUZZ_TARGET" = "all" ]; then
+            target_count=4
+          else
+            target_count=1
+          fi
+
+          required_minutes=$((((seconds * target_count) + 59) / 60 + buffer_minutes))
+          if [ "$FUZZ_TIMEOUT_MINUTES" -lt "$required_minutes" ]; then
+            echo "timeout_minutes=$FUZZ_TIMEOUT_MINUTES is too small for target=$FUZZ_TARGET duration=$FUZZ_DURATION." >&2
+            echo "Estimated minimum is ${required_minutes} minutes, including ${buffer_minutes} minutes for setup, minimization, and upload." >&2
+            exit 1
+          fi
+
           compact_runs_on="${FUZZ_RUNS_ON//[[:space:]]/}"
-          if [ "$compact_runs_on" = '["ubuntu-latest"]' ] && [ "$seconds" -ge 86400 ]; then
-            echo "duration=$FUZZ_DURATION is release-length evidence and cannot use the hosted default runs_on=$FUZZ_RUNS_ON." >&2
+          if [ "$compact_runs_on" = '["ubuntu-latest"]' ] && [ "$required_minutes" -gt "$hosted_limit_minutes" ]; then
+            echo "target=$FUZZ_TARGET duration=$FUZZ_DURATION needs about ${required_minutes} minutes and cannot use the hosted default runs_on=$FUZZ_RUNS_ON." >&2
+            echo "GitHub-hosted runners are limited to about ${hosted_limit_minutes} minutes." >&2
             echo "Use runs_on labels for a runner whose runtime policy supports the requested duration." >&2
             exit 1
           fi

--- a/.github/workflows/fuzz-evidence.yml
+++ b/.github/workflows/fuzz-evidence.yml
@@ -1,0 +1,90 @@
+name: Fuzz Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Fuzz target to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - parser
+          - csv_reader
+          - intern
+          - compound_arena
+      duration:
+        description: Per-target libFuzzer duration, for example 60s or 24h
+        required: true
+        default: 60s
+        type: string
+
+jobs:
+  fuzz-evidence:
+    name: libFuzzer evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 6000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install fuzz build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang meson ninja-build
+          clang --version
+          meson --version
+          ninja --version
+
+      - name: Configure fuzz build
+        run: |
+          CC=clang meson setup build-fuzz -Denable_fuzz=true -Db_sanitize=address
+
+      - name: Compile fuzz targets
+        run: |
+          meson compile -C build-fuzz \
+            parser_fuzz csv_reader_fuzz intern_fuzz compound_arena_fuzz
+
+      - name: Run libFuzzer soak
+        run: |
+          if [ "${{ inputs.target }}" = "all" ]; then
+            target_args=(--all)
+          else
+            target_args=(--target "${{ inputs.target }}")
+          fi
+
+          scripts/fuzz/run-libfuzzer-soak.sh \
+            --build-dir build-fuzz \
+            --work-dir fuzz-evidence/soak \
+            --duration "${{ inputs.duration }}" \
+            "${target_args[@]}"
+
+      - name: Minimize corpus
+        if: ${{ success() }}
+        run: |
+          if [ "${{ inputs.target }}" = "all" ]; then
+            target_args=(--all)
+          else
+            target_args=(--target "${{ inputs.target }}")
+          fi
+
+          if [ ! -d fuzz-evidence/soak ]; then
+            echo "No soak evidence root found; skipping minimization."
+            exit 0
+          fi
+
+          scripts/fuzz/minimize-libfuzzer-corpus.sh \
+            --build-dir build-fuzz \
+            --input-dir fuzz-evidence/soak \
+            --out-dir fuzz-evidence/minimized \
+            "${target_args[@]}"
+
+      - name: Upload fuzz evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-evidence-${{ inputs.target }}-${{ inputs.duration }}
+          path: fuzz-evidence
+          if-no-files-found: warn

--- a/.github/workflows/fuzz-evidence.yml
+++ b/.github/workflows/fuzz-evidence.yml
@@ -19,18 +19,50 @@ on:
         required: true
         default: 60s
         type: string
+      runs_on:
+        description: JSON runner labels; use a long-running self-hosted/larger runner for 24h evidence
+        required: true
+        default: '["ubuntu-latest"]'
+        type: string
 
 jobs:
   fuzz-evidence:
     name: libFuzzer evidence
-    runs-on: ubuntu-latest
-    timeout-minutes: 6000
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    env:
+      FUZZ_TARGET: ${{ inputs.target }}
+      FUZZ_DURATION: ${{ inputs.duration }}
+      FUZZ_RUNS_ON: ${{ inputs.runs_on }}
 
     steps:
+      - name: Validate runner and duration
+        shell: bash
+        run: |
+          if [[ ! "$FUZZ_DURATION" =~ ^[0-9]+([smh])?$ ]]; then
+            echo "duration must be an integer number of seconds or use s/m/h suffix: $FUZZ_DURATION" >&2
+            exit 1
+          fi
+
+          value="${FUZZ_DURATION%[smh]}"
+          suffix="${FUZZ_DURATION:${#value}}"
+          case "$suffix" in
+            h) seconds=$((value * 3600)) ;;
+            m) seconds=$((value * 60)) ;;
+            s|"") seconds=$value ;;
+          esac
+
+          compact_runs_on="${FUZZ_RUNS_ON//[[:space:]]/}"
+          if [ "$compact_runs_on" = '["ubuntu-latest"]' ] && [ "$seconds" -ge 86400 ]; then
+            echo "duration=$FUZZ_DURATION is release-length evidence and cannot use the hosted default runs_on=$FUZZ_RUNS_ON." >&2
+            echo "Use runs_on labels for a runner whose runtime policy supports the requested duration." >&2
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
 
       - name: Install fuzz build dependencies
+        shell: bash
         run: |
           sudo apt-get update
           sudo apt-get install -y clang meson ninja-build
@@ -39,35 +71,39 @@ jobs:
           ninja --version
 
       - name: Configure fuzz build
+        shell: bash
         run: |
           CC=clang meson setup build-fuzz -Denable_fuzz=true -Db_sanitize=address
 
       - name: Compile fuzz targets
+        shell: bash
         run: |
           meson compile -C build-fuzz \
             parser_fuzz csv_reader_fuzz intern_fuzz compound_arena_fuzz
 
       - name: Run libFuzzer soak
+        shell: bash
         run: |
-          if [ "${{ inputs.target }}" = "all" ]; then
+          if [ "$FUZZ_TARGET" = "all" ]; then
             target_args=(--all)
           else
-            target_args=(--target "${{ inputs.target }}")
+            target_args=(--target "$FUZZ_TARGET")
           fi
 
           scripts/fuzz/run-libfuzzer-soak.sh \
             --build-dir build-fuzz \
             --work-dir fuzz-evidence/soak \
-            --duration "${{ inputs.duration }}" \
+            --duration "$FUZZ_DURATION" \
             "${target_args[@]}"
 
       - name: Minimize corpus
         if: ${{ success() }}
+        shell: bash
         run: |
-          if [ "${{ inputs.target }}" = "all" ]; then
+          if [ "$FUZZ_TARGET" = "all" ]; then
             target_args=(--all)
           else
-            target_args=(--target "${{ inputs.target }}")
+            target_args=(--target "$FUZZ_TARGET")
           fi
 
           if [ ! -d fuzz-evidence/soak ]; then
@@ -88,3 +124,4 @@ jobs:
           name: fuzz-evidence-${{ inputs.target }}-${{ inputs.duration }}
           path: fuzz-evidence
           if-no-files-found: warn
+          retention-days: 30

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -171,6 +171,11 @@ tooling gap and verify the script help and missing-tool error path instead.
 
 ## Follow-Ups
 
-Issue `#743` lands the harnesses, seed corpora, AFL++ entrypoints, and
-libFuzzer smoke scaffold only. Longer 24h soak runs, corpus workflow, and B7
-GitHub comment/reporting integration remain follow-ups under `#694` / `#874`.
+Issue `#743` landed the initial harnesses, seed corpora, AFL++ entrypoints, and
+libFuzzer smoke scaffold. Issue `#874` adds the reproducible libFuzzer soak
+runner, corpus minimizer, and manual evidence workflow in this branch.
+
+Actual pre-RC 24h evidence still requires executing the workflow, retaining the
+uploaded artifacts, and linking the run evidence before release. B7 / `#694`
+reporting also remains follow-up work until those retained artifacts are
+referenced from the release evidence trail.

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -69,6 +69,45 @@ Minimized corpora are not committed by the script. Committing any corpus update
 is a later reviewed step after successful soak and minimization evidence has
 been retained for `#874` / `#684`.
 
+## Manual Fuzz Evidence Workflow
+
+`.github/workflows/fuzz-evidence.yml` is a manual `workflow_dispatch` workflow
+for release-candidate evidence. It is not scheduled, it is not triggered on PR
+or push, and it is not a required CI gate.
+
+Launch it before an RC from GitHub Actions with:
+
+- `target`: `all`, `parser`, `csv_reader`, `intern`, or `compound_arena`
+  (default: `all`).
+- `duration`: per-target libFuzzer duration such as `60s`, `10m`, or `24h`
+  (default: `60s`).
+
+The default `60s` run is only a smoke/evidence-path validation. Release
+evidence for `#874` / `#684` / `#694` requires an explicit long run, normally
+`duration=24h`. The duration is per target; `target=all` runs the four targets
+sequentially for that duration each unless maintainers launch separate
+per-target workflow runs.
+
+The workflow builds the four libFuzzer targets with Clang, writes soak evidence
+under `fuzz-evidence/soak`, and, only if the soak step succeeds, writes
+minimized corpora under `fuzz-evidence/minimized`. Artifacts are uploaded with
+`if: always()`, so crashes and nonzero exits should still retain available soak
+logs and reproducers even when minimization does not run.
+
+Retained release evidence should include:
+
+- the GitHub workflow run URL,
+- the uploaded `fuzz-evidence` artifact bundle,
+- `soak/manifest.txt`,
+- each target's soak `metadata.txt` and `logs/libfuzzer.log`,
+- crash/reproducer artifacts under each target's `artifacts/`,
+- `minimized/manifest.txt` and minimized target corpus roots when soak succeeds.
+
+Pass/fail policy: any libFuzzer crash or nonzero target exit blocks the RC.
+Keep the uploaded reproducers/logs, file a follow-up with the failing target and
+artifact paths, fix the issue, and rerun the evidence workflow before retrying
+the RC.
+
 ## AFL++
 
 The `scripts/afl/*.sh` entrypoints run AFL++ against the same four target

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -49,6 +49,26 @@ directory. The `24h` command is the intended release evidence producer for
 `#684` / `#694`, but the runner itself does not prove that a soak happened
 until that command has actually been executed and its artifacts retained.
 
+## libFuzzer Corpus Minimization
+
+After a successful soak, stage a minimized corpus into a separate output root:
+
+```sh
+scripts/fuzz/minimize-libfuzzer-corpus.sh \
+  --build-dir build-fuzz --input-dir path/to/soak-root \
+  --out-dir path/to/minimized-root --all
+```
+
+For a single target, `--input-dir` may point directly at that target's corpus.
+The output layout mirrors the soak evidence shape:
+`<out-dir>/<target>/corpus`, `<out-dir>/<target>/logs/minimize.log`,
+`<out-dir>/<target>/artifacts`, `<out-dir>/<target>/metadata.txt`, plus a
+top-level `manifest.txt`.
+
+Minimized corpora are not committed by the script. Committing any corpus update
+is a later reviewed step after successful soak and minimization evidence has
+been retained for `#874` / `#684`.
+
 ## AFL++
 
 The `scripts/afl/*.sh` entrypoints run AFL++ against the same four target
@@ -78,7 +98,7 @@ Concise local validation for fuzz scaffolding changes:
 
 ```sh
 git diff --check origin/main..HEAD
-bash -n tests/fuzz/run_fuzz_smoke.sh scripts/afl/*.sh
+bash -n tests/fuzz/run_fuzz_smoke.sh scripts/afl/*.sh scripts/fuzz/*.sh
 meson test -C build parser --print-errorlogs
 CC=gcc meson setup build-fuzz-gcc -Denable_fuzz=true
 ```

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -24,6 +24,31 @@ tests use `tests/fuzz/run_fuzz_smoke.sh`, which copies each tracked seed corpus
 from `tests/fuzz/corpus/` into a build-tree work directory before running the
 target. Source corpora are not mutated.
 
+## libFuzzer Soak Runner
+
+Issue `#874` adds a release-evidence runner for longer libFuzzer campaigns.
+It uses the same compiled fuzz binaries and copies committed seeds into
+writable per-target corpus directories before each run.
+
+Short local validation:
+
+```sh
+scripts/fuzz/run-libfuzzer-soak.sh \
+  --build-dir build-fuzz --target parser --duration 5s
+```
+
+Release soak invocation:
+
+```sh
+scripts/fuzz/run-libfuzzer-soak.sh \
+  --build-dir build-fuzz --all --duration 24h
+```
+
+The runner writes per-target logs, artifacts, and metadata under its work
+directory. The `24h` command is the intended release evidence producer for
+`#684` / `#694`, but the runner itself does not prove that a soak happened
+until that command has actually been executed and its artifacts retained.
+
 ## AFL++
 
 The `scripts/afl/*.sh` entrypoints run AFL++ against the same four target

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -83,28 +83,39 @@ Launch it before an RC from GitHub Actions with:
   (default: `60s`).
 - `runs_on`: JSON runner labels for the Actions job
   (default: `["ubuntu-latest"]`).
+- `timeout_minutes`: GitHub Actions job timeout in minutes, separate from the
+  per-target libFuzzer duration (default: `360`).
 
-The hosted default runner is only for smoke/evidence-path validation. The
-default `60s` run does not produce release evidence. Release evidence for
-`#874` / `#684` / `#694` requires an explicit long run, normally
-`duration=24h`, and a runner whose runtime policy supports the requested
-duration. Use `runs_on` to select appropriate self-hosted or larger runner
-labels for planned 24h evidence.
+The hosted default runner is only for smoke/evidence-path validation. For a
+hosted smoke run, leave `runs_on=["ubuntu-latest"]`, `duration=60s`, and
+`timeout_minutes=360`. That default path does not produce release evidence.
+Release evidence for `#874` / `#684` / `#694` requires an explicit long run,
+normally `duration=24h`, and a runner whose runtime policy supports the
+requested duration. Use `runs_on` to select appropriate self-hosted or larger
+runner labels for planned 24h evidence.
+
+For a single-target 24h release run, select one target such as `parser`, set
+`duration=24h`, set `runs_on` to the long-running runner labels, and set
+`timeout_minutes` above 1440 plus setup/minimization/upload buffer; `1500` is a
+reasonable starting point. The workflow validates the timeout estimate before
+building.
 
 The duration is per target. `target=all` runs the four targets sequentially for
 that duration each, so release evidence should usually be launched as separate
 per-target workflow runs or on a runner whose runtime policy covers the full
-all-target runtime. The workflow rejects `24h`-class durations on the hosted
-default `["ubuntu-latest"]` runner labels because GitHub-hosted runner limits
-cannot complete that release-evidence path.
+all-target runtime. `target=all` with `duration=24h` is about 96h plus
+overhead. The workflow rejects runs whose estimated runtime exceeds
+`timeout_minutes`, and rejects the hosted default `["ubuntu-latest"]` runner
+labels whenever the estimate exceeds the hosted 6h limit.
 
 The workflow builds the four libFuzzer targets with Clang, writes soak evidence
 under `fuzz-evidence/soak`, and, only if the soak step succeeds, writes
 minimized corpora under `fuzz-evidence/minimized`. Artifacts are uploaded with
 `if: always()`, so crashes and nonzero exits should still retain available soak
 logs and reproducers even when minimization does not run. Artifact upload after
-runner cancellation or timeout is best-effort; planned long-run evidence should
-use a runner that is not expected to time out.
+runner cancellation or timeout is best-effort, and long-run artifact upload,
+token, and runtime policies are runner-dependent. Planned release evidence
+should use a runner that is not expected to time out or be cancelled.
 
 Retained release evidence should include:
 

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -81,18 +81,30 @@ Launch it before an RC from GitHub Actions with:
   (default: `all`).
 - `duration`: per-target libFuzzer duration such as `60s`, `10m`, or `24h`
   (default: `60s`).
+- `runs_on`: JSON runner labels for the Actions job
+  (default: `["ubuntu-latest"]`).
 
-The default `60s` run is only a smoke/evidence-path validation. Release
-evidence for `#874` / `#684` / `#694` requires an explicit long run, normally
-`duration=24h`. The duration is per target; `target=all` runs the four targets
-sequentially for that duration each unless maintainers launch separate
-per-target workflow runs.
+The hosted default runner is only for smoke/evidence-path validation. The
+default `60s` run does not produce release evidence. Release evidence for
+`#874` / `#684` / `#694` requires an explicit long run, normally
+`duration=24h`, and a runner whose runtime policy supports the requested
+duration. Use `runs_on` to select appropriate self-hosted or larger runner
+labels for planned 24h evidence.
+
+The duration is per target. `target=all` runs the four targets sequentially for
+that duration each, so release evidence should usually be launched as separate
+per-target workflow runs or on a runner whose runtime policy covers the full
+all-target runtime. The workflow rejects `24h`-class durations on the hosted
+default `["ubuntu-latest"]` runner labels because GitHub-hosted runner limits
+cannot complete that release-evidence path.
 
 The workflow builds the four libFuzzer targets with Clang, writes soak evidence
 under `fuzz-evidence/soak`, and, only if the soak step succeeds, writes
 minimized corpora under `fuzz-evidence/minimized`. Artifacts are uploaded with
 `if: always()`, so crashes and nonzero exits should still retain available soak
-logs and reproducers even when minimization does not run.
+logs and reproducers even when minimization does not run. Artifact upload after
+runner cancellation or timeout is best-effort; planned long-run evidence should
+use a runner that is not expected to time out.
 
 Retained release evidence should include:
 

--- a/scripts/fuzz/minimize-libfuzzer-corpus.sh
+++ b/scripts/fuzz/minimize-libfuzzer-corpus.sh
@@ -85,6 +85,32 @@ absolute_path() {
     esac
 }
 
+ensure_non_overlapping_corpora() {
+    local target=$1
+    local input_corpus=$2
+    local output_corpus=$3
+    local input_abs output_abs
+
+    input_abs=$(absolute_path "$input_corpus")
+    output_abs=$(absolute_path "$output_corpus")
+
+    if [ "$input_abs" = "$output_abs" ]; then
+        die "input and output corpora overlap for $target: both resolve to $input_abs"
+    fi
+
+    case "$output_abs" in
+        "$input_abs"/*)
+            die "output corpus is inside input corpus for $target: $output_abs inside $input_abs"
+            ;;
+    esac
+
+    case "$input_abs" in
+        "$output_abs"/*)
+            die "input corpus is inside output corpus for $target: $input_abs inside $output_abs"
+            ;;
+    esac
+}
+
 input_corpus_for_target() {
     local target=$1
     if [ "${#selected_targets[@]}" -eq 1 ] && [ -d "$input_dir" ] \
@@ -93,6 +119,20 @@ input_corpus_for_target() {
     else
         printf '%s/%s/corpus' "$input_dir" "$target"
     fi
+}
+
+preflight_target() {
+    local target=$1
+    local bin_name binary input_corpus output_corpus
+
+    bin_name=$(binary_name "$target")
+    binary="$build_dir/tests/$bin_name"
+    input_corpus=$(input_corpus_for_target "$target")
+    output_corpus="$out_dir/$target/corpus"
+
+    [ -x "$binary" ] || die "target binary not found or not executable: $binary"
+    [ -d "$input_corpus" ] || die "input corpus directory not found for $target: $input_corpus"
+    ensure_non_overlapping_corpora "$target" "$input_corpus" "$output_corpus"
 }
 
 run_target() {
@@ -112,6 +152,7 @@ run_target() {
 
     [ -x "$binary" ] || die "target binary not found or not executable: $binary"
     [ -d "$input_corpus" ] || die "input corpus directory not found for $target: $input_corpus"
+    ensure_non_overlapping_corpora "$target" "$input_corpus" "$output_corpus"
 
     mkdir -p "$output_corpus" "$artifact_dir" "$log_dir"
     start_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -234,6 +275,10 @@ case "$out_dir" in
         die "--out-dir must not be inside the input corpus/root"
         ;;
 esac
+
+for target in "${selected_targets[@]}"; do
+    preflight_target "$target"
+done
 
 mkdir -p "$out_dir"
 out_dir=$(cd "$out_dir" && pwd)

--- a/scripts/fuzz/minimize-libfuzzer-corpus.sh
+++ b/scripts/fuzz/minimize-libfuzzer-corpus.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+# For commercial licenses, contact: inquiry@cleverplant.com
+#
+# Minimize libFuzzer corpora produced by the wirelog soak runner.
+
+set -euo pipefail
+
+TARGETS=(parser csv_reader intern compound_arena)
+
+usage() {
+    cat <<EOF
+Usage: $0 --build-dir DIR --input-dir DIR --out-dir DIR (--all | --target NAME...)
+
+Options:
+  --build-dir DIR  Meson build directory containing tests/*_fuzz binaries.
+  --input-dir DIR  Soak artifact root containing <target>/corpus directories,
+                  or a direct corpus directory when exactly one --target is used.
+  --out-dir DIR    Output root for minimized corpora and evidence files.
+  --target NAME    Target to minimize. Repeatable. Names: parser, csv_reader, intern, compound_arena.
+  --all            Minimize all targets from a soak artifact root.
+  --help           Show this help.
+
+The minimizer runs libFuzzer merge mode as:
+  <binary> -merge=1 <out-dir>/<target>/corpus <input-corpus> -artifact_prefix=<out-dir>/<target>/artifacts/
+
+It never mutates tests/fuzz/corpus/* or the input corpus.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+repo_root() {
+    git -C "$(cd "$(dirname "$0")/../.." && pwd)" rev-parse --show-toplevel
+}
+
+is_valid_target() {
+    local target=$1
+    local known
+    for known in "${TARGETS[@]}"; do
+        [ "$target" = "$known" ] && return 0
+    done
+    return 1
+}
+
+binary_name() {
+    case "$1" in
+        parser) printf 'parser_fuzz' ;;
+        csv_reader) printf 'csv_reader_fuzz' ;;
+        intern) printf 'intern_fuzz' ;;
+        compound_arena) printf 'compound_arena_fuzz' ;;
+        *) return 1 ;;
+    esac
+}
+
+write_tool_versions() {
+    local out=$1
+    {
+        if command -v clang >/dev/null 2>&1; then
+            printf 'clang=%s\n' "$(clang --version | head -n 1)"
+        else
+            printf 'clang=unavailable\n'
+        fi
+        if command -v llvm-symbolizer >/dev/null 2>&1; then
+            printf 'llvm_symbolizer=%s\n' "$(llvm-symbolizer --version | head -n 1)"
+        else
+            printf 'llvm_symbolizer=unavailable\n'
+        fi
+    } >>"$out"
+}
+
+absolute_path() {
+    if command -v realpath >/dev/null 2>&1; then
+        realpath -m "$1"
+        return
+    fi
+    case "$1" in
+        /*) printf '%s' "$1" ;;
+        *) printf '%s/%s' "$(pwd)" "$1" ;;
+    esac
+}
+
+input_corpus_for_target() {
+    local target=$1
+    if [ "${#selected_targets[@]}" -eq 1 ] && [ -d "$input_dir" ] \
+            && [ ! -d "$input_dir/$target/corpus" ]; then
+        printf '%s' "$input_dir"
+    else
+        printf '%s/%s/corpus' "$input_dir" "$target"
+    fi
+}
+
+run_target() {
+    local target=$1
+    local bin_name binary input_corpus target_dir output_corpus artifact_dir log_dir log_file metadata
+    local start_ts end_ts status
+
+    bin_name=$(binary_name "$target")
+    binary="$build_dir/tests/$bin_name"
+    input_corpus=$(input_corpus_for_target "$target")
+    target_dir="$out_dir/$target"
+    output_corpus="$target_dir/corpus"
+    artifact_dir="$target_dir/artifacts"
+    log_dir="$target_dir/logs"
+    log_file="$log_dir/minimize.log"
+    metadata="$target_dir/metadata.txt"
+
+    [ -x "$binary" ] || die "target binary not found or not executable: $binary"
+    [ -d "$input_corpus" ] || die "input corpus directory not found for $target: $input_corpus"
+
+    mkdir -p "$output_corpus" "$artifact_dir" "$log_dir"
+    start_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local -a cmd=("$binary" "-merge=1" "$output_corpus" "$input_corpus" "-artifact_prefix=$artifact_dir/")
+
+    {
+        printf 'git_commit=%s\n' "$git_commit"
+        printf 'target=%s\n' "$target"
+        printf 'binary=%s\n' "$binary"
+        printf 'input_corpus=%s\n' "$input_corpus"
+        printf 'output_corpus=%s\n' "$output_corpus"
+        printf 'artifact_dir=%s\n' "$artifact_dir"
+        printf 'log_file=%s\n' "$log_file"
+        printf 'start_timestamp=%s\n' "$start_ts"
+        printf 'command='
+        printf '%q ' "${cmd[@]}"
+        printf '\n'
+    } >"$metadata"
+    write_tool_versions "$metadata"
+
+    printf '[%s] minimizing %s\n' "$target" "${cmd[*]}"
+    set +e
+    "${cmd[@]}" >"$log_file" 2>&1
+    status=$?
+    set -e
+    end_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    {
+        printf 'end_timestamp=%s\n' "$end_ts"
+        printf 'exit_status=%s\n' "$status"
+    } >>"$metadata"
+
+    {
+        printf 'target=%s\n' "$target"
+        printf 'metadata=%s\n' "$metadata"
+        printf 'log=%s\n' "$log_file"
+        printf 'artifacts=%s\n' "$artifact_dir"
+        printf 'input_corpus=%s\n' "$input_corpus"
+        printf 'output_corpus=%s\n' "$output_corpus"
+        printf 'exit_status=%s\n' "$status"
+        printf '\n'
+    } >>"$manifest"
+
+    if [ "$status" -ne 0 ]; then
+        echo "ERROR: target $target minimization failed with status $status; see $log_file" >&2
+        return "$status"
+    fi
+    return 0
+}
+
+build_dir=""
+input_dir=""
+out_dir=""
+run_all=0
+selected_targets=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --build-dir)
+            [ "$#" -ge 2 ] || die "--build-dir requires a directory"
+            build_dir=$2
+            shift 2
+            ;;
+        --input-dir)
+            [ "$#" -ge 2 ] || die "--input-dir requires a directory"
+            input_dir=$2
+            shift 2
+            ;;
+        --out-dir)
+            [ "$#" -ge 2 ] || die "--out-dir requires a directory"
+            out_dir=$2
+            shift 2
+            ;;
+        --target)
+            [ "$#" -ge 2 ] || die "--target requires a name"
+            is_valid_target "$2" || die "unknown target '$2' (expected: ${TARGETS[*]})"
+            selected_targets+=("$2")
+            shift 2
+            ;;
+        --all)
+            run_all=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$build_dir" ] || die "--build-dir is required"
+[ -d "$build_dir" ] || die "build directory not found: $build_dir"
+[ -n "$input_dir" ] || die "--input-dir is required"
+[ -d "$input_dir" ] || die "input directory not found: $input_dir"
+[ -n "$out_dir" ] || die "--out-dir is required"
+
+if [ "$run_all" -eq 1 ]; then
+    selected_targets=("${TARGETS[@]}")
+elif [ "${#selected_targets[@]}" -eq 0 ]; then
+    die "select at least one --target or use --all"
+fi
+
+if [ "$run_all" -eq 1 ] && [ -d "$input_dir/corpus" ]; then
+    die "--all requires a soak artifact root with per-target corpus directories, not a direct corpus"
+fi
+
+root=$(repo_root)
+build_dir=$(cd "$build_dir" && pwd)
+input_dir=$(cd "$input_dir" && pwd)
+out_dir=$(absolute_path "$out_dir")
+
+case "$out_dir" in
+    "$root/tests/fuzz/corpus"|"$root/tests/fuzz/corpus"/*)
+        die "--out-dir must not be inside tracked tests/fuzz/corpus"
+        ;;
+    "$input_dir"|"$input_dir"/*)
+        die "--out-dir must not be inside the input corpus/root"
+        ;;
+esac
+
+mkdir -p "$out_dir"
+out_dir=$(cd "$out_dir" && pwd)
+
+manifest="$out_dir/manifest.txt"
+git_commit=$(git -C "$root" rev-parse HEAD)
+
+{
+    printf 'git_commit=%s\n' "$git_commit"
+    printf 'start_timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'build_dir=%s\n' "$build_dir"
+    printf 'input_dir=%s\n' "$input_dir"
+    printf 'out_dir=%s\n' "$out_dir"
+    printf 'targets=%s\n' "${selected_targets[*]}"
+    printf '\n'
+} >"$manifest"
+write_tool_versions "$manifest"
+printf '\n' >>"$manifest"
+
+overall=0
+for target in "${selected_targets[@]}"; do
+    if run_target "$target"; then
+        :
+    else
+        status=$?
+        if [ "$overall" -eq 0 ]; then
+            overall=$status
+        fi
+    fi
+done
+
+{
+    printf 'end_timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'overall_exit_status=%s\n' "$overall"
+} >>"$manifest"
+
+if [ "$overall" -ne 0 ]; then
+    echo "libFuzzer corpus minimization failed; see $manifest" >&2
+    exit "$overall"
+fi
+
+echo "libFuzzer corpus minimization completed; manifest: $manifest"

--- a/scripts/fuzz/run-libfuzzer-soak.sh
+++ b/scripts/fuzz/run-libfuzzer-soak.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+# For commercial licenses, contact: inquiry@cleverplant.com
+#
+# Run bounded libFuzzer soak campaigns over committed wirelog fuzz seeds.
+
+set -euo pipefail
+
+TARGETS=(parser csv_reader intern compound_arena)
+
+usage() {
+    cat <<EOF
+Usage: $0 --build-dir DIR [--work-dir DIR] --duration VALUE (--all | --target NAME...)
+
+Options:
+  --build-dir DIR   Meson build directory containing tests/*_fuzz binaries.
+  --work-dir DIR    Artifact/work root. Default: \${TMPDIR:-/tmp}/wirelog-libfuzzer-soak-<timestamp>
+  --duration VALUE  Run duration per target. Supports integer seconds or s/m/h suffixes.
+                   Examples: 60, 30s, 10m, 24h.
+  --target NAME     Target to run. Repeatable. Names: parser, csv_reader, intern, compound_arena.
+  --all             Run all targets.
+  --help            Show this help.
+
+The runner copies tests/fuzz/corpus/<target>/ into writable per-target corpus
+directories before invoking libFuzzer. Source corpora are never mutated.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+repo_root() {
+    git -C "$(cd "$(dirname "$0")/../.." && pwd)" rev-parse --show-toplevel
+}
+
+is_valid_target() {
+    local target=$1
+    local known
+    for known in "${TARGETS[@]}"; do
+        [ "$target" = "$known" ] && return 0
+    done
+    return 1
+}
+
+binary_name() {
+    case "$1" in
+        parser) printf 'parser_fuzz' ;;
+        csv_reader) printf 'csv_reader_fuzz' ;;
+        intern) printf 'intern_fuzz' ;;
+        compound_arena) printf 'compound_arena_fuzz' ;;
+        *) return 1 ;;
+    esac
+}
+
+parse_duration() {
+    local value=$1
+    case "$value" in
+        ''|*[!0-9smh]*)
+            return 1
+            ;;
+        *s)
+            local n=${value%s}
+            [[ "$n" =~ ^[0-9]+$ ]] || return 1
+            printf '%s' "$n"
+            ;;
+        *m)
+            local n=${value%m}
+            [[ "$n" =~ ^[0-9]+$ ]] || return 1
+            printf '%s' "$((n * 60))"
+            ;;
+        *h)
+            local n=${value%h}
+            [[ "$n" =~ ^[0-9]+$ ]] || return 1
+            printf '%s' "$((n * 3600))"
+            ;;
+        *)
+            [[ "$value" =~ ^[0-9]+$ ]] || return 1
+            printf '%s' "$value"
+            ;;
+    esac
+}
+
+write_tool_versions() {
+    local out=$1
+    {
+        if command -v clang >/dev/null 2>&1; then
+            printf 'clang=%s\n' "$(clang --version | head -n 1)"
+        else
+            printf 'clang=unavailable\n'
+        fi
+        if command -v llvm-symbolizer >/dev/null 2>&1; then
+            printf 'llvm_symbolizer=%s\n' "$(llvm-symbolizer --version | head -n 1)"
+        else
+            printf 'llvm_symbolizer=unavailable\n'
+        fi
+    } >>"$out"
+}
+
+copy_corpus() {
+    local source_dir=$1
+    local work_corpus=$2
+
+    rm -rf "$work_corpus"
+    mkdir -p "$work_corpus"
+    cp -a "$source_dir/." "$work_corpus"
+}
+
+run_target() {
+    local target=$1
+    local bin_name binary source_corpus target_dir work_corpus artifact_dir log_dir log_file metadata
+    local start_ts end_ts status
+
+    bin_name=$(binary_name "$target")
+    binary="$build_dir/tests/$bin_name"
+    source_corpus="$root/tests/fuzz/corpus/$target"
+    target_dir="$work_dir/$target"
+    work_corpus="$target_dir/corpus"
+    artifact_dir="$target_dir/artifacts"
+    log_dir="$target_dir/logs"
+    log_file="$log_dir/libfuzzer.log"
+    metadata="$target_dir/metadata.txt"
+
+    [ -x "$binary" ] || die "target binary not found or not executable: $binary"
+    [ -d "$source_corpus" ] || die "source corpus directory not found: $source_corpus"
+
+    mkdir -p "$artifact_dir" "$log_dir"
+    copy_corpus "$source_corpus" "$work_corpus"
+
+    start_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local -a cmd=("$binary" "$work_corpus" "-max_total_time=$duration_seconds" "-artifact_prefix=$artifact_dir/")
+
+    {
+        printf 'git_commit=%s\n' "$git_commit"
+        printf 'target=%s\n' "$target"
+        printf 'duration_input=%s\n' "$duration_input"
+        printf 'duration_seconds=%s\n' "$duration_seconds"
+        printf 'binary=%s\n' "$binary"
+        printf 'source_corpus=%s\n' "$source_corpus"
+        printf 'working_corpus=%s\n' "$work_corpus"
+        printf 'artifact_dir=%s\n' "$artifact_dir"
+        printf 'log_file=%s\n' "$log_file"
+        printf 'start_timestamp=%s\n' "$start_ts"
+        printf 'command='
+        printf '%q ' "${cmd[@]}"
+        printf '\n'
+    } >"$metadata"
+    write_tool_versions "$metadata"
+
+    printf '[%s] running %s\n' "$target" "${cmd[*]}"
+    set +e
+    "${cmd[@]}" >"$log_file" 2>&1
+    status=$?
+    set -e
+    end_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+    {
+        printf 'end_timestamp=%s\n' "$end_ts"
+        printf 'exit_status=%s\n' "$status"
+    } >>"$metadata"
+
+    {
+        printf 'target=%s\n' "$target"
+        printf 'metadata=%s\n' "$metadata"
+        printf 'log=%s\n' "$log_file"
+        printf 'artifacts=%s\n' "$artifact_dir"
+        printf 'exit_status=%s\n' "$status"
+        printf '\n'
+    } >>"$manifest"
+
+    if [ "$status" -ne 0 ]; then
+        echo "ERROR: target $target failed with status $status; see $log_file" >&2
+        return "$status"
+    fi
+    return 0
+}
+
+build_dir=""
+work_dir=""
+duration_input=""
+run_all=0
+selected_targets=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --build-dir)
+            [ "$#" -ge 2 ] || die "--build-dir requires a directory"
+            build_dir=$2
+            shift 2
+            ;;
+        --work-dir)
+            [ "$#" -ge 2 ] || die "--work-dir requires a directory"
+            work_dir=$2
+            shift 2
+            ;;
+        --duration)
+            [ "$#" -ge 2 ] || die "--duration requires a value"
+            duration_input=$2
+            shift 2
+            ;;
+        --target)
+            [ "$#" -ge 2 ] || die "--target requires a name"
+            is_valid_target "$2" || die "unknown target '$2' (expected: ${TARGETS[*]})"
+            selected_targets+=("$2")
+            shift 2
+            ;;
+        --all)
+            run_all=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$build_dir" ] || die "--build-dir is required"
+[ -d "$build_dir" ] || die "build directory not found: $build_dir"
+[ -n "$duration_input" ] || die "--duration is required"
+duration_seconds=$(parse_duration "$duration_input") \
+    || die "invalid duration '$duration_input' (use seconds or s/m/h suffix)"
+[ "$duration_seconds" -gt 0 ] || die "duration must be greater than zero"
+
+if [ "$run_all" -eq 1 ]; then
+    selected_targets=("${TARGETS[@]}")
+elif [ "${#selected_targets[@]}" -eq 0 ]; then
+    die "select at least one --target or use --all"
+fi
+
+root=$(repo_root)
+build_dir=$(cd "$build_dir" && pwd)
+if [ -z "$work_dir" ]; then
+    work_dir="${TMPDIR:-/tmp}/wirelog-libfuzzer-soak-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "$work_dir"
+work_dir=$(cd "$work_dir" && pwd)
+manifest="$work_dir/manifest.txt"
+git_commit=$(git -C "$root" rev-parse HEAD)
+
+{
+    printf 'git_commit=%s\n' "$git_commit"
+    printf 'start_timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'build_dir=%s\n' "$build_dir"
+    printf 'work_dir=%s\n' "$work_dir"
+    printf 'duration_input=%s\n' "$duration_input"
+    printf 'duration_seconds=%s\n' "$duration_seconds"
+    printf 'targets=%s\n' "${selected_targets[*]}"
+    printf '\n'
+} >"$manifest"
+write_tool_versions "$manifest"
+printf '\n' >>"$manifest"
+
+overall=0
+for target in "${selected_targets[@]}"; do
+    if run_target "$target"; then
+        :
+    else
+        status=$?
+        if [ "$overall" -eq 0 ]; then
+            overall=$status
+        fi
+    fi
+done
+
+{
+    printf 'end_timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'overall_exit_status=%s\n' "$overall"
+} >>"$manifest"
+
+if [ "$overall" -ne 0 ]; then
+    echo "libFuzzer soak failed; see $manifest" >&2
+    exit "$overall"
+fi
+
+echo "libFuzzer soak completed; manifest: $manifest"


### PR DESCRIPTION
## Summary

Closes #874.

Adds the reproducible libFuzzer evidence path for the v0.44 security/fuzz milestone:

- libFuzzer soak runner for parser, CSV reader, intern, and compound arena targets
- libFuzzer corpus minimizer with input/output overlap guards
- manual `workflow_dispatch` fuzz evidence workflow with artifact retention
- runbook documentation for 24h per-target evidence, minimization, timeout/runner requirements, and #684/#694 evidence linkage

This PR does **not** claim that the actual pre-RC 24h soak has already run. It adds the infrastructure and documented artifact path. Release evidence still requires maintainers to run the manual workflow on a suitable long-running runner and retain/link the uploaded artifacts before RC.

## Validation

- `git diff --check origin/main..HEAD`
- `bash -n tests/fuzz/run_fuzz_smoke.sh scripts/afl/*.sh scripts/fuzz/*.sh`
- Ruby YAML parse sanity for `.github/workflows/fuzz-evidence.yml`
- Soak runner: help/error paths and fake-target artifact/layout validation
- Corpus minimizer: help/error paths, fake merge validation, input/output overlap rejection
- Reviewer + Architect/Critic gates completed for each atomic unit

## Known gaps

- `actionlint` is not installed locally, so the workflow was not linted with actionlint.
- Local machine has no `clang`, so real libFuzzer execution/minimization was not run locally.
- The first real workflow validation should be a short manual dispatch after merge; the release evidence run should use explicit long-running runner labels and sufficient `timeout_minutes`.
