### PR TITLE
docs: complete v0.44 operational drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ external-consumer audit.
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) -- system design, optimizer pipeline, execution model
 - [docs/THREADING.md](docs/THREADING.md) -- threading backends, atomics audit, K-fusion / TDD concurrency contracts
 - [docs/CRASH_RESTART.md](docs/CRASH_RESTART.md) -- crash/restart durability responsibilities for embedded hosts
+- [docs/EMBEDDED.md](docs/EMBEDDED.md) -- embedded integration posture, build options, and host responsibilities
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ external-consumer audit.
 
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) -- system design, optimizer pipeline, execution model
 - [docs/THREADING.md](docs/THREADING.md) -- threading backends, atomics audit, K-fusion / TDD concurrency contracts
+- [docs/CRASH_RESTART.md](docs/CRASH_RESTART.md) -- crash/restart durability responsibilities for embedded hosts
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ external-consumer audit.
 - [docs/THREADING.md](docs/THREADING.md) -- threading backends, atomics audit, K-fusion / TDD concurrency contracts
 - [docs/CRASH_RESTART.md](docs/CRASH_RESTART.md) -- crash/restart durability responsibilities for embedded hosts
 - [docs/EMBEDDED.md](docs/EMBEDDED.md) -- embedded integration posture, build options, and host responsibilities
+- [docs/INTERNALS.md](docs/INTERNALS.md) -- maintainer map of internal subsystems and public/private boundaries
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification

--- a/docs/CRASH_RESTART.md
+++ b/docs/CRASH_RESTART.md
@@ -1,0 +1,91 @@
+# Crash and Restart Guide
+
+wirelog is an in-process embedded library. It does not own the host process,
+the host storage layer, or service orchestration. This guide describes the
+current crash/restart posture so embedders can design their own durability
+boundary.
+
+## Guarantees
+
+Within a live process, wirelog owns the memory behind the sessions, executors,
+plans, results, intern tables, callback registrations, pending deltas, and
+compound handles it creates. Normal API errors are reported through the API
+surface for the active call path.
+
+Process restart is different from in-process error handling. If the process
+crashes or is killed, wirelog does not preserve in-memory engine state for
+automatic recovery. Detailed error taxonomy and `WL_LOG` safety guidance are
+tracked separately for the future error model work; see `docs/THREADING.md` for
+current concurrency contracts and README logging caveats.
+
+## Non-Guarantees
+
+On process crash, the following in-memory state is lost:
+
+- sessions and executors,
+- generated plans and result objects,
+- callback registrations,
+- pending deltas,
+- intern IDs,
+- compound handles,
+- adapter/plugin runtime state owned by the host process.
+
+wirelog currently has no built-in WAL, checkpoint format, fsync discipline,
+crash recovery store, durable transaction log, or automatic restart
+orchestration. It also does not repair partial host writes or partial export
+artifacts after a crash.
+
+## Host-Owned Durability
+
+If restart recovery is required, the host application owns the durable source
+of truth. Common strategies include:
+
+- storing the Datalog source program or generated program bundle,
+- recording durable EDB facts or input events in a host-owned log,
+- periodically writing host-owned snapshots,
+- using host storage transactions and fsync policy appropriate for the
+  deployment,
+- recording adapter or plugin configuration needed to reopen inputs and
+  outputs.
+
+Partial writes, partially exported files, adapter side effects, plugin state,
+and external file or database durability are host or adapter responsibilities.
+See `docs/io-adapters.md` for adapter integration guidance.
+
+## Safe Restart Pattern
+
+A conservative restart path is:
+
+1. Recreate or reload the source program.
+2. Recreate the session or executor from that program.
+3. Reopen adapters, files, and plugins owned by the host.
+4. Re-register callbacks.
+5. Replay host-owned durable EDB facts and runtime events in deterministic
+   order.
+6. Resume stepping, snapshotting, or exporting from the reconstructed state.
+
+Inline `.dl` facts are not restored by a hidden recovery path. They are loaded
+again through normal program/session construction and easy-facade lazy-build
+semantics. See `docs/SEMANTICS.md` for inline fact materialization and Z-set
+insert/remove semantics.
+
+Choose one replay order and keep it stable. If the host keeps both snapshots
+and an event log, define whether the event log is replayed from the snapshot
+point or from process start; wirelog does not infer that boundary.
+
+## Non-Durable Identifiers
+
+Intern IDs and compound handles are session/process-local implementation
+values. Do not persist them as durable identifiers, and do not expect them to be
+stable across process restarts, session recreation, or program reloads.
+
+Persist source strings, relation names, primary-key values, or host-owned
+application identifiers instead. Re-intern strings and recreate compound values
+after rebuilding the session.
+
+## Security and Deployment Notes
+
+Restart policy is part of the host application's threat model and operations
+model. wirelog does not open network listeners or provide restart supervision.
+For the embedded-library threat model, optional crypto posture, and export
+self-classification, see `docs/SECURITY_MODEL.md`.

