### PR TITLE
parser+columnar: add crc32_ethernet / crc32_castagnoli built-ins

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -52,6 +52,9 @@ bench_backend_src = files(
   subdir_wirelog / 'util/log.c',
   subdir_wirelog / 'util/log_emit.c',
   subdir_wirelog / 'string_ops.c',
+  # Issue #884: columnar/ops.c calls into ethernet_crc32()/castagnoli_crc32()
+  # for the CRC-32 evaluator cases.
+  subdir_wirelog / 'crc32.c',
 )
 
 bench_io_src = files(

--- a/meson.build
+++ b/meson.build
@@ -344,6 +344,7 @@ wirelog_sources += wirelog_optimizer_src
 wirelog_sources += wirelog_arena_src
 wirelog_sources += wirelog_thread_src
 wirelog_sources += wirelog_backend_src
+wirelog_sources += wirelog_crc32_src
 wirelog_sources += wirelog_workqueue_src
 wirelog_sources += wirelog_io_src
 wirelog_sources += wirelog_string_ops_src

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -789,6 +789,11 @@ backend_src = files(
   '../wirelog/util/log.c',
   '../wirelog/util/log_emit.c',
   '../wirelog/string_ops.c',
+  # Issue #884: the columnar evaluator's WL_PLAN_EXPR_ARITH_CRC32_*
+  # cases call ethernet_crc32()/castagnoli_crc32() from this TU.  Pull
+  # the engine in so every backend-test binary has the symbols at
+  # link time.
+  '../wirelog/crc32.c',
 )
 
 arena_src = files(
@@ -2295,6 +2300,28 @@ if cc.get_id() != 'msvc'
   )
 
   test('crc32_hw_equivalence', test_crc32_hw_equivalence_exe)
+
+  # CRC-32 evaluator tests (Issue #884): drive the columnar evaluator end
+  # to end and verify it matches the engine functions in wirelog/crc32.c.
+  # Reuses crc32_arch_c_args / crc32_src defined above.
+  test_crc32_eval_exe = executable(
+    'test_crc32_eval',
+    files('test_crc32_eval.c'),
+    parser_src,
+    ir_src,
+    optimizer_src,
+    backend_src,
+    io_src,
+    arena_src,
+    thread_src,
+    workqueue_src,
+    crc32_src,
+    c_args: crc32_arch_c_args,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  )
+
+  test('crc32_eval', test_crc32_eval_exe)
 endif
 
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2163,6 +2163,21 @@ test_hash_parser_exe = executable(
 
 test('hash_parser', test_hash_parser_exe)
 
+# CRC-32 parser tests (Issue #884): verify the lexer/parser accept
+# crc32_ethernet(...) and crc32_castagnoli(...) as built-in keywords.
+test_crc32_parser_exe = executable(
+  'test_crc32_parser',
+  files('test_crc32_parser.c'),
+  parser_src,
+  ir_src,
+  io_src,
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep],
+)
+
+test('crc32_parser', test_crc32_parser_exe)
+
 test_hash_eval_exe = executable(
   'test_hash_eval',
   files('test_hash_eval.c'),

--- a/tests/test_crc32_eval.c
+++ b/tests/test_crc32_eval.c
@@ -1,0 +1,408 @@
+/*
+ * test_crc32_eval.c - CRC-32 Built-in Evaluator Tests (Issue #884)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * End-to-end tests for crc32_ethernet() / crc32_castagnoli() Datalog
+ * built-ins.  Verifies that the columnar evaluator computes the operator
+ * (no fail-closed path), that distinct int64 inputs produce distinct
+ * outputs, that the two variants disagree on the same input, and that
+ * the comparison form used in examples/05-crc32-checksum/crc32_validate.dl
+ * (crc32_ethernet(x) = c filter) drives the result set deterministically.
+ *
+ * The tests use int64 inputs the same way the existing cryptographic
+ * hash tests do: the evaluator pops the int64 from the filter stack and
+ * hashes its 8 little-endian bytes.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/crc32.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                  \
+            tests_run++;                      \
+            printf("  [TEST] %-60s", (name)); \
+            fflush(stdout);                   \
+        } while (0)
+
+#define PASS()             \
+        do {               \
+            tests_passed++; \
+            printf(" PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                              \
+            tests_failed++;               \
+            printf(" FAIL: %s\n", (msg)); \
+            return;                       \
+        } while (0)
+
+struct result_ctx {
+    int64_t col0[64];
+    uint32_t count;
+    int snapshot_rc;
+};
+
+static void
+capture_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    struct result_ctx *ctx = (struct result_ctx *)user_data;
+    (void)relation;
+    (void)ncols;
+    if (ctx->count < 64) {
+        ctx->col0[ctx->count] = row[0];
+        ctx->count++;
+    }
+}
+
+struct two_col_ctx {
+    int64_t col0;
+    int64_t col1;
+    uint32_t count;
+};
+
+static void
+capture_two_cols_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    struct two_col_ctx *ctx = (struct two_col_ctx *)user_data;
+    (void)relation;
+    if (ncols >= 2 && ctx->count == 0) {
+        ctx->col0 = row[0];
+        ctx->col1 = row[1];
+    }
+    ctx->count++;
+}
+
+static int
+run_program(const char *src, struct result_ctx *ctx)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    if (wl_session_load_facts(sess, prog) != 0) {
+        wl_session_destroy(sess);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    ctx->count = 0;
+    ctx->snapshot_rc = wl_session_snapshot(sess, capture_cb, ctx);
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return 0;
+}
+
+/* ======================================================================== */
+/* crc32_ethernet() evaluator tests                                         */
+/* ======================================================================== */
+
+static void
+test_crc32_ethernet_determinism(void)
+{
+    TEST("crc32_ethernet(0): two evaluations produce the same result");
+
+    const char *src = ".decl a(x: int64)\n"
+        "a(0).\n"
+        ".decl r(z: int64)\n"
+        "r(crc32_ethernet(x)) :- a(x).\n";
+
+    struct result_ctx ctx1, ctx2;
+    if (run_program(src, &ctx1) != 0 || ctx1.snapshot_rc != 0) {
+        FAIL("first evaluation failed");
+    }
+    if (run_program(src, &ctx2) != 0 || ctx2.snapshot_rc != 0) {
+        FAIL("second evaluation failed");
+    }
+    if (ctx1.count != 1 || ctx2.count != 1) {
+        FAIL("expected 1 tuple each run");
+    }
+    if (ctx1.col0[0] != ctx2.col0[0]) {
+        FAIL("crc32_ethernet(0) not deterministic across runs");
+    }
+    PASS();
+}
+
+static void
+test_crc32_ethernet_distinct_inputs(void)
+{
+    TEST("crc32_ethernet: distinct inputs produce distinct outputs");
+
+    const char *src = ".decl a(x: int64)\n"
+        "a(0). a(1). a(42).\n"
+        ".decl r(z: int64)\n"
+        "r(crc32_ethernet(x)) :- a(x).\n";
+
+    struct result_ctx ctx;
+    if (run_program(src, &ctx) != 0 || ctx.snapshot_rc != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ctx.count != 3) {
+        FAIL("expected 3 tuples");
+    }
+    if (ctx.col0[0] == ctx.col0[1] || ctx.col0[0] == ctx.col0[2]
+        || ctx.col0[1] == ctx.col0[2]) {
+        FAIL("crc32_ethernet collision on distinct inputs");
+    }
+    PASS();
+}
+
+static void
+test_crc32_ethernet_matches_engine(void)
+{
+    TEST("crc32_ethernet(0x123456789ABCDEF0) matches engine output");
+
+    const int64_t input = (int64_t)0x123456789ABCDEF0LL;
+    uint8_t bytes[sizeof(input)];
+    memcpy(bytes, &input, sizeof(input));
+    uint32_t expected = ethernet_crc32(bytes, sizeof(bytes));
+
+    char src[256];
+    snprintf(src, sizeof(src),
+        ".decl a(x: int64)\n"
+        "a(%" PRId64 ").\n"
+        ".decl r(z: int64)\n"
+        "r(crc32_ethernet(x)) :- a(x).\n",
+        input);
+
+    struct result_ctx ctx;
+    if (run_program(src, &ctx) != 0 || ctx.snapshot_rc != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ctx.count != 1) {
+        FAIL("expected 1 tuple");
+    }
+    if ((uint32_t)ctx.col0[0] != expected) {
+        char buf[128];
+        snprintf(buf, sizeof(buf),
+            "evaluator=0x%08x engine=0x%08x",
+            (uint32_t)ctx.col0[0], expected);
+        FAIL(buf);
+    }
+    PASS();
+}
+
+static void
+test_crc32_ethernet_filter_matches(void)
+{
+    TEST("crc32_ethernet(x) = c filter selects only matching rows");
+
+    /* Compute the Ethernet CRC-32 of the int64 12345 so the rule can
+     * pin a single matching row. */
+    const int64_t input = 12345;
+    uint8_t bytes[sizeof(input)];
+    memcpy(bytes, &input, sizeof(input));
+    int64_t target = (int64_t)ethernet_crc32(bytes, sizeof(bytes));
+
+    char src[384];
+    snprintf(src, sizeof(src),
+        ".decl pair(x: int64, c: int64)\n"
+        "pair(12345, %" PRId64 "). pair(54321, 0).\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- pair(x, c), crc32_ethernet(x) = c.\n",
+        target);
+
+    struct result_ctx ctx;
+    if (run_program(src, &ctx) != 0 || ctx.snapshot_rc != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ctx.count != 1 || ctx.col0[0] != 12345) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "count=%u first=%" PRId64,
+            ctx.count, ctx.count ? ctx.col0[0] : 0);
+        FAIL(buf);
+    }
+    PASS();
+}
+
+/* ======================================================================== */
+/* crc32_castagnoli() evaluator tests                                       */
+/* ======================================================================== */
+
+static void
+test_crc32_castagnoli_determinism(void)
+{
+    TEST("crc32_castagnoli(0): two evaluations produce the same result");
+
+    const char *src = ".decl a(x: int64)\n"
+        "a(0).\n"
+        ".decl r(z: int64)\n"
+        "r(crc32_castagnoli(x)) :- a(x).\n";
+
+    struct result_ctx ctx1, ctx2;
+    if (run_program(src, &ctx1) != 0 || ctx1.snapshot_rc != 0) {
+        FAIL("first evaluation failed");
+    }
+    if (run_program(src, &ctx2) != 0 || ctx2.snapshot_rc != 0) {
+        FAIL("second evaluation failed");
+    }
+    if (ctx1.count != 1 || ctx2.count != 1) {
+        FAIL("expected 1 tuple each run");
+    }
+    if (ctx1.col0[0] != ctx2.col0[0]) {
+        FAIL("crc32_castagnoli(0) not deterministic across runs");
+    }
+    PASS();
+}
+
+static void
+test_crc32_castagnoli_matches_engine(void)
+{
+    TEST("crc32_castagnoli(0x123456789ABCDEF0) matches engine output");
+
+    const int64_t input = (int64_t)0x123456789ABCDEF0LL;
+    uint8_t bytes[sizeof(input)];
+    memcpy(bytes, &input, sizeof(input));
+    uint32_t expected = castagnoli_crc32(bytes, sizeof(bytes));
+
+    char src[256];
+    snprintf(src, sizeof(src),
+        ".decl a(x: int64)\n"
+        "a(%" PRId64 ").\n"
+        ".decl r(z: int64)\n"
+        "r(crc32_castagnoli(x)) :- a(x).\n",
+        input);
+
+    struct result_ctx ctx;
+    if (run_program(src, &ctx) != 0 || ctx.snapshot_rc != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ctx.count != 1) {
+        FAIL("expected 1 tuple");
+    }
+    if ((uint32_t)ctx.col0[0] != expected) {
+        char buf[128];
+        snprintf(buf, sizeof(buf),
+            "evaluator=0x%08x engine=0x%08x",
+            (uint32_t)ctx.col0[0], expected);
+        FAIL(buf);
+    }
+    PASS();
+}
+
+/* ======================================================================== */
+/* Variant separation: Ethernet vs Castagnoli                              */
+/* ======================================================================== */
+
+static void
+test_crc32_variants_differ(void)
+{
+    TEST("crc32_ethernet and crc32_castagnoli disagree on a non-trivial input");
+
+    /* CRC-32 Ethernet (poly 0x04C11DB7) and Castagnoli (poly 0x1EDC6F41)
+     * are different polynomials.  For any non-zero input they should
+     * produce different residues. */
+    const char *src = ".decl a(x: int64)\n"
+        "a(42).\n"
+        ".decl r(eth: int64, cast: int64)\n"
+        "r(crc32_ethernet(x), crc32_castagnoli(x)) :- a(x).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        FAIL("parse failed");
+    }
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        FAIL("plan failed");
+    }
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("session create failed");
+    }
+    if (wl_session_load_facts(sess, prog) != 0) {
+        wl_session_destroy(sess);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("session load failed");
+    }
+
+    struct two_col_ctx captured = { 0, 0, 0 };
+    int snap_rc = wl_session_snapshot(sess, capture_two_cols_cb, &captured);
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+
+    if (snap_rc != 0 || captured.count != 1) {
+        FAIL("snapshot did not return a single row");
+    }
+    if (captured.col0 == captured.col1) {
+        FAIL("crc32_ethernet and crc32_castagnoli produced identical output");
+    }
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== wirelog CRC-32 Evaluator Tests (Issue #884) ===\n\n");
+
+    printf("--- crc32_ethernet() ---\n");
+    test_crc32_ethernet_determinism();
+    test_crc32_ethernet_distinct_inputs();
+    test_crc32_ethernet_matches_engine();
+    test_crc32_ethernet_filter_matches();
+
+    printf("\n--- crc32_castagnoli() ---\n");
+    test_crc32_castagnoli_determinism();
+    test_crc32_castagnoli_matches_engine();
+
+    printf("\n--- Variant separation ---\n");
+    test_crc32_variants_differ();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+        printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_crc32_parser.c
+++ b/tests/test_crc32_parser.c
@@ -1,0 +1,281 @@
+/*
+ * test_crc32_parser.c - CRC-32 Built-in Parser Tests (Issue #884)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Verifies that the parser recognizes the crc32_ethernet() and
+ * crc32_castagnoli() built-in functions and creates correct BINARY_EXPR AST
+ * nodes with WIRELOG_ARITH_CRC32_ETH / WIRELOG_ARITH_CRC32_CAST ops.
+ *
+ * Syntax: crc32_ethernet(expr), crc32_castagnoli(expr)  -- unary, like md5(expr).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../wirelog/parser/parser.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                      \
+        do {                                \
+            tests_run++;                    \
+            printf("  [TEST] %-60s", name); \
+            fflush(stdout);                 \
+        } while (0)
+
+#define PASS()             \
+        do {                   \
+            tests_passed++;    \
+            printf(" PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                   \
+        do {                            \
+            tests_failed++;             \
+            printf(" FAIL: %s\n", msg); \
+        } while (0)
+
+#define PARSE(src)                \
+        char errbuf[512] = { 0 };     \
+        wl_parser_ast_node_t *program \
+            = wl_parser_parse_string(src, errbuf, sizeof(errbuf))
+
+#define ASSERT_PARSED()                                             \
+        do {                                                            \
+            if (!program) {                                             \
+                char buf[600];                                          \
+                snprintf(buf, sizeof(buf), "parse failed: %s", errbuf); \
+                FAIL(buf);                                              \
+                return;                                                 \
+            }                                                           \
+            if (program->type != WL_PARSER_AST_NODE_PROGRAM) {          \
+                wl_parser_ast_node_free(program);                       \
+                FAIL("root is not PROGRAM");                            \
+                return;                                                 \
+            }                                                           \
+        } while (0)
+
+#define CLEANUP() wl_parser_ast_node_free(program)
+
+static const wl_parser_ast_node_t *
+child(const wl_parser_ast_node_t *node, uint32_t index)
+{
+    if (!node || index >= node->child_count)
+        return NULL;
+    return node->children[index];
+}
+
+static const wl_parser_ast_node_t *
+first_head_arg(const wl_parser_ast_node_t *program)
+{
+    const wl_parser_ast_node_t *rule = child(program, 0);
+    if (!rule || rule->type != WL_PARSER_AST_NODE_RULE)
+        return NULL;
+    const wl_parser_ast_node_t *head = child(rule, 0);
+    if (!head || head->type != WL_PARSER_AST_NODE_HEAD)
+        return NULL;
+    return child(head, 0);
+}
+
+static const wl_parser_ast_node_t *
+first_body_cmp_left(const wl_parser_ast_node_t *program)
+{
+    const wl_parser_ast_node_t *rule = child(program, 0);
+    if (!rule)
+        return NULL;
+    for (uint32_t i = 1; i < rule->child_count; i++) {
+        const wl_parser_ast_node_t *b = child(rule, i);
+        if (b && b->type == WL_PARSER_AST_NODE_COMPARISON)
+            return child(b, 0);
+    }
+    return NULL;
+}
+
+/* ======================================================================== */
+/* crc32_ethernet() Parser Tests                                            */
+/* ======================================================================== */
+
+static void
+test_parse_crc32_ethernet_in_head(void)
+{
+    TEST("crc32_ethernet(x) in head creates BINARY_EXPR with CRC32_ETH op");
+    PARSE("r(crc32_ethernet(x)) :- a(x).");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *expr = first_head_arg(program);
+    if (!expr || expr->type != WL_PARSER_AST_NODE_BINARY_EXPR) {
+        CLEANUP();
+        FAIL("expected BINARY_EXPR in head");
+        return;
+    }
+    if (expr->arith_op != WIRELOG_ARITH_CRC32_ETH) {
+        CLEANUP();
+        FAIL("expected arith_op == WIRELOG_ARITH_CRC32_ETH");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_crc32_ethernet_has_one_child(void)
+{
+    TEST("crc32_ethernet(x) is unary: exactly 1 child");
+    PARSE("r(crc32_ethernet(x)) :- a(x).");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *expr = first_head_arg(program);
+    if (!expr || expr->arith_op != WIRELOG_ARITH_CRC32_ETH
+        || expr->child_count != 1) {
+        CLEANUP();
+        FAIL("expected unary CRC32_ETH expression");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_crc32_ethernet_in_filter(void)
+{
+    TEST(
+        "crc32_ethernet(x) = y in body creates COMPARISON with CRC32_ETH left");
+    PARSE("r(x) :- a(x, y), crc32_ethernet(x) = y.");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *lhs = first_body_cmp_left(program);
+    if (!lhs || lhs->type != WL_PARSER_AST_NODE_BINARY_EXPR
+        || lhs->arith_op != WIRELOG_ARITH_CRC32_ETH) {
+        CLEANUP();
+        FAIL("expected CRC32_ETH expr on left side of comparison");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_crc32_ethernet_filter_neq(void)
+{
+    TEST("crc32_ethernet(x) != y in body comparison parses cleanly");
+    PARSE("r(x) :- a(x, y), crc32_ethernet(x) != y.");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *lhs = first_body_cmp_left(program);
+    if (!lhs || lhs->arith_op != WIRELOG_ARITH_CRC32_ETH) {
+        CLEANUP();
+        FAIL("expected CRC32_ETH expr on left side of != comparison");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+/*
+ * Issue #884 minimal reproducer: the original symptom was that the parser
+ * could not consume crc32_ethernet on either side of an equality.  Pin the
+ * minimal program so regressions stay visible.
+ */
+static void
+test_parse_crc32_ethernet_issue_884_reproducer(void)
+{
+    TEST("Issue #884 minimal repro: in(s,c) + crc32_ethernet(S) = C");
+    PARSE(".decl in(s: symbol, c: int64)\n"
+        ".decl out(s: symbol)\n"
+        "in(\"abc\", 123).\n"
+        "out(S) :- in(S, C), crc32_ethernet(S) = C.\n");
+    ASSERT_PARSED();
+    CLEANUP();
+    PASS();
+}
+
+/* ======================================================================== */
+/* crc32_castagnoli() Parser Tests                                          */
+/* ======================================================================== */
+
+static void
+test_parse_crc32_castagnoli_in_head(void)
+{
+    TEST("crc32_castagnoli(x) in head creates BINARY_EXPR with CRC32_CAST op");
+    PARSE("r(crc32_castagnoli(x)) :- a(x).");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *expr = first_head_arg(program);
+    if (!expr || expr->type != WL_PARSER_AST_NODE_BINARY_EXPR) {
+        CLEANUP();
+        FAIL("expected BINARY_EXPR in head");
+        return;
+    }
+    if (expr->arith_op != WIRELOG_ARITH_CRC32_CAST) {
+        CLEANUP();
+        FAIL("expected arith_op == WIRELOG_ARITH_CRC32_CAST");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_crc32_castagnoli_in_filter(void)
+{
+    TEST("crc32_castagnoli(x) = y on left side of comparison");
+    PARSE("r(x) :- a(x, y), crc32_castagnoli(x) = y.");
+    ASSERT_PARSED();
+
+    const wl_parser_ast_node_t *lhs = first_body_cmp_left(program);
+    if (!lhs || lhs->arith_op != WIRELOG_ARITH_CRC32_CAST) {
+        CLEANUP();
+        FAIL("expected CRC32_CAST expr on left side of comparison");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+/* ======================================================================== */
+/* Distinctness sanity                                                      */
+/* ======================================================================== */
+
+static void
+test_parse_crc32_variants_distinct_ops(void)
+{
+    TEST("crc32_ethernet and crc32_castagnoli map to distinct arith_ops");
+    if (WIRELOG_ARITH_CRC32_ETH == WIRELOG_ARITH_CRC32_CAST) {
+        FAIL("CRC32_ETH and CRC32_CAST collide in arith_op enum");
+        return;
+    }
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== wirelog CRC-32 Parser Tests (Issue #884) ===\n\n");
+
+    printf("--- crc32_ethernet() ---\n");
+    test_parse_crc32_ethernet_in_head();
+    test_parse_crc32_ethernet_has_one_child();
+    test_parse_crc32_ethernet_in_filter();
+    test_parse_crc32_ethernet_filter_neq();
+    test_parse_crc32_ethernet_issue_884_reproducer();
+
+    printf("\n--- crc32_castagnoli() ---\n");
+    test_parse_crc32_castagnoli_in_head();
+    test_parse_crc32_castagnoli_in_filter();
+
+    printf("\n--- Sanity ---\n");
+    test_parse_crc32_variants_distinct_ops();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+        printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -37,6 +37,7 @@
 #include "wirelog/util/log.h"
 
 #include "../wirelog-internal.h"
+#include "../crc32.h"
 #include "../intern.h"
 #include "../string_ops.h"
 
@@ -446,6 +447,22 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_HASH: {
             int64_t a = filt_pop(&s);
             filt_push(&s, (int64_t)XXH3_64bits(&a, sizeof(a)));
+            break;
+        }
+
+        case WL_PLAN_EXPR_ARITH_CRC32_ETH: {
+            int64_t a = filt_pop(&s);
+            uint8_t bytes[sizeof(a)];
+            memcpy(bytes, &a, sizeof(bytes));
+            filt_push(&s, (int64_t)ethernet_crc32(bytes, sizeof(bytes)));
+            break;
+        }
+
+        case WL_PLAN_EXPR_ARITH_CRC32_CAST: {
+            int64_t a = filt_pop(&s);
+            uint8_t bytes[sizeof(a)];
+            memcpy(bytes, &a, sizeof(bytes));
+            filt_push(&s, (int64_t)castagnoli_crc32(bytes, sizeof(bytes)));
             break;
         }
 

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -109,6 +109,38 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
                            'util/lockfree_queue.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+#CRC-32 Module (Issue #145 / #884)
+#
+#crc32.c implements hardware-accelerated CRC-32 (Ethernet poly + Castagnoli
+#poly) via SSE4.2 intrinsics on x86_64 and the ARMv8-A CRC extension on
+#aarch64.  The columnar evaluator's WL_PLAN_EXPR_ARITH_CRC32_* cases call
+#into these functions (Issue #884), so any test binary that pulls in the
+#columnar backend also pulls in crc32.c.  The architecture intrinsics
+#require their own compile flags; we apply them project-wide rather than
+#per-target because (a) the same flags were already required by the three
+#standalone crc32 tests, (b) all currently-supported deployment targets
+#predate-by-a-decade the relevant CPU features (SSE4.2 = Nehalem 2008,
+#ARMv8-A+CRC = ARMv8.1 2014), and (c) the alternative — threading
+#per-source compile flags through 130+ test binaries — is significantly
+#more fragile.
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
+
+wirelog_crc32_src = files('crc32.c')
+
+wirelog_crc32_arch_c_args = []
+if cc.get_id() != 'msvc'
+  if host_machine.cpu_family() == 'x86_64'
+    wirelog_crc32_arch_c_args = ['-msse4.2']
+  elif host_machine.cpu_family() == 'aarch64'
+    wirelog_crc32_arch_c_args = ['-march=armv8-a+crc']
+  endif
+endif
+
+if wirelog_crc32_arch_c_args.length() > 0
+  add_project_arguments(wirelog_crc32_arch_c_args, language: 'c')
+endif
+
+#== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #I / O Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 

--- a/wirelog/parser/lexer.c
+++ b/wirelog/parser/lexer.c
@@ -257,6 +257,12 @@ identifier_type(const char *start, uint32_t length)
     if (IS_KW("uuid5"))
         return WL_PARSER_LEXER_TOK_UUID5;
 
+    /* CRC-32 function keywords (Issue #884) */
+    if (IS_KW("crc32_ethernet"))
+        return WL_PARSER_LEXER_TOK_CRC32_ETH;
+    if (IS_KW("crc32_castagnoli"))
+        return WL_PARSER_LEXER_TOK_CRC32_CAST;
+
     /* String function keywords */
     if (IS_KW("strlen"))
         return WL_PARSER_LEXER_TOK_STRLEN;
@@ -589,6 +595,10 @@ wl_parser_lexer_token_type_str(wl_parser_lexer_token_type_t type)
         return "UUID4";
     case WL_PARSER_LEXER_TOK_UUID5:
         return "UUID5";
+    case WL_PARSER_LEXER_TOK_CRC32_ETH:
+        return "CRC32_ETHERNET";
+    case WL_PARSER_LEXER_TOK_CRC32_CAST:
+        return "CRC32_CASTAGNOLI";
     case WL_PARSER_LEXER_TOK_STRLEN:
         return "STRLEN";
     case WL_PARSER_LEXER_TOK_CAT:

--- a/wirelog/parser/lexer.h
+++ b/wirelog/parser/lexer.h
@@ -99,6 +99,10 @@ typedef enum {
     WL_PARSER_LEXER_TOK_UUID4, /* uuid4 */
     WL_PARSER_LEXER_TOK_UUID5, /* uuid5 */
 
+    /* CRC-32 function keywords (Issue #884) */
+    WL_PARSER_LEXER_TOK_CRC32_ETH,  /* crc32_ethernet */
+    WL_PARSER_LEXER_TOK_CRC32_CAST, /* crc32_castagnoli */
+
     /* String function keywords */
     WL_PARSER_LEXER_TOK_STRLEN,      /* strlen */
     WL_PARSER_LEXER_TOK_CAT,         /* cat */

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -601,6 +601,50 @@ parse_factor(wl_parser_t *parser)
         return node;
     }
 
+    /* CRC-32 Ethernet/ISO function: crc32_ethernet(expr) (Issue #884) */
+    if (parser->current.type == WL_PARSER_LEXER_TOK_CRC32_ETH) {
+        parser_advance(parser); /* consume crc32_ethernet */
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_LPAREN,
+            "expected '(' after crc32_ethernet")) {
+            return NULL;
+        }
+        wl_parser_ast_node_t *arg = parse_arithmetic_expr(parser);
+        if (!arg)
+            return NULL;
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
+            "expected ')' after crc32_ethernet argument")) {
+            wl_parser_ast_node_free(arg);
+            return NULL;
+        }
+        wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
+            WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
+        unary->arith_op = WIRELOG_ARITH_CRC32_ETH;
+        wl_parser_ast_node_add_child(unary, arg);
+        return unary;
+    }
+
+    /* CRC-32 Castagnoli (iSCSI) function: crc32_castagnoli(expr) (Issue #884) */
+    if (parser->current.type == WL_PARSER_LEXER_TOK_CRC32_CAST) {
+        parser_advance(parser); /* consume crc32_castagnoli */
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_LPAREN,
+            "expected '(' after crc32_castagnoli")) {
+            return NULL;
+        }
+        wl_parser_ast_node_t *arg = parse_arithmetic_expr(parser);
+        if (!arg)
+            return NULL;
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
+            "expected ')' after crc32_castagnoli argument")) {
+            wl_parser_ast_node_free(arg);
+            return NULL;
+        }
+        wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
+            WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
+        unary->arith_op = WIRELOG_ARITH_CRC32_CAST;
+        wl_parser_ast_node_add_child(unary, arg);
+        return unary;
+    }
+
     /* UUID4 function: uuid4() - nullary */
     if (parser->current.type == WL_PARSER_LEXER_TOK_UUID4) {
         parser_advance(parser); /* consume uuid4 */
@@ -705,7 +749,9 @@ is_bitwise_token(wl_parser_lexer_token_type_t type)
            || type == WL_PARSER_LEXER_TOK_SHA512
            || type == WL_PARSER_LEXER_TOK_HMAC_SHA256
            || type == WL_PARSER_LEXER_TOK_UUID4
-           || type == WL_PARSER_LEXER_TOK_UUID5;
+           || type == WL_PARSER_LEXER_TOK_UUID5
+           || type == WL_PARSER_LEXER_TOK_CRC32_ETH
+           || type == WL_PARSER_LEXER_TOK_CRC32_CAST;
 }
 
 static wl_parser_ast_node_t *


### PR DESCRIPTION
## Summary

- C1: parser/lexer learns the `crc32_ethernet(...)` and `crc32_castagnoli(...)` keywords, mirroring the existing MD5/SHA1 unary builtin wiring. Closes the parse-time gap reported in #884.
- C2: columnar evaluator drives the new IR cases through `wirelog/crc32.c`'s `ethernet_crc32` / `castagnoli_crc32`, so the example `examples/05-crc32-checksum/crc32_validate.dl` now runs end-to-end instead of failing closed on `goto bad`.

Two atomic, independently-buildable commits with TDD-style test files for each: `tests/test_crc32_parser.c` (parser AST) and `tests/test_crc32_eval.c` (evaluator + engine bit-exact agreement + Issue #884 reproducer).

## Test plan
- [x] `meson test -C build crc32_parser` (8/8)
- [x] `meson test -C build crc32_eval` (7/7)
- [x] Full suite — 244/254 pass + 9 skip + 1 fail; the one failure is the pre-existing locale-dependent ABI gate filed separately as #886 (reproduces on a clean main with no changes).
- [x] `LC_ALL=C` ABI diff against `abi/libwirelog-1.0.symbols` — no drift. The CRC-32 engine functions stay hidden-visibility internal symbols.
- [x] Manual: `wirelog_cli examples/05-crc32-checksum/crc32_validate.dl` parses and runs.

## Notes for reviewers

- The architecture-specific intrinsic flags for CRC-32 (`-msse4.2` on x86_64, `-march=armv8-a+crc` on aarch64) are now promoted to `add_project_arguments` so every binary that compiles `columnar/ops.c` can also link `crc32.c`. The same flags were already required by the three standalone CRC-32 tests; the implied CPU baseline (Nehalem 2008 / ARMv8.1 2014) is what those tests already assumed. Per-source plumbing through 130+ test binaries was rejected as fragile (see the commit message on C2 and the inline rationale in `wirelog/meson.build`).
- The `abi - wirelog:abi_symbols` failure is independent — it is the `LC_COLLATE` locale issue tracked in #886 and reproduces on a clean main.

Issue: #884