### PR TITLE
docs: consolidate error and log safety policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ external-consumer audit.
 - [docs/CRASH_RESTART.md](docs/CRASH_RESTART.md) -- crash/restart durability responsibilities for embedded hosts
 - [docs/EMBEDDED.md](docs/EMBEDDED.md) -- embedded integration posture, build options, and host responsibilities
 - [docs/INTERNALS.md](docs/INTERNALS.md) -- maintainer map of internal subsystems and public/private boundaries
+- [docs/ERROR_MODEL.md](docs/ERROR_MODEL.md) -- error reporting, logging safety, fork/signal constraints, and restart handoff
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification

--- a/docs/ERROR_MODEL.md
+++ b/docs/ERROR_MODEL.md
@@ -1,0 +1,112 @@
+# Error Model
+
+This document is the current user-facing policy for wirelog error reporting,
+diagnostics/logging safety, signal and fork constraints, and restart handoff.
+It describes the current contract; it does not claim a complete stable
+error-code taxonomy.
+
+## Error Boundaries
+
+wirelog reports problems through three different channels:
+
+- **Normal API errors**: public APIs report ordinary failures through
+  `wirelog_error_t`, NULL returns, boolean returns, or facade-specific return
+  values. Examples include parse failures, invalid program state, session
+  creation errors, memory allocation failure, and easy/advanced session
+  operation errors.
+- **Diagnostics/logging**: `WL_LOG` and `WL_LOG_FILE` are diagnostic controls.
+  They are for operator or developer visibility, not application control flow.
+- **Process-fatal conditions**: crashes, aborts, process kills, and signal
+  termination are outside normal API error reporting. After process restart,
+  the host must rebuild wirelog state from host-owned inputs or snapshots.
+
+Use API return values for control flow. Use logs to explain what happened after
+the fact, not to decide whether an operation succeeded.
+
+## Normal API Errors
+
+The public API uses `wirelog_error_t` where the caller needs a structured
+status. Pointer-returning APIs may return NULL and optionally write a
+`wirelog_error_t` to an out-parameter. Easy and advanced session APIs return
+`wirelog_error_t` directly where applicable.
+
+Current guidance:
+
+- Check every public API return value that can fail.
+- Treat `WIRELOG_OK` as success and all other values as failure.
+- Use `wirelog_error_string()` for user-facing or diagnostic text when a
+  `wirelog_error_t` is available.
+- Do not depend on logs being enabled, ordered, or present for correctness.
+
+The enum is intentionally small today. Future work may refine taxonomy and
+mapping, but this document does not freeze a full code-by-code policy.
+
+## Diagnostics and WL_LOG
+
+`WL_LOG` is a runtime, section-filtered diagnostic facility documented in the
+README logging section. `WL_LOG_FILE` can redirect output to a file. If opening
+`WL_LOG_FILE` fails, wirelog falls back to `stderr` with a one-time notice.
+
+Safety policy:
+
+- `WL_LOG` is not async-signal-safe.
+- Do not call `wirelog_*` APIs from signal handlers.
+- The emit path uses non-async-signal-safe operations such as formatting and
+  file I/O, including `vsnprintf` and `fwrite`.
+- Thresholds are written at `wl_log_init()`. Runtime threshold reads are
+  lock-free byte loads, but logging output still goes through stdio.
+- `WL_LOG` must remain diagnostic-only. Applications should not parse log
+  output as an API.
+
+Signal handlers should do only host-owned async-signal-safe work, such as
+setting an atomic flag of the correct type for the host or writing a byte to a
+host-owned file descriptor. Let normal host control flow call wirelog APIs after
+the signal handler returns.
+
+## Fork Constraints
+
+wirelog does not install a `pthread_atfork` handler.
+
+Prefer fork-then-exec. After `fork()`, a child that immediately calls
+`execve()` or an equivalent exec-family function does not continue using
+wirelog state across the fork boundary.
+
+Fork-without-exec use is constrained by `docs/THREADING.md`. In particular,
+child processes must not assume inherited sessions, registries, callbacks,
+locks, adapters, or log sinks are safe to keep using. If a fork-without-exec
+child changes the log sink, call `wl_log_init()` again before logging.
+
+Adapter registry and plugin-loader fork concerns are covered by
+`docs/io-adapters.md` and `docs/THREADING.md`.
+
+## Process-Fatal Conditions and Restart Handoff
+
+Process crashes and forced termination are not normal API errors. wirelog does
+not provide a built-in WAL, checkpoint store, durable transaction log, or
+automatic restart orchestration.
+
+If restart recovery is needed, the host owns the durable source of truth:
+
+- source program or generated program bundle,
+- input facts and runtime events,
+- snapshots or checkpoints maintained by the host,
+- adapter and plugin configuration,
+- output/export durability and partial-write policy.
+
+On restart, rebuild wirelog state from those host-owned inputs: parse or reload
+the program, recreate sessions or executors, reopen adapters, re-register
+callbacks, and replay durable facts/events in a deterministic order.
+
+The embedded-library threat model and optional crypto/export posture are
+documented in `docs/SECURITY_MODEL.md`.
+
+## Host Checklist
+
+- Use `wirelog_error_t`, NULL returns, and facade return values for control
+  flow.
+- Use `WL_LOG` and `WL_LOG_FILE` only for diagnostics.
+- Do not call `wirelog_*` APIs or `WL_LOG` from signal handlers.
+- Prefer fork-then-exec. For fork-without-exec, follow `docs/THREADING.md`.
+- If a forked child changes the log sink, call `wl_log_init()` again before
+  logging.
+- Keep restart durability in host-owned storage, not in wirelog process memory.

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -495,9 +495,8 @@ above. No separate gate exists for TDD.
 wirelog is **not async-signal-safe**.
 
 - `WL_LOG` (the structured logger declared in `wirelog/util/log.h`)