--- a/docs/EMBEDDED.md
+++ b/docs/EMBEDDED.md
@@ -1,0 +1,116 @@
+# Embedded Integration Guide
+
+wirelog is an in-process C11 library embedded inside a host application. The
+host owns I/O, durable storage, process lifecycle, restart supervision, and
+threading policy around each session.
+
+This guide summarizes the current embedded posture. It is not a new API
+surface; it points embedders to the existing public headers and operational
+docs.
+
+## Public Integration Surface
+
+Use installed public headers for host integration:
+
+- `wirelog/wirelog.h` for parser, program, executor, and result APIs.
+- `wirelog/wirelog-easy.h` for the simple session facade.
+- `wirelog/wirelog-advanced.h` for explicit sessions, backend selection, worker
+  counts, callbacks, snapshots, and compound helpers.
+- `wirelog/io/io_adapter.h` for public I/O adapter integration.
+
+Internal `wl_*` headers and symbols are not an integration surface. Do not
+include internal headers such as `wirelog/session.h`, and do not depend on
+internal `wl_*` names, layout, or lifetime rules.
+
+## Build Options
+
+The Meson options below are user-visible for embedded builds:
+
+| Option | Embedded guidance |
+| --- | --- |
+| `embedded` | Opt-in embedded build mode. Do not assume a specific dependency or binary-size reduction unless you verify it for the target build. |
+| `tests` | Set `-Dtests=false` for release artifacts that do not need test binaries. |
+| `documentation` | Documentation build toggle; currently described as not implemented in `meson_options.txt`. |
+| `threads` | Selects threading backend: `native` auto-detects C11/POSIX, `posix` forces pthreads. See `docs/THREADING.md`. |
+| `wirelog_log_max_level` | Release and embedded builds should usually set `-Dwirelog_log_max_level=error` to compile out higher-volume logging sites. |
+| `mbedTLS` | Defaults to `disabled`. Keep disabled unless crypto built-ins are required; enabling changes dependency and export posture. See `docs/SECURITY_MODEL.md`. |
+| `io_plugin_dlopen` | Enables optional CLI plugin loading through `dlopen` where supported. Most embedded hosts link adapters directly or own dynamic loading themselves. |
+| `android` | Opt-in Android cross-build path. Source build support exists; packaged AAR/Prefab artifacts are deferred. |
+| `ios` | Opt-in iOS build path. Source build support exists; packaged XCFramework artifacts are deferred. |
+| `crc32_variant` | Selects the default CRC-32 variant, `ethernet` or `castagnoli`. |
+| `enable_fuzz` | Maintainer-only fuzz build/smoke option, not an embedded runtime feature. |
+
+Android and iOS platform artifact posture is tracked in
+`docs/PLATFORM_SUPPORT.md`. Do not infer packaged mobile artifacts from the
+source build options alone.
+
+## Lifecycle and Restart
+
+wirelog does not provide a daemon, network listener, restart supervisor, WAL,
+checkpoint store, durable transaction log, or automatic crash recovery service.
+The host decides when to create and destroy programs, sessions, executors,
+adapters, and callbacks.
+
+For restart recovery, persist host-owned inputs or snapshots and rebuild
+wirelog state after process restart. See `docs/CRASH_RESTART.md` for the
+recommended restart pattern and the list of non-durable in-memory state.
+
+## Threading and Concurrency
+
+Sessions, callbacks, and adapters run inside the host process. The host owns
+thread creation, worker-count choices, synchronization around session use, and
+callback workload limits.
+
+Bound worker count and concurrency to match the target device. Avoid blocking
+or unbounded callback work on latency-sensitive threads. See
+`docs/THREADING.md` for the current threading backend, atomics, fork-safety, and
+worker-session contracts.
+
+## Resource Constraints
+
+wirelog sessions, executors, generated plans, results, intern tables, and
+compound arenas are in-memory and scoped to the host process. Intern IDs and
+compound handles are session/process-local; do not persist them as durable
+identifiers.
+
+Embedded hosts should bound:
+
+- source program size and parse frequency,
+- input fact size and relation cardinality,
+- recursion and query shapes accepted from users,
+- worker counts and concurrent session activity,
+- callback work and allocation behavior,
+- adapter side effects, file handles, and external writes.
+
+wirelog does not currently make a hard real-time, fixed-memory, or
+allocation-free execution guarantee. Hosts with strict memory or latency budgets
+should enforce their own limits at the integration boundary.
+
+## I/O and Adapter Boundaries
+
+The host owns I/O policy. wirelog adapters run in process and should be treated
+as part of the host's trusted integration boundary. Reopen files, sockets owned
+by the host, plugin handles, and adapter state during restart as needed.
+
+For adapter patterns and the public adapter ABI, see `docs/io-adapters.md`.
+Partial writes, export artifacts, and adapter side effects are the host or
+adapter's responsibility.
+
+## Logging and Security Posture
+
+For release/embedded artifacts, prefer:
+
+```sh
+meson setup build-embedded --buildtype=release \
+  -Dembedded=true \
+  -Dtests=false \
+  -Dwirelog_log_max_level=error \
+  -DmbedTLS=disabled
+```
+
+The default `mbedTLS=disabled` build avoids the optional crypto/export posture.
+If you enable mbedTLS-backed built-ins, review `docs/SECURITY_MODEL.md` and
+your distribution requirements.
+
+Detailed `WL_LOG` and future error-model safety taxonomy is intentionally not
+duplicated here. Keep logging volume and log sinks under host control.

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1,0 +1,95 @@
+# Internals Map
+
+This document is for wirelog contributors and maintainers. It orients readers
+to the source tree and the public/internal boundary. It is not an embedder API,
+ABI promise, or stability contract.
+
+Internal headers, internal symbols, file layout, and subsystem boundaries may
+change without compatibility promises. Embedded applications should use the
+installed public headers described in `docs/EMBEDDED.md`.
+
+## Public and Internal Boundary
+
+The installed public header list is the `wirelog_public_headers` array in
+`meson.build`:
+
+- `wirelog/wirelog.h`
+- `wirelog/wirelog-types.h`
+- `wirelog/wirelog-parser.h`
+- `wirelog/wirelog-ir.h`
+- `wirelog/wirelog-optimizer.h`
+- `wirelog/wirelog-export.h`
+- `wirelog/wirelog-easy.h`
+- `wirelog/wirelog-advanced.h`
+
+`wirelog/io/io_adapter.h` is installed separately under `wirelog/io`. The
+generated `wirelog/wirelog-version.h` header is tracked separately from the
+source header list.
+
+Public API symbols and public macros use the `wirelog_*` / `WIRELOG_*`
+prefixes. New installed public prototypes use `WIRELOG_API` from
+`wirelog/wirelog-export.h`.
+
+Internal headers and symbols use `wl_*` / `WL_*`. Where practical, internal
+names encode their subdirectory or module. For example, parser internals live
+under `wirelog/parser/*`, while IR internals live under `wirelog/ir/*`.
+This naming helps maintainers navigate the tree; it does not make those names
+stable for downstream code.
+
+## Subsystem Map
+
+| Area | Main files | Role |
+| --- | --- | --- |
+| Public API facades | `wirelog/wirelog.h`, `wirelog/wirelog-easy.h`, `wirelog/wirelog-advanced.h`, `wirelog/api_facade.c`, `wirelog/wirelog-easy.c`, `wirelog/wirelog_advanced.c` | Installed entry points and facade implementations for parser/program/executor, easy sessions, and advanced sessions. |
+| Parser and AST | `wirelog/parser/*` | Lexer, parser, and AST construction for Datalog source. |
+| IR, programs, stratification, interning | `wirelog/ir/*`, `wirelog/intern.*` | Public IR wrappers, internal program representation, stratification, and string interning. |
+| Optimizer passes | `wirelog/passes/*` | Fusion, join plan placement, magic sets, sideways information passing, and subsumption passes. |
+| Execution plan generation | `wirelog/exec_plan*` | Backend-neutral execution-plan types and lowering from IR/program state. |
+| Session and backend abstraction | `wirelog/session.*`, `wirelog/session_facts.*`, `wirelog/backend.h` | Internal session lifecycle, inline fact seeding, and backend vtable boundary. |
+| Columnar backend | `wirelog/columnar/*` | Relations, arrangements, frontier/progress tracking, expression evaluation, diff traces, delta pools, partitioning, and columnar session execution. |
+| Arenas and compound storage | `wirelog/arena/*`, `wirelog/columnar/compound_side.*`, `wirelog/columnar/handle_remap*` | Arena allocation, compound arena handles, side relations, and handle remapping support. |
+| I/O adapters | `wirelog/io/*` | Public adapter ABI implementation, CSV reader/adapter code, and adapter context internals. |
+| Threading, workqueue, logging utilities | `wirelog/thread*`, `wirelog/workqueue.*`, `wirelog/util/*` | Thread backend wrappers, worker queues, lock-free helpers, and internal logging implementation. |
+| CLI | `wirelog/cli/*` | Command-line driver, plugin loader, and CLI-specific wiring around the library. |
+
+For broader design context, see `docs/ARCHITECTURE.md`. For semantic contracts
+that internals must preserve, see `docs/SEMANTICS.md`, `docs/COMPOUND_TERMS.md`,
+and `docs/RDF_QUADS.md`.
+
+## Runtime Ownership Notes
+
+Most internal state is process-local and session-scoped: generated plans,
+sessions, executors, result objects, intern tables, compound arenas, callbacks,
+and pending deltas are rebuilt or discarded through normal API lifetimes. See
+`docs/CRASH_RESTART.md` for restart posture and `docs/EMBEDDED.md` for host
+integration responsibilities.
+
+Threading details are intentionally not duplicated here. Maintainers changing
+worker dispatch, atomics, locks, session ownership, or fork-sensitive behavior
+should update and validate `docs/THREADING.md` alongside code and tests.
+
+Security and export posture are also documented separately. Maintainers changing
+crypto build behavior, mbedTLS dependencies, or externally visible threat-model
+assumptions should update `docs/SECURITY_MODEL.md`.
+
+I/O adapter changes that affect the installed adapter ABI or host/plugin
+integration should be reflected in `docs/io-adapters.md`.
+
+## Changing Internals Checklist
+
+Before landing an internal change, check whether it crosses a public boundary:
+
+- Keep installed public headers free of internal `wl_*` / `WL_*` names unless a
+  deliberate compatibility decision is documented.
+- Use `wirelog_*` / `WIRELOG_*` and `WIRELOG_API` for new public installed
+  declarations.
+- If the public header surface or exported symbol set changes, update the ABI
+  and public-header gates as needed.
+- If a public source migration is required, update `docs/MIGRATION.md`.
+- If runtime semantics change, update `docs/SEMANTICS.md` and focused tests.
+- If compound terms, RDF quads, threading, crash/restart, embedded posture,
+  security, or I/O adapter behavior changes, update the matching docs linked
+  above.
+
+Internal-only refactors do not need migration notes, but they should preserve
+the public contracts and tests for the affected subsystem.


