### PR TITLE
docs: consolidate 0.30 to 1.0 migration guide

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -104,11 +104,9 @@ if (err != WIRELOG_OK) {
 
 err = wirelog_session_insert(session, "edge", values, 1, 2);
 if (err == WIRELOG_OK) {
-    err = wirelog_session_step(session);
+    err = wirelog_session_snapshot(session, on_tuple, user_data);
 }
 
-wirelog_session_snapshot(session, on_tuple, user_data);
-wirelog_session_remove(session, "edge", values, 1, 2);
 wirelog_session_destroy(session);
 ```
 
@@ -119,11 +117,26 @@ only when the host deliberately requires the current columnar backend:
 wirelog_session_create(program, WIRELOG_BACKEND_COLUMNAR, 1, &session);
 ```
 
-### Inline facts are materialized at session creation (#718)
+For a given inserted batch, choose either step/delta mode or snapshot
+mode.  Do not call `wirelog_session_step()` and then
+`wirelog_session_snapshot()` on the same batch; both calls evaluate the
+batch and combining them can duplicate derived rows.
 
-Inline `.dl` facts are seeded before the session is returned from
-`wirelog_session_create()` or `wirelog_easy_open()`.  Hosts do not need
-to replay static facts into a newly opened session.
+### Inline facts are materialized before first use (#718)
+
+Inline `.dl` fact timing depends on the facade:
+
+- Advanced API: facts are seeded before `wirelog_session_create()`
+  returns.
+- Easy API default: `wirelog_easy_open()` is lazy; facts are seeded at
+  the first lazy build, before the first
+  `wirelog_easy_insert()`, `wirelog_easy_remove()`,
+  `wirelog_easy_step()`, `wirelog_easy_set_delta_cb()`, or
+  `wirelog_easy_snapshot()` operation completes.
+- Easy API eager mode: facts are seeded before
+  `wirelog_easy_open_opts(... eager_build=true ...)` returns.
+
+Hosts do not need to replay static facts into a newly opened session.
 
 Delta callbacks registered after open do not receive synthetic initial
 deltas for inline facts that were already materialized.  Register the

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,131 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### Advanced session API is public via wirelog-advanced.h (#717)
+
+The canonical public advanced-session API is
+`#include <wirelog/wirelog-advanced.h>`.  Do not include or call
+internal `wl_session_*` helpers or `wirelog/session.h` from host
+applications; those names are private implementation details and are
+not part of the installed public API contract.
+
+Backend selection is public through `wirelog_backend_kind_t`:
+
+- `WIRELOG_BACKEND_DEFAULT` lets the engine choose the default backend.
+- `WIRELOG_BACKEND_COLUMNAR` selects the C columnar backend explicitly.
+
+Prefer `WIRELOG_BACKEND_DEFAULT` unless a host has a specific reason
+to pin the backend.  If you store or switch on `wirelog_backend_kind_t`,
+include a conservative default branch so future additive backend values
+do not break your code.
+
+Before, internal-only code often looked like this:
+
+```c
+#include "wirelog/session.h"
+
+wl_session_t *s = wl_session_create(program);
+wl_session_insert(s, "edge", values, 1, 2);
+wl_session_step(s);
+wl_session_destroy(s);
+```
+
+Migrate to the installed public surface:
+
+```c
+#include <wirelog/wirelog-advanced.h>
+
+wirelog_session_t *session = NULL;
+wirelog_error_t err = wirelog_session_create(program,
+    WIRELOG_BACKEND_DEFAULT, 0, &session);
+if (err != WIRELOG_OK) {
+    /* handle error */
+}
+
+err = wirelog_session_insert(session, "edge", values, 1, 2);
+if (err == WIRELOG_OK) {
+    err = wirelog_session_step(session);
+}
+
+wirelog_session_snapshot(session, on_tuple, user_data);
+wirelog_session_remove(session, "edge", values, 1, 2);
+wirelog_session_destroy(session);
+```
+
+Use `WIRELOG_BACKEND_COLUMNAR` instead of `WIRELOG_BACKEND_DEFAULT`
+only when the host deliberately requires the current columnar backend:
+
+```c
+wirelog_session_create(program, WIRELOG_BACKEND_COLUMNAR, 1, &session);
+```
+
+### Inline facts are materialized at session creation (#718)
+
+Inline `.dl` facts are seeded before the session is returned from
+`wirelog_session_create()` or `wirelog_easy_open()`.  Hosts do not need
+to replay static facts into a newly opened session.
+
+Delta callbacks registered after open do not receive synthetic initial
+deltas for inline facts that were already materialized.  Register the
+callback for runtime changes, and use `wirelog_session_snapshot()` or
+`wirelog_easy_snapshot()` if the host needs the initial derived state:
+
+```c
+wirelog_session_create(program, WIRELOG_BACKEND_DEFAULT, 0, &session);
+wirelog_session_set_delta_cb(session, on_delta, user_data);
+
+/* No synthetic callbacks for inline facts happen here. */
+wirelog_session_snapshot(session, on_tuple, user_data);
+```
+
+If a host mirrors inline facts itself and inserts the same row again,
+the duplicate host insert increases the Z-set multiplicity.  For
+set-like host behavior, either let wirelog seed inline facts on its own
+or inspect `wirelog_program_get_facts()` before inserting a mirrored
+row.
+
+### Z-set host insert/remove arithmetic
+
+Host inserts and removes are differential Z-set operations:
+
+- `wirelog_session_insert()` / `wirelog_easy_insert()` increments row
+  multiplicity by `+1`.
+- `wirelog_session_remove()` / `wirelog_easy_remove()` decrements row
+  multiplicity by `-1`.
+
+Removing a row that was seeded from inline `.dl` facts may leave the
+row present if multiplicity remains positive.  For example:
+
+```text
+inline fact edge(1, 2)     => multiplicity +1
+host insert edge(1, 2)     => multiplicity +2
+host remove edge(1, 2)     => multiplicity +1, still observable
+second host remove         => multiplicity  0, no longer observable
+```
+
+See `docs/SEMANTICS.md` for the full Z-set and inline-fact contract.
+
+### Public attributes and deprecation annotations
+
+New declarations in installed public headers should use `WIRELOG_API`
+as the visibility/export annotation:
+
+```c
+WIRELOG_API wirelog_error_t
+wirelog_example_public_function(void);
+```
+
+`WIRELOG_PUBLIC` remains available as a compatibility-level macro after
+the `WL_PUBLIC` rename, but consumers should prefer `WIRELOG_API` in
+new public declarations and examples.
+
+APIs scheduled for removal may be annotated with
+`WIRELOG_DEPRECATED_SINCE(major, minor)`.  When migrating off a
+deprecated compatibility shim, update to the replacement API directly.
+If a project must temporarily keep compatibility calls, suppress known
+deprecation warnings locally around that shim rather than disabling
+deprecation warnings globally.
+
 ### I/O adapter framework rename + ABI v2 bump (#762)
 
 The `wirelog/io/io_adapter.h` public-installed header carried

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -61,6 +61,33 @@ during the v0.40 API audit and subsequent v1.0 freeze.  See epic #755
 for the full scope.  Entries are filed atomically as the renames land;
 #745 then consolidates the narrative for the GA migration guide.
 
+### Completeness audit notes
+
+This subsection cross-checks user-facing categories visible in the
+local `git log v0.30.0..main` history.  It is a migration guide index,
+not a claim of external validation.
+
+| Category | Migration status |
+| --- | --- |
+| Advanced session API (#717) | Detailed recipe below.  Use `wirelog/wirelog-advanced.h`, `wirelog_session_create()`, and `wirelog_backend_kind_t`; do not include internal `wirelog/session.h`. |
+| Easy facade rename (#756) | Detailed recipe below.  Rename `wl_easy_*` / `WL_EASY_*` to `wirelog_easy_*` / `WIRELOG_EASY_*` and include `wirelog/wirelog-easy.h`. |
+| I/O adapter rename and ABI v2 (#762) | Detailed recipe below.  Rename `wl_io_*` / `WL_IO_*`, rebuild plugins, and export `wirelog_io_plugin_entry`. |
+| Callback typedefs (#758), intern typedef (#760), string enum constants (#757) | Detailed rename tables below.  Textual source migration is required only for consumers using the renamed public typedefs or enum constants. |
+| Export macros (#759/#782) | Detailed recipe below and in the public-attributes entry.  New public declarations use `WIRELOG_API`; `WIRELOG_PUBLIC` is compatibility-level after the `WL_PUBLIC` rename. |
+| Inline facts, Z-set arithmetic, and backend selection (#718/#717) | Detailed recipes below.  Review timing differences between advanced eager creation, easy lazy build, and easy eager mode. |
+| Build option `enable_fuzz` | No source migration needed for library consumers.  It enables fuzz harness build/smoke targets for maintainers and CI. |
+| Build options `android` and `ios` | No source migration needed for ordinary consumers.  They are opt-in platform build paths; Android/iOS packaged artifacts remain deferred platform posture unless a release explicitly says otherwise. |
+| Build option `mbedTLS` | No source migration needed when staying on the default `mbedTLS=disabled` artifact.  Enabling crypto built-ins changes dependency/export posture; see `docs/SECURITY_MODEL.md`. |
+| Build option `threads` | No source migration needed for public API consumers.  It selects the native or POSIX threading backend for builds and test configurations. |
+| Build option `crc32_variant` | No source migration needed for public API consumers.  It selects CRC32 implementation strategy at build time. |
+| Build option `io_plugin_dlopen` | No source migration needed unless packaging dynamic I/O plugins; plugin source migrations are covered by the I/O adapter ABI v2 recipe. |
+| Build option `wirelog_log_max_level` | No source migration needed.  It controls compiled logging threshold and release/perf build posture. |
+| Dependency/release reproducibility (#715) | No source migration needed unless vendoring or packaging dependencies.  Wraps are pinned for reproducible `xxHash` and `nanoarrow` dependency inputs. |
+| Platform buildability and artifact posture | No source migration needed for ordinary consumers.  Android and iOS are opt-in build paths; binary artifact publication remains a release/platform policy question. |
+| Numerical fail-closed overflow and recursive aggregation canonicalization | See the `0.41 -> 0.43` section.  No 0.30 public API rename is needed, but callers may observe fail-closed errors or canonicalized recursive aggregate results. |
+| Security/export posture | No source migration needed when using the default build.  `mbedTLS=disabled` remains the default; see `docs/SECURITY_MODEL.md` before enabling crypto built-ins. |
+| Fuzz, SBOM, security policy, and release gates | No source migration needed for library consumers.  These are release-process and maintainer-tooling changes unless your downstream packaging pipeline adopts them. |
+
 ### Advanced session API is public via wirelog-advanced.h (#717)
 
 The canonical public advanced-session API is


### PR DESCRIPTION
## Summary

Closes #745.

Consolidates the `docs/MIGRATION.md` `0.30 -> 1.0` section so #699 external validation has a concrete guide to test.

Adds:

- advanced session API migration guidance for #717
- inline fact materialization and Z-set semantics guidance for #718
- backend selection guidance for `wirelog_backend_kind_t`
- `WIRELOG_API` / `WIRELOG_DEPRECATED_SINCE` migration guidance
- a `v0.30.0..main` completeness audit index that maps user-facing changes to detailed recipes or explicit “no source migration needed” notes

This PR does **not** complete #699 external validation. It makes that validation actionable by giving validators a consolidated guide to follow.

## Validation

- `git diff --check origin/main..HEAD`
- `rg` checks for #717/#718, advanced session API, backend selection, Z-set semantics, public API/deprecation macros, build options, #715, and no-source-migration audit notes
- Reviewer + Architect/Critic gates completed for each atomic unit

## Known gaps

- `markdownlint` is not installed locally, so markdownlint was not run.