-  is explicitly NOT async-signal-safe; see the comment block at
-  `wirelog/util/log.h:11-17` and the canonical statement in the
-  project `CLAUDE.md` Runtime Diagnostics section.
+  is explicitly NOT async-signal-safe; see `docs/ERROR_MODEL.md`
+  and the internal comment block in `wirelog/util/log.h`.
 - After `fork()`, if the child changes the log sink, the child
   must call `wl_log_init()` again.
 - The `mem_ledger`, the SPSC delta queue, the columnar evaluator,
@@ -510,8 +509,8 @@ If a host process needs to interrupt a long-running
 `wirelog_session_*` cancellation flag from the signal-handling
 thread (not from inside the handler itself).
 
-Cross-reference: Risk C6, issue #709 (WL_LOG signal-safety only
-documented in `CLAUDE.md`).
+Cross-reference: Risk C6, issue #709 (consolidated in
+`docs/ERROR_MODEL.md`).
 
 ---
 
@@ -621,9 +620,9 @@ process that will use it.** Crossing a `fork()` boundary without
 The `wirelog/util/log.h` structured logger has its own fork-safety
 note: after `fork()`, if the child changes the log sink, the child
 must call `wl_log_init()` again. This is documented in §9 (signal-
-safety) and in `CLAUDE.md` Runtime Diagnostics. It is reproduced
-here for completeness: the logger fits the same fork-without-exec
-hazard pattern as the I/O adapter registry.
+safety) and `docs/ERROR_MODEL.md`. It is reproduced here for
+completeness: the logger fits the same fork-without-exec hazard
+pattern as the I/O adapter registry.
 
 ### 10.5 What about `pthread_atfork`?
 
@@ -724,14 +723,13 @@ advisory leg); issue #826 (native TSan SEGV triage);
 - `wirelog/columnar/rotation_standard.c:28-32`,
   `rotation_pinned.c:50-56` — rotation strategy epoch-boundary
   callbacks.
-- `wirelog/util/log.h:11-17` — WL_LOG signal-safety statement.
-- `CLAUDE.md` Runtime Diagnostics section — canonical WL_LOG /
-  `WL_DEBUG_JOIN` / `WL_CONSOLIDATION_LOG` rules.
+- `wirelog/util/log.h` — internal WL_LOG safety summary.
+- `docs/ERROR_MODEL.md` — canonical WL_LOG signal/fork safety policy.
 - Issue #681 — v0.41 ABI Infrastructure epic.
 - Issue #734 — this document.
 - Issue #708 — TSan + `-Dthreads=posix` cross-link.
 - Issue #716 — io_adapter fork-safety (§10).
-- Issue #709 — WL_LOG signal-safety risk note.
+- Issue #709 — error-model and WL_LOG safety documentation.
 - Issue #731 — CRDT median-time perf gate (empirical anchor for
   K = 4 parallel threshold).
 - Commit `61e081b` — `fix(#579)`: skip compound-arena GC dispatch