### PR DESCRIPTION
## Summary

Closes #875.

Adds the three remaining v0.44 docs drafts from #684 that are not owned by #709:

- `docs/CRASH_RESTART.md` for process-failure recovery guarantees, non-guarantees, and host restart expectations
- `docs/EMBEDDED.md` for embedded build options, disabled/deferred surfaces, logging/security posture, and resource constraints
- `docs/INTERNALS.md` for maintainer-facing subsystem orientation and public/internal API boundaries

README now links all three documents. #709 remains the owner for the future `ERROR_MODEL.md` / `WL_LOG` safety consolidation.

## Atomic commits and workflow review

- `60602f5` `docs: add crash restart guide`
  - Reviewer: no blocking findings
  - Architect/Critic: agreed no blocking follow-up required
- `4ec68bd` `docs: add embedded integration guide`
  - Reviewer: no blocking findings; noted omitted `ipc` row as non-blocking
  - Architect/Critic: agreed omission can be deferred
- `b6a113a` `docs: add internals map`
  - Reviewer: no blocking findings; noted `wirelog/exec_plan*` shorthand as non-blocking
  - Architect/Critic: agreed no blocking follow-up required

## Validation

- `git diff --check origin/main..HEAD`
- `rg -n "CRASH_RESTART|EMBEDDED|INTERNALS|docs/CRASH_RESTART|docs/EMBEDDED|docs/INTERNALS" README.md docs/CRASH_RESTART.md docs/EMBEDDED.md docs/INTERNALS.md`
- Per-commit `git show --check --stat HEAD` during each atomic unit

Known gap: `markdownlint` was not available locally. `npx --no-install markdownlint docs/CRASH_RESTART.md docs/EMBEDDED.md docs/INTERNALS.md README.md` failed with no local executable.