--- a/wirelog/util/log.h
+++ b/wirelog/util/log.h
@@ -1,24 +1,23 @@
-/*
- * wirelog/util/log.h - wirelog Structured Logger (GST_DEBUG style)
- *
- * Copyright (C) CleverPlant
- * Licensed under LGPL-3.0
- * For commercial licenses, contact: inquiry@cleverplant.com
+/**
+ * @file wirelog/util/log.h
+ * @brief Internal structured logger (GST_DEBUG style).
  *
  * INTERNAL HEADER - never transitively included by any installed/public header.
- * Enforced by scripts/check_log_header_not_public.sh.
+ * Enforced by scripts/check_log_header_not_public.sh. This header is not an
+ * installed/public API surface.
  *
  * Zero-overhead when disabled:
- *   - Levels above WL_LOG_COMPILE_MAX_LEVEL (-Dwirelog_log_max_level=...) are
- *     stripped at compile time; argument expressions are NOT evaluated.
- *   - Runtime-disabled sites are a single byte load + predicted-not-taken branch.
+ * - Levels above WL_LOG_COMPILE_MAX_LEVEL (-Dwirelog_log_max_level=...) are
+ *   stripped at compile time; argument expressions are NOT evaluated.
+ * - Runtime-disabled sites are a single byte load plus predicted-not-taken
+ *   branch.
  *
- * Safety:
- *   - WL_LOG is NOT async-signal-safe. Do not call from signal handlers.
- *   - No pthread_atfork is installed. After fork(), children that changed the
- *     sink must call wl_log_init() again.
- *   - Thresholds are written once at wl_log_init(); subsequent reads are
- *     lock-free byte loads. Emit uses FILE-internal locking via fwrite.
+ * Safety (see docs/ERROR_MODEL.md):
+ * - WL_LOG is NOT async-signal-safe. Do not call from signal handlers.
+ * - No pthread_atfork is installed. After fork(), children that changed the
+ *   sink must call wl_log_init() again.
+ * - Thresholds are written once at wl_log_init(); subsequent reads are
+ *   lock-free byte loads. Emit uses stdio/file I/O, including fwrite.
  */
 
 #ifndef WIRELOG_UTIL_LOG_H

--- a/wirelog/util/log_emit.c
+++ b/wirelog/util/log_emit.c
@@ -16,6 +16,7 @@
  *     provides message atomicity on POSIX.
  *   - Not reentrant: wl_log_emit MUST NOT call WL_LOG.
  *   - Not async-signal-safe: vsnprintf and fwrite are not AS-safe.
+ *     See docs/ERROR_MODEL.md for the user-facing policy.
  */
 
 #include "wirelog/util/log.h"


### PR DESCRIPTION
## Summary

Closes #709.

Adds `docs/ERROR_MODEL.md` as the canonical user-facing policy for:

- public API error boundaries and diagnostics-vs-control-flow guidance
- `WL_LOG` async-signal-safety and fork constraints
- `pthread_atfork` non-goal and `wl_log_init()` sink re-init guidance
- host-owned restart/durability handoff

Then updates existing threading/logger comments to point at that canonical document instead of the stale `CLAUDE.md` / #709 gap wording.

## Atomic commits and workflow review

- `0bb07ff` `docs: add error model policy`
  - Reviewer: no blocking findings or non-blocking observations
  - Architect/Critic: agreed the doc can stand as canonical policy before pointer updates
- `827bfcd` `docs: point log safety docs at error model`
  - Reviewer: no blocking findings or non-blocking observations
  - Architect/Critic: agreed #709 is complete at commit level

## Validation

- `git diff --check origin/main..HEAD`
- `rg -n "ERROR_MODEL|async-signal|fork|pthread_atfork|wl_log_init|WL_LOG|wirelog_error_t|THREADING|io-adapters|SECURITY_MODEL|@file|@brief" docs/ERROR_MODEL.md README.md docs/THREADING.md wirelog/util/log.h wirelog/util/log_emit.c`
- `meson test -C build threading_doc log_abi_header_not_public --print-errorlogs`
- Per-commit `git show --check --stat HEAD` during each atomic unit

Known gap: `markdownlint` is not available locally. `npx --no-install markdownlint docs/ERROR_MODEL.md README.md` failed because no local executable was installed.