### PR TITLE
ci: publish perf portfolio history

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -47,6 +47,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   perf:
@@ -193,7 +194,7 @@ jobs:
           name: perf-portfolio-${{ matrix.os }}-${{ matrix.compiler }}
           path: perf-artifacts/portfolio
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 35
 
       - name: Summarize flowlog portfolio
         if: always()
@@ -222,6 +223,74 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo '</details>' >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  portfolio-skip-rate:
+    name: Perf portfolio SKIP-rate history
+    needs: perf
+    if: always()
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download recent portfolio artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p perf-artifacts/history perf-artifacts/skip-rate
+          warnings=perf-artifacts/skip-rate/warnings.log
+          : > "$warnings"
+          cutoff="$(date -u -d '30 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+          if ! gh run list \
+              --workflow perf-nightly.yml \
+              --created ">=$cutoff" \
+              --limit 100 \
+              --json databaseId \
+              --jq '.[].databaseId' > perf-artifacts/skip-rate/runs.txt; then
+            echo "gh run list failed; no history downloaded" >> "$warnings"
+          fi
+          while IFS= read -r run_id; do
+            [ -n "$run_id" ] || continue
+            dest="perf-artifacts/history/run-$run_id"
+            mkdir -p "$dest"
+            if ! gh run download "$run_id" \
+                --pattern 'perf-portfolio-*' \
+                --dir "$dest"; then
+              echo "failed to download perf portfolio artifacts for run $run_id" >> "$warnings"
+            fi
+          done < perf-artifacts/skip-rate/runs.txt
+
+      - name: Summarize portfolio SKIP-rate history
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p perf-artifacts/skip-rate
+          python scripts/perf/summarize-flowlog-portfolio-history.py \
+            --root perf-artifacts/history \
+            --window-days 30 \
+            --json-out perf-artifacts/skip-rate/skip-rate.json \
+            > perf-artifacts/skip-rate/skip-rate.md
+          if [ -s perf-artifacts/skip-rate/warnings.log ]; then
+            {
+              echo ''
+              echo '<details><summary>Artifact download warnings</summary>'
+              echo ''
+              sed 's/^/- /' perf-artifacts/skip-rate/warnings.log
+              echo ''
+              echo '</details>'
+            } >> perf-artifacts/skip-rate/skip-rate.md
+          fi
+          cat perf-artifacts/skip-rate/skip-rate.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload portfolio SKIP-rate summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-portfolio-skip-rate
+          path: perf-artifacts/skip-rate
+          if-no-files-found: warn
+          retention-days: 35
 
   # ==========================================================================
   # Stress nightly (Issue #594): runs the W=4 / R=500 freeze-cycle and

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -28,7 +28,22 @@ on:
   schedule:
     # Daily at 04:00 UTC (overnight US Pacific / EU early morning).
     - cron: '0 4 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      portfolio_tier:
+        description: 'bench_flowlog portfolio tier'
+        type: choice
+        options:
+          - smoke
+          - light
+          - readme-full
+        default: light
+      portfolio_workers:
+        description: 'Comma-separated portfolio worker counts'
+        default: '1'
+      portfolio_repeat:
+        description: 'Portfolio repeat count'
+        default: '1'
 
 permissions:
   contents: read
@@ -128,6 +143,57 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson test -C build-perf --suite perf --print-errorlogs --num-processes 1
+
+      - name: Collect flowlog portfolio (Linux)
+        if: ${{ always() && runner.os == 'Linux' }}
+        shell: bash
+        env:
+          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'light' }}
+          PORTFOLIO_WORKERS: ${{ github.event.inputs.portfolio_workers || '1' }}
+          PORTFOLIO_REPEAT: ${{ github.event.inputs.portfolio_repeat || '1' }}
+        run: |
+          set +e
+          python scripts/perf/run-flowlog-portfolio.py \
+            --bench build-perf/bench/bench_flowlog \
+            --tier "$PORTFOLIO_TIER" \
+            --workers "$PORTFOLIO_WORKERS" \
+            --repeat "$PORTFOLIO_REPEAT" \
+            --out-dir perf-artifacts/portfolio
+          rc=$?
+          echo "portfolio_exit=$rc" >> "$GITHUB_OUTPUT"
+          echo "PORTFOLIO_EXIT=$rc" >> "$GITHUB_ENV"
+          echo "portfolio_exit=$rc" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Collect flowlog portfolio (Windows)
+        if: ${{ always() && runner.os == 'Windows' }}
+        shell: bash
+        env:
+          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'light' }}
+          PORTFOLIO_WORKERS: ${{ github.event.inputs.portfolio_workers || '1' }}
+          PORTFOLIO_REPEAT: ${{ github.event.inputs.portfolio_repeat || '1' }}
+        run: |
+          set +e
+          python scripts/perf/run-flowlog-portfolio.py \
+            --bench build-perf/bench/bench_flowlog.exe \
+            --tier "$PORTFOLIO_TIER" \
+            --workers "$PORTFOLIO_WORKERS" \
+            --repeat "$PORTFOLIO_REPEAT" \
+            --out-dir perf-artifacts/portfolio
+          rc=$?
+          echo "portfolio_exit=$rc" >> "$GITHUB_OUTPUT"
+          echo "PORTFOLIO_EXIT=$rc" >> "$GITHUB_ENV"
+          echo "portfolio_exit=$rc" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Upload flowlog portfolio artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-portfolio-${{ matrix.os }}-${{ matrix.compiler }}
+          path: perf-artifacts/portfolio
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Publish results
         if: always()

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -37,7 +37,7 @@ on:
           - smoke
           - light
           - readme-full
-        default: light
+        default: readme-full
       portfolio_workers:
         description: 'Comma-separated portfolio worker counts'
         default: '1'
@@ -149,7 +149,7 @@ jobs:
         if: ${{ always() && runner.os == 'Linux' }}
         shell: bash
         env:
-          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'light' }}
+          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'readme-full' }}
           PORTFOLIO_WORKERS: ${{ github.event.inputs.portfolio_workers || '1' }}
           PORTFOLIO_REPEAT: ${{ github.event.inputs.portfolio_repeat || '1' }}
         run: |
@@ -170,7 +170,7 @@ jobs:
         if: ${{ always() && runner.os == 'Windows' }}
         shell: bash
         env:
-          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'light' }}
+          PORTFOLIO_TIER: ${{ github.event.inputs.portfolio_tier || 'readme-full' }}
           PORTFOLIO_WORKERS: ${{ github.event.inputs.portfolio_workers || '1' }}
           PORTFOLIO_REPEAT: ${{ github.event.inputs.portfolio_repeat || '1' }}
         run: |

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -195,6 +195,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Summarize flowlog portfolio
+        if: always()
+        shell: bash
+        run: |
+          python scripts/perf/summarize-flowlog-portfolio.py \
+            --artifact-dir perf-artifacts/portfolio \
+            --artifact-name "perf-portfolio-${{ matrix.os }}-${{ matrix.compiler }}" \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Publish results
         if: always()
         shell: bash

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -254,11 +254,12 @@ branch-protection gates.  The portfolio artifacts and current-run
 summary are required observability outputs for the nightly job so
 maintainers can inspect workload coverage and current results.
 
-Last-N SKIP-rate monitoring is the remaining #828 follow-up; it is
-intended to detect silently degraded coverage without claiming that the
-current run is a stable regression gate.  Promoting perf checks to
-blocking status requires a dedicated stable perf runner and a separate
-policy change.
+The workflow also produces best-effort 30-day/current-available
+SKIP-rate monitoring as a workflow summary and a
+`perf-portfolio-skip-rate` artifact.  This detects silently degraded
+coverage without adding thresholds, gates, or paging.  Promoting perf
+checks to blocking status requires a dedicated stable perf runner and a
+separate policy change.
 
 ### mbedTLS-enabled validation policy
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -241,6 +241,25 @@ Per #746 B17, `release-1.x` requires:
 - Signed commits (GPG verified).
 - Tag protection on `v1.x.*`.
 
+### Perf nightly monitoring posture
+
+For v1.0, `.github/workflows/perf-nightly.yml` remains
+`continue-on-error: true`.  GitHub-hosted perf runners are noisy enough
+that nightly performance checks should not directly block merges,
+release PRs, or release tags.
+
+The nightly `meson test --suite perf` run and the `bench_flowlog`
+portfolio artifacts/current-run summaries are monitoring evidence, not
+branch-protection gates.  The portfolio artifacts and current-run
+summary are required observability outputs for the nightly job so
+maintainers can inspect workload coverage and current results.
+
+Last-N SKIP-rate monitoring is the remaining #828 follow-up; it is
+intended to detect silently degraded coverage without claiming that the
+current run is a stable regression gate.  Promoting perf checks to
+blocking status requires a dedicated stable perf runner and a separate
+policy change.
+
 ### mbedTLS-enabled validation policy
 
 The stable check name for optional crypto validation is

--- a/scripts/perf/run-flowlog-portfolio.py
+++ b/scripts/perf/run-flowlog-portfolio.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""Run bench_flowlog portfolio workloads and write structured artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_WORKERS = "1,8,16"
+
+
+WORKLOADS: dict[str, dict[str, Any]] = {
+    "tc": {
+        "args": ["--data", "graph_100.csv"],
+        "data": ["graph_100.csv"],
+    },
+    "reach": {
+        "args": ["--data", "graph_100.csv"],
+        "data": ["graph_100.csv"],
+    },
+    "cc": {
+        "args": ["--data", "graph_100.csv"],
+        "data": ["graph_100.csv"],
+    },
+    "sssp": {
+        "args": [
+            "--data",
+            "graph_100.csv",
+            "--data-weighted",
+            "graph_100_weighted.csv",
+        ],
+        "data": ["graph_100.csv", "graph_100_weighted.csv"],
+    },
+    "sg": {
+        "args": ["--data", "graph_100.csv"],
+        "data": ["graph_100.csv"],
+    },
+    "bipartite": {
+        "args": ["--data", "graph_100.csv"],
+        "data": ["graph_100.csv"],
+    },
+    "andersen": {
+        "args": ["--data-andersen", "andersen"],
+        "data": ["andersen"],
+    },
+    "dyck": {
+        "args": ["--data-dyck", "dyck"],
+        "data": ["dyck"],
+    },
+    "cspa-fast": {
+        "args": ["--data-cspa", "cspa"],
+        "data": ["cspa"],
+    },
+    "cspa": {
+        "args": ["--data-cspa", "cspa"],
+        "data": ["cspa"],
+    },
+    "csda": {
+        "args": ["--data-csda", "csda"],
+        "data": ["csda"],
+    },
+    "galen": {
+        "args": ["--data-galen", "galen"],
+        "data": ["galen"],
+    },
+    "polonius": {
+        "args": ["--data-polonius", "polonius"],
+        "data": ["polonius"],
+    },
+    "ddisasm": {
+        "args": ["--data-ddisasm", "ddisasm"],
+        "data": ["ddisasm"],
+    },
+    "crdt": {
+        "args": ["--data-crdt", "crdt"],
+        "data": ["crdt"],
+    },
+    "doop": {
+        "args": ["--data-doop", "doop"],
+        "data": ["doop"],
+    },
+}
+
+README_FULL_WORKLOADS = [
+    "tc",
+    "reach",
+    "cc",
+    "sssp",
+    "sg",
+    "bipartite",
+    "andersen",
+    "dyck",
+    "cspa-fast",
+    "cspa",
+    "csda",
+    "galen",
+    "polonius",
+    "ddisasm",
+    "crdt",
+    "doop",
+]
+
+TIERS = {
+    "smoke": {
+        "description": "cheap local validation tier",
+        "workloads": ["reach", "sssp"],
+        "excluded_reason": "smoke tier keeps local validation fast",
+    },
+    "light": {
+        "description": "graph-only tier without heavy portfolio workloads",
+        "workloads": ["tc", "reach", "cc", "sssp", "sg", "bipartite"],
+        "excluded_reason": "light tier excludes analysis, CRDT, and DOOP workloads",
+    },
+    "readme-full": {
+        "description": "README-scale portfolio: 15 table rows plus cspa incremental command",
+        "workloads": README_FULL_WORKLOADS,
+        "excluded_reason": None,
+    },
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def parse_workers(value: str) -> list[int]:
+    workers: list[int] = []
+    for part in value.split(","):
+        text = part.strip()
+        if not text:
+            continue
+        try:
+            parsed = int(text, 10)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"invalid worker count: {text}") from exc
+        if parsed <= 0:
+            raise argparse.ArgumentTypeError("worker counts must be positive")
+        if parsed not in workers:
+            workers.append(parsed)
+    if not workers:
+        raise argparse.ArgumentTypeError("at least one worker count is required")
+    return workers
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value, 10)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid integer: {value}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def resolve_under(root: Path, value: str) -> str:
+    return str(root / value)
+
+
+def run_git(repo_root: Path, args: list[str]) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def git_metadata(repo_root: Path) -> dict[str, Any]:
+    sha = run_git(repo_root, ["rev-parse", "HEAD"])
+    dirty_status = run_git(repo_root, ["status", "--porcelain"])
+    return {
+        "sha": sha,
+        "dirty": None if dirty_status is None else bool(dirty_status),
+    }
+
+
+def tier_definition(tier: str, workloads: list[str]) -> dict[str, Any]:
+    excluded = [name for name in README_FULL_WORKLOADS if name not in workloads]
+    tier_info = TIERS.get(tier, {})
+    return {
+        "tier": tier,
+        "description": tier_info.get("description", "custom workload list"),
+        "workloads": workloads,
+        "workload_count": len(workloads),
+        "readme_command_count": len(README_FULL_WORKLOADS),
+        "excluded_workloads": excluded,
+        "excluded_reason": tier_info.get("excluded_reason") if excluded else None,
+    }
+
+
+def build_command(
+    bench: Path,
+    data_root: Path,
+    workload: str,
+    workers: int,
+    repeat: int,
+) -> list[str] | None:
+    spec = WORKLOADS.get(workload)
+    if spec is None:
+        return None
+
+    data_args: list[str] = []
+    raw_args = spec["args"]
+    for index, arg in enumerate(raw_args):
+        if index % 2 == 0:
+            data_args.append(arg)
+        else:
+            data_args.append(resolve_under(data_root, arg))
+
+    return [
+        str(bench),
+        "--workload",
+        workload,
+        *data_args,
+        "--workers",
+        str(workers),
+        "--repeat",
+        str(repeat),
+        "--format",
+        "json",
+    ]
+
+
+def missing_data_paths(data_root: Path, workload: str) -> list[str]:
+    spec = WORKLOADS.get(workload)
+    if spec is None:
+        return []
+    missing: list[str] = []
+    for rel in spec["data"]:
+        path = data_root / rel
+        if not path.exists():
+            missing.append(str(path))
+    return missing
+
+
+def parse_bench_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
+    text = stdout.strip()
+    if not text:
+        return None, "empty stdout"
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON stdout: {exc}"
+    if not isinstance(parsed, dict):
+        return None, "bench JSON root is not an object"
+    return parsed, None
+
+
+def summarize_bench(parsed: dict[str, Any] | None) -> dict[str, Any]:
+    if parsed is None:
+        return {}
+    wall = parsed.get("wall_time_ms")
+    median_ms = wall.get("median") if isinstance(wall, dict) else None
+    return {
+        "bench_workload": parsed.get("workload"),
+        "tuples": parsed.get("tuples"),
+        "iterations": parsed.get("iterations"),
+        "peak_rss_kb": parsed.get("peak_rss_kb"),
+        "median_ms": median_ms,
+    }
+
+
+def make_skip_record(
+    workload: str,
+    workers: int,
+    repeat: int,
+    command: list[str] | None,
+    reason: str,
+    detail: Any = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "skip",
+        "reason": reason,
+        "detail": detail,
+        "workload": workload,
+        "workers": workers,
+        "repeat": repeat,
+        "command": command,
+        "started_at": utc_now(),
+        "ended_at": utc_now(),
+        "duration_sec": 0.0,
+        "return_code": None,
+        "bench": None,
+        "summary": {},
+    }
+
+
+def run_one(
+    bench: Path,
+    data_root: Path,
+    workload: str,
+    workers: int,
+    repeat: int,
+) -> dict[str, Any]:
+    command = build_command(bench, data_root, workload, workers, repeat)
+    if command is None:
+        return make_skip_record(workload, workers, repeat, None, "unknown_workload")
+
+    if not bench.exists():
+        return make_skip_record(
+            workload,
+            workers,
+            repeat,
+            command,
+            "missing_bench_binary",
+            str(bench),
+        )
+    if not bench.is_file() or not bench.stat().st_mode & 0o111:
+        return make_skip_record(
+            workload,
+            workers,
+            repeat,
+            command,
+            "bench_binary_not_executable",
+            str(bench),
+        )
+
+    missing = missing_data_paths(data_root, workload)
+    if missing:
+        return make_skip_record(
+            workload,
+            workers,
+            repeat,
+            command,
+            "missing_data",
+            missing,
+        )
+
+    started = utc_now()
+    t0 = time.monotonic()
+    try:
+        proc = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        duration = time.monotonic() - t0
+        ended = utc_now()
+    except OSError as exc:
+        duration = time.monotonic() - t0
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "fail",
+            "reason": "exec_error",
+            "detail": str(exc),
+            "workload": workload,
+            "workers": workers,
+            "repeat": repeat,
+            "command": command,
+            "started_at": started,
+            "ended_at": utc_now(),
+            "duration_sec": round(duration, 6),
+            "return_code": None,
+            "bench": None,
+            "summary": {},
+        }
+
+    parsed, parse_error = parse_bench_json(proc.stdout)
+    status = "ok" if proc.returncode == 0 and parse_error is None else "fail"
+    reason = None
+    if proc.returncode != 0:
+        reason = "bench_failed"
+    elif parse_error is not None:
+        reason = "json_parse_failed"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "reason": reason,
+        "detail": parse_error,
+        "workload": workload,
+        "workers": workers,
+        "repeat": repeat,
+        "command": command,
+        "started_at": started,
+        "ended_at": ended,
+        "duration_sec": round(duration, 6),
+        "return_code": proc.returncode,
+        "bench": parsed,
+        "summary": summarize_bench(parsed),
+        "stderr_tail": proc.stderr[-4000:] if proc.stderr else "",
+        "stdout_tail": proc.stdout[-4000:] if status != "ok" else "",
+    }
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            f.write("\n")
+
+
+def tsv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value).replace("\t", " ").replace("\n", " ")
+
+
+def write_tsv(path: Path, records: list[dict[str, Any]]) -> None:
+    columns = [
+        "status",
+        "reason",
+        "workload",
+        "workers",
+        "repeat",
+        "return_code",
+        "duration_sec",
+        "median_ms",
+        "tuples",
+        "iterations",
+        "peak_rss_kb",
+        "command",
+    ]
+    with path.open("w", encoding="utf-8") as f:
+        f.write("\t".join(columns))
+        f.write("\n")
+        for record in records:
+            summary = record.get("summary") or {}
+            row = {
+                "status": record.get("status"),
+                "reason": record.get("reason"),
+                "workload": record.get("workload"),
+                "workers": record.get("workers"),
+                "repeat": record.get("repeat"),
+                "return_code": record.get("return_code"),
+                "duration_sec": record.get("duration_sec"),
+                "median_ms": summary.get("median_ms"),
+                "tuples": summary.get("tuples"),
+                "iterations": summary.get("iterations"),
+                "peak_rss_kb": summary.get("peak_rss_kb"),
+                "command": " ".join(record.get("command") or []),
+            }
+            f.write("\t".join(tsv_value(row[col]) for col in columns))
+            f.write("\n")
+
+
+def build_manifest(
+    args: argparse.Namespace,
+    repo_root: Path,
+    data_root: Path,
+    out_dir: Path,
+    workloads: list[str],
+    started_at: str,
+    ended_at: str,
+    duration_sec: float,
+    records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    status_counts = Counter(record["status"] for record in records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "wirelog-flowlog-portfolio",
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_sec": round(duration_sec, 6),
+        "repo": git_metadata(repo_root),
+        "repo_root": str(repo_root),
+        "data_root": str(data_root),
+        "output_dir": str(out_dir),
+        "bench_path": str(args.bench),
+        "bench_exists": args.bench.exists(),
+        "bench_executable": args.bench.is_file() and bool(args.bench.stat().st_mode & 0o111)
+        if args.bench.exists()
+        else False,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "python": {
+            "version": platform.python_version(),
+            "executable": sys.executable,
+        },
+        "args": {
+            "tier": args.tier,
+            "workers": args.workers,
+            "repeat": args.repeat,
+            "workloads": args.workload,
+        },
+        "tier_definition": tier_definition(args.tier, workloads),
+        "record_count": len(records),
+        "status_counts": dict(sorted(status_counts.items())),
+        "artifacts": {
+            "manifest": "manifest.json",
+            "portfolio_jsonl": "portfolio.jsonl",
+            "portfolio_tsv": "portfolio.tsv",
+            "failures_jsonl": "failures.jsonl",
+        },
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run bench_flowlog portfolio workloads and write manifest.json, "
+            "portfolio.jsonl, portfolio.tsv, and failures.jsonl artifacts."
+        )
+    )
+    parser.add_argument(
+        "--bench",
+        type=Path,
+        default=Path("build/bench/bench_flowlog"),
+        help="bench_flowlog binary path (default: build/bench/bench_flowlog)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root used for git metadata and default data root",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=None,
+        help="bench data root (default: REPO_ROOT/bench/data)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("perf-artifacts/portfolio"),
+        help="artifact output directory (default: perf-artifacts/portfolio)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=parse_workers,
+        default=parse_workers(DEFAULT_WORKERS),
+        help=f"comma-separated worker counts (default: {DEFAULT_WORKERS})",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=positive_int,
+        default=5,
+        help="bench_flowlog repeat count for each command (default: 5)",
+    )
+    parser.add_argument(
+        "--tier",
+        choices=["smoke", "light", "readme-full", "full"],
+        default="smoke",
+        help=(
+            "workload tier: smoke, light, or readme-full/full. "
+            "Heavy README-scale runs are explicit. (default: smoke)"
+        ),
+    )
+    parser.add_argument(
+        "--workload",
+        action="append",
+        default=None,
+        help="override tier with one workload name; may be repeated",
+    )
+    args = parser.parse_args(argv)
+
+    args.repo_root = args.repo_root.resolve()
+    args.data_root = (
+        args.data_root.resolve() if args.data_root else args.repo_root / "bench" / "data"
+    )
+    args.out_dir = args.out_dir.resolve()
+    args.bench = args.bench.resolve()
+    if args.tier == "full":
+        args.tier = "readme-full"
+    return args
+
+
+def selected_workloads(args: argparse.Namespace) -> list[str]:
+    if args.workload:
+        workloads: list[str] = []
+        for name in args.workload:
+            if name not in workloads:
+                workloads.append(name)
+        return workloads
+    return list(TIERS[args.tier]["workloads"])
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    workloads = selected_workloads(args)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    started_at = utc_now()
+    t0 = time.monotonic()
+    records: list[dict[str, Any]] = []
+    for workload in workloads:
+        for workers in args.workers:
+            record = run_one(args.bench, args.data_root, workload, workers, args.repeat)
+            records.append(record)
+            print(
+                f"{record['status']}: workload={workload} workers={workers} "
+                f"reason={record.get('reason') or '-'}",
+                file=sys.stderr,
+            )
+
+    ended_at = utc_now()
+    duration_sec = time.monotonic() - t0
+    failures = [record for record in records if record["status"] != "ok"]
+    manifest = build_manifest(
+        args,
+        args.repo_root,
+        args.data_root,
+        args.out_dir,
+        workloads,
+        started_at,
+        ended_at,
+        duration_sec,
+        records,
+    )
+
+    (args.out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_jsonl(args.out_dir / "portfolio.jsonl", records)
+    write_tsv(args.out_dir / "portfolio.tsv", records)
+    write_jsonl(args.out_dir / "failures.jsonl", failures)
+
+    if any(record["status"] == "fail" for record in records):
+        return 1
+    if any(record["status"] == "skip" for record in records):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/perf/run-flowlog-portfolio.py
+++ b/scripts/perf/run-flowlog-portfolio.py
@@ -63,6 +63,7 @@ WORKLOADS: dict[str, dict[str, Any]] = {
     "cspa": {
         "args": ["--data-cspa", "cspa"],
         "data": ["cspa"],
+        "parser": "cspa_incremental_tsv",
     },
     "csda": {
         "args": ["--data-csda", "csda"],
@@ -225,7 +226,7 @@ def build_command(
         else:
             data_args.append(resolve_under(data_root, arg))
 
-    return [
+    command = [
         str(bench),
         "--workload",
         workload,
@@ -234,9 +235,10 @@ def build_command(
         str(workers),
         "--repeat",
         str(repeat),
-        "--format",
-        "json",
     ]
+    if spec.get("parser", "json") == "json":
+        command.extend(["--format", "json"])
+    return command
 
 
 def missing_data_paths(data_root: Path, workload: str) -> list[str]:
@@ -264,9 +266,76 @@ def parse_bench_json(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
     return parsed, None
 
 
+def parse_int(value: str) -> int:
+    return int(value, 10)
+
+
+def parse_float(value: str) -> float:
+    return float(value)
+
+
+def parse_cspa_incremental_tsv(stdout: str) -> tuple[dict[str, Any] | None, str | None]:
+    columns = [
+        ("workload", str),
+        ("facts", parse_int),
+        ("baseline_ms", parse_float),
+        ("initial_ms", parse_float),
+        ("insert_ms", parse_float),
+        ("reeval_ms", parse_float),
+        ("speedup", parse_float),
+        ("tuples_before", parse_int),
+        ("tuples_after", parse_int),
+        ("iters_before", parse_int),
+        ("iters_after", parse_int),
+        ("peak_rss_kb", parse_int),
+        ("bench_status", str),
+    ]
+
+    for line in reversed(stdout.splitlines()):
+        if not line.startswith("cspa_incr\t"):
+            continue
+        fields = line.split("\t")
+        if len(fields) != len(columns):
+            return None, f"cspa_incr row has {len(fields)} fields, expected {len(columns)}"
+
+        parsed: dict[str, Any] = {}
+        try:
+            for (name, converter), value in zip(columns, fields, strict=True):
+                parsed[name] = converter(value)
+        except ValueError as exc:
+            return None, f"invalid cspa_incr field: {exc}"
+        return parsed, None
+
+    return None, "missing cspa_incr TSV row"
+
+
+def parse_bench_output(
+    parser: str,
+    stdout: str,
+) -> tuple[dict[str, Any] | None, str | None, str]:
+    if parser == "json":
+        parsed, error = parse_bench_json(stdout)
+        return parsed, error, "json_parse_failed"
+    if parser == "cspa_incremental_tsv":
+        parsed, error = parse_cspa_incremental_tsv(stdout)
+        return parsed, error, "tsv_parse_failed"
+    return None, f"unknown parser: {parser}", "parse_failed"
+
+
 def summarize_bench(parsed: dict[str, Any] | None) -> dict[str, Any]:
     if parsed is None:
         return {}
+    if parsed.get("workload") == "cspa_incr":
+        reeval_ms = parsed.get("reeval_ms")
+        return {
+            "bench_workload": parsed.get("workload"),
+            "tuples": parsed.get("tuples_after"),
+            "iterations": parsed.get("iters_after"),
+            "peak_rss_kb": parsed.get("peak_rss_kb"),
+            "median_ms": reeval_ms,
+            "reeval_ms": reeval_ms,
+            "speedup": parsed.get("speedup"),
+        }
     wall = parsed.get("wall_time_ms")
     median_ms = wall.get("median") if isinstance(wall, dict) else None
     return {
@@ -311,6 +380,7 @@ def run_one(
     workers: int,
     repeat: int,
 ) -> dict[str, Any]:
+    spec = WORKLOADS.get(workload)
     command = build_command(bench, data_root, workload, workers, repeat)
     if command is None:
         return make_skip_record(workload, workers, repeat, None, "unknown_workload")
@@ -378,13 +448,18 @@ def run_one(
             "summary": {},
         }
 
-    parsed, parse_error = parse_bench_json(proc.stdout)
-    status = "ok" if proc.returncode == 0 and parse_error is None else "fail"
+    parser = spec.get("parser", "json") if spec else "json"
+    parsed, parse_error, parse_reason = parse_bench_output(parser, proc.stdout)
+    bench_status = parsed.get("bench_status") if isinstance(parsed, dict) else None
+    parser_ok = parse_error is None and (bench_status in (None, "OK"))
+    status = "ok" if proc.returncode == 0 and parser_ok else "fail"
     reason = None
     if proc.returncode != 0:
         reason = "bench_failed"
     elif parse_error is not None:
-        reason = "json_parse_failed"
+        reason = parse_reason
+    elif bench_status not in (None, "OK"):
+        reason = "bench_status_not_ok"
 
     return {
         "schema_version": SCHEMA_VERSION,

--- a/scripts/perf/summarize-flowlog-portfolio-history.py
+++ b/scripts/perf/summarize-flowlog-portfolio-history.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Summarize recent flowlog portfolio artifact history."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATUS_KEYS = ("ok", "skip", "fail", "unknown")
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None, f"missing {path}"
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON in {path}: {exc}"
+    except OSError as exc:
+        return None, f"cannot read {path}: {exc}"
+    if not isinstance(data, dict):
+        return None, f"{path} JSON root is not an object"
+    return data, None
+
+
+def read_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    records: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return [], [f"missing {path}"]
+    except OSError as exc:
+        return [], [f"cannot read {path}: {exc}"]
+
+    for line_no, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            warnings.append(f"{path}:{line_no}: malformed JSONL record: {exc}")
+            continue
+        if not isinstance(item, dict):
+            warnings.append(f"{path}:{line_no}: JSONL record is not an object")
+            continue
+        records.append(item)
+    return records, warnings
+
+
+def read_tsv(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+    except FileNotFoundError:
+        return [], [f"missing {path}"]
+    except OSError as exc:
+        return [], [f"cannot read {path}: {exc}"]
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        records.append(
+            {
+                "status": row.get("status") or "unknown",
+                "reason": row.get("reason") or None,
+                "workload": row.get("workload") or "unknown",
+                "workers": row.get("workers") or "unknown",
+            }
+        )
+    if not records:
+        return [], [f"{path} has no portfolio records"]
+    return records, []
+
+
+def find_artifact_dirs(root: Path) -> list[Path]:
+    dirs: list[Path] = []
+    seen: set[Path] = set()
+    for manifest in root.rglob("manifest.json"):
+        directory = manifest.parent
+        if directory in seen:
+            continue
+        if (directory / "portfolio.jsonl").exists() or (directory / "portfolio.tsv").exists():
+            dirs.append(directory)
+            seen.add(directory)
+    return sorted(dirs)
+
+
+def infer_artifact_name(path: Path) -> str:
+    for part in reversed(path.parts):
+        if part.startswith("perf-portfolio-"):
+            return part
+    return path.name
+
+
+def infer_os_compiler(artifact_name: str) -> tuple[str, str]:
+    prefix = "perf-portfolio-"
+    if not artifact_name.startswith(prefix):
+        return "unknown", "unknown"
+    rest = artifact_name[len(prefix) :]
+    if "-" not in rest:
+        return rest or "unknown", "unknown"
+    os_name, compiler = rest.rsplit("-", 1)
+    return os_name or "unknown", compiler or "unknown"
+
+
+def normalize_status(value: Any) -> str:
+    status = str(value or "unknown").lower()
+    return status if status in STATUS_KEYS else "unknown"
+
+
+def count_record(records: list[dict[str, Any]]) -> dict[str, int]:
+    counts = Counter(normalize_status(record.get("status")) for record in records)
+    return {key: counts.get(key, 0) for key in STATUS_KEYS}
+
+
+def empty_counts() -> dict[str, int]:
+    return {key: 0 for key in STATUS_KEYS}
+
+
+def add_counts(target: dict[str, int], source: dict[str, int]) -> None:
+    for key in STATUS_KEYS:
+        target[key] += source.get(key, 0)
+
+
+def skip_rate(counts: dict[str, int]) -> float:
+    total = sum(counts.get(key, 0) for key in STATUS_KEYS)
+    return (counts.get("skip", 0) / total) if total else 0.0
+
+
+def load_artifact(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    warnings: list[str] = []
+    manifest, error = read_json(path / "manifest.json")
+    if error:
+        warnings.append(error)
+        manifest = {}
+
+    records, record_warnings = read_jsonl(path / "portfolio.jsonl")
+    warnings.extend(record_warnings)
+    if not records:
+        tsv_records, tsv_warnings = read_tsv(path / "portfolio.tsv")
+        records = tsv_records
+        warnings.extend(tsv_warnings)
+        if records:
+            warnings.append(f"{path}: used portfolio.tsv fallback")
+
+    artifact_name = infer_artifact_name(path)
+    os_name, compiler = infer_os_compiler(artifact_name)
+    started = parse_time(manifest.get("started_at")) if isinstance(manifest, dict) else None
+    ended = parse_time(manifest.get("ended_at")) if isinstance(manifest, dict) else None
+    timestamp = ended or started
+    counts = count_record(records)
+
+    return (
+        {
+            "path": str(path),
+            "artifact_name": artifact_name,
+            "os": os_name,
+            "compiler": compiler,
+            "started_at": manifest.get("started_at") if isinstance(manifest, dict) else None,
+            "ended_at": manifest.get("ended_at") if isinstance(manifest, dict) else None,
+            "timestamp": timestamp.isoformat(timespec="seconds") if timestamp else None,
+            "records": records,
+            "record_count": len(records),
+            "counts": counts,
+            "skip_rate": skip_rate(counts),
+        },
+        warnings,
+    )
+
+
+def group_artifacts(artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    totals = empty_counts()
+    by_platform: dict[tuple[str, str], dict[str, int]] = defaultdict(empty_counts)
+    by_workload: dict[tuple[str, str], dict[str, int]] = defaultdict(empty_counts)
+    by_platform_workload: dict[tuple[str, str, str, str], dict[str, int]] = defaultdict(empty_counts)
+    reasons: Counter[tuple[str, str]] = Counter()
+
+    for artifact in artifacts:
+        counts = artifact["counts"]
+        add_counts(totals, counts)
+        platform_key = (artifact["os"], artifact["compiler"])
+        add_counts(by_platform[platform_key], counts)
+        for record in artifact["records"]:
+            record_counts = empty_counts()
+            status = normalize_status(record.get("status"))
+            record_counts[status] = 1
+            workload_key = (str(record.get("workload") or "unknown"), str(record.get("workers") or "unknown"))
+            add_counts(by_workload[workload_key], record_counts)
+            platform_workload_key = (
+                artifact["os"],
+                artifact["compiler"],
+                workload_key[0],
+                workload_key[1],
+            )
+            add_counts(by_platform_workload[platform_workload_key], record_counts)
+            if status != "ok":
+                reasons[(status, str(record.get("reason") or "unspecified"))] += 1
+
+    def rows_from_counts(grouped: dict[tuple[Any, ...], dict[str, int]], key_names: tuple[str, ...]) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for key, counts in sorted(grouped.items()):
+            total = sum(counts.values())
+            rows.append(
+                {
+                    **{name: key[index] for index, name in enumerate(key_names)},
+                    "record_count": total,
+                    **counts,
+                    "skip_rate": skip_rate(counts),
+                }
+            )
+        return rows
+
+    return {
+        "totals": {
+            "record_count": sum(totals.values()),
+            **totals,
+            "skip_rate": skip_rate(totals),
+        },
+        "by_platform": rows_from_counts(by_platform, ("os", "compiler")),
+        "by_workload_workers": rows_from_counts(by_workload, ("workload", "workers")),
+        "by_platform_workload_workers": rows_from_counts(
+            by_platform_workload,
+            ("os", "compiler", "workload", "workers"),
+        ),
+        "reasons": [
+            {"status": status, "reason": reason, "count": count}
+            for (status, reason), count in sorted(reasons.items())
+        ],
+    }
+
+
+def table_escape(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
+def pct(value: float) -> str:
+    return f"{value * 100.0:.1f}%"
+
+
+def counts_table(rows: list[dict[str, Any]], first_cols: list[str]) -> list[str]:
+    headings = [*first_cols, "Records", "OK", "Skip", "Fail", "Unknown", "Skip rate"]
+    lines = ["| " + " | ".join(headings) + " |"]
+    lines.append("|" + "|".join(["---"] * len(headings)) + "|")
+    for row in rows:
+        values = [
+            *(table_escape(row.get(col)) for col in first_cols),
+            str(row.get("record_count", 0)),
+            str(row.get("ok", 0)),
+            str(row.get("skip", 0)),
+            str(row.get("fail", 0)),
+            str(row.get("unknown", 0)),
+            pct(float(row.get("skip_rate", 0.0))),
+        ]
+        lines.append("| " + " | ".join(values) + " |")
+    return lines
+
+
+def build_summary(result: dict[str, Any]) -> str:
+    metadata = result["metadata"]
+    grouped = result["groups"]
+    totals = grouped["totals"]
+    lines: list[str] = []
+    lines.append("## Flowlog Portfolio SKIP-Rate History")
+    lines.append("")
+    lines.append(
+        f"Requested window: `{metadata['requested_window_days']}` days; "
+        f"observed artifacts: `{metadata['observed_artifact_count']}`; "
+        f"observed records: `{metadata['observed_record_count']}`."
+    )
+    if metadata["observed_artifact_count"] < metadata["requested_window_days"]:
+        lines.append(
+            f"Observed artifact count is below the requested day window "
+            f"({metadata['observed_artifact_count']} < {metadata['requested_window_days']}); "
+            "summary uses currently available artifacts."
+        )
+    lines.append("")
+    lines.append(
+        f"Totals: ok `{totals['ok']}`, skip `{totals['skip']}`, "
+        f"fail `{totals['fail']}`, unknown `{totals['unknown']}`, "
+        f"skip rate `{pct(float(totals['skip_rate']))}`."
+    )
+    lines.append("")
+
+    if grouped["by_platform"]:
+        lines.append("### By OS / Compiler")
+        lines.extend(counts_table(grouped["by_platform"], ["os", "compiler"]))
+        lines.append("")
+
+    if grouped["by_workload_workers"]:
+        lines.append("### By Workload / Workers")
+        lines.extend(counts_table(grouped["by_workload_workers"], ["workload", "workers"]))
+        lines.append("")
+
+    if grouped["by_platform_workload_workers"]:
+        lines.append("### By OS / Compiler / Workload / Workers")
+        lines.extend(
+            counts_table(
+                grouped["by_platform_workload_workers"],
+                ["os", "compiler", "workload", "workers"],
+            )
+        )
+        lines.append("")
+
+    if grouped["reasons"]:
+        lines.append("### Non-OK Reasons")
+        lines.append("| Status | Reason | Count |")
+        lines.append("|---|---|---|")
+        for row in grouped["reasons"]:
+            lines.append(
+                f"| {table_escape(row['status'])} | {table_escape(row['reason'])} | {row['count']} |"
+            )
+        lines.append("")
+
+    warnings = metadata["warnings"]
+    if warnings:
+        lines.append("<details><summary>History artifact warnings</summary>")
+        lines.append("")
+        for warning in warnings:
+            lines.append(f"- {warning}")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def summarize(root: Path, window_days: int, now: datetime) -> dict[str, Any]:
+    cutoff = now - timedelta(days=window_days)
+    warnings: list[str] = []
+    artifacts: list[dict[str, Any]] = []
+
+    if not root.exists():
+        warnings.append(f"history root does not exist: {root}")
+        artifact_dirs: list[Path] = []
+    else:
+        artifact_dirs = find_artifact_dirs(root)
+        if not artifact_dirs:
+            warnings.append(f"no perf portfolio artifacts found under {root}")
+
+    for artifact_dir in artifact_dirs:
+        artifact, artifact_warnings = load_artifact(artifact_dir)
+        warnings.extend(artifact_warnings)
+        if artifact is None:
+            continue
+        timestamp = parse_time(artifact.get("timestamp"))
+        if timestamp is not None and timestamp < cutoff:
+            continue
+        artifacts.append(artifact)
+
+    grouped = group_artifacts(artifacts)
+    result = {
+        "metadata": {
+            "generated_at": now.isoformat(timespec="seconds"),
+            "requested_window_days": window_days,
+            "history_root": str(root),
+            "observed_artifact_count": len(artifacts),
+            "observed_record_count": grouped["totals"]["record_count"],
+            "warnings": warnings,
+        },
+        "artifacts": [
+            {
+                key: value
+                for key, value in artifact.items()
+                if key not in {"records"}
+            }
+            for artifact in artifacts
+        ],
+        "groups": grouped,
+    }
+    result["markdown"] = build_summary(result)
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize last-N/current-available flowlog portfolio SKIP rates."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("perf-artifacts/history"),
+        help="Root containing downloaded/extracted perf-portfolio-* artifact directories.",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=30,
+        help="Requested history window in days; available artifacts are summarized.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Optional path for machine-readable JSON output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    window_days = max(args.window_days, 1)
+    result = summarize(args.root, window_days, utc_now())
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(result["markdown"], end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/perf/summarize-flowlog-portfolio.py
+++ b/scripts/perf/summarize-flowlog-portfolio.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Emit a current-run Markdown summary for flowlog portfolio artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None, f"missing {path}"
+    except json.JSONDecodeError as exc:
+        return None, f"malformed JSON in {path}: {exc}"
+    except OSError as exc:
+        return None, f"cannot read {path}: {exc}"
+    if not isinstance(data, dict):
+        return None, f"{path} JSON root is not an object"
+    return data, None
+
+
+def load_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return [], [f"missing {path}"]
+    except OSError as exc:
+        return [], [f"cannot read {path}: {exc}"]
+
+    for line_no, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"{path}:{line_no}: malformed JSONL record: {exc}")
+            continue
+        if not isinstance(item, dict):
+            errors.append(f"{path}:{line_no}: JSONL record is not an object")
+            continue
+        records.append(item)
+    return records, errors
+
+
+def load_tsv(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as f:
+            rows = list(csv.DictReader(f, delimiter="\t"))
+    except FileNotFoundError:
+        return [], [f"missing {path}"]
+    except OSError as exc:
+        return [], [f"cannot read {path}: {exc}"]
+
+    if not rows:
+        return [], [f"{path} has no data rows"]
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        summary = {
+            "median_ms": row.get("median_ms") or None,
+            "tuples": row.get("tuples") or None,
+            "iterations": row.get("iterations") or None,
+            "peak_rss_kb": row.get("peak_rss_kb") or None,
+        }
+        records.append(
+            {
+                "status": row.get("status") or "",
+                "reason": row.get("reason") or None,
+                "workload": row.get("workload") or "",
+                "workers": row.get("workers") or "",
+                "repeat": row.get("repeat") or "",
+                "return_code": row.get("return_code") or None,
+                "summary": summary,
+            }
+        )
+    return records, []
+
+
+def table_escape(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
+def fmt_number(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, float):
+        return f"{value:.3f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def manifest_value(manifest: dict[str, Any] | None, path: list[str], default: Any = "") -> Any:
+    data: Any = manifest
+    for key in path:
+        if not isinstance(data, dict) or key not in data:
+            return default
+        data = data[key]
+    return data
+
+
+def status_counts(records: list[dict[str, Any]], manifest: dict[str, Any] | None) -> dict[str, int]:
+    counts = Counter(str(record.get("status") or "unknown") for record in records)
+    if not counts and isinstance(manifest, dict):
+        manifest_counts = manifest.get("status_counts")
+        if isinstance(manifest_counts, dict):
+            for key, value in manifest_counts.items():
+                try:
+                    counts[str(key)] = int(value)
+                except (TypeError, ValueError):
+                    counts[str(key)] = 0
+    return {key: counts.get(key, 0) for key in ["ok", "skip", "fail", "unknown"]}
+
+
+def reason_counts(records: list[dict[str, Any]]) -> Counter[tuple[str, str]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for record in records:
+        status = str(record.get("status") or "unknown")
+        if status == "ok":
+            continue
+        reason = str(record.get("reason") or "unspecified")
+        counts[(status, reason)] += 1
+    return counts
+
+
+def records_from_artifacts(artifact_dir: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    jsonl_records, jsonl_errors = load_jsonl(artifact_dir / "portfolio.jsonl")
+    if jsonl_records:
+        return jsonl_records, jsonl_errors
+
+    tsv_records, tsv_errors = load_tsv(artifact_dir / "portfolio.tsv")
+    if tsv_records:
+        return tsv_records, jsonl_errors + ["using portfolio.tsv fallback"] + tsv_errors
+    return [], jsonl_errors + tsv_errors
+
+
+def emit_summary(
+    artifact_dir: Path,
+    artifact_name: str | None,
+    manifest: dict[str, Any] | None,
+    records: list[dict[str, Any]],
+    warnings: list[str],
+) -> str:
+    lines: list[str] = []
+    lines.append("## Flowlog Portfolio")
+    lines.append("")
+    if artifact_name:
+        lines.append(f"Artifact: `{artifact_name}`")
+    lines.append(f"Artifact path: `{artifact_dir}`")
+    lines.append("")
+
+    if manifest is None and not records:
+        lines.append("Portfolio artifacts are unavailable or unreadable for this run.")
+    else:
+        tier = manifest_value(manifest, ["args", "tier"], "unknown")
+        workers = manifest_value(manifest, ["args", "workers"], "unknown")
+        repeat = manifest_value(manifest, ["args", "repeat"], "unknown")
+        record_count = len(records) if records else manifest_value(manifest, ["record_count"], 0)
+        if isinstance(workers, list):
+            workers_text = ",".join(str(item) for item in workers)
+        else:
+            workers_text = str(workers)
+
+        lines.append(
+            f"Tier `{tier}`, workers `{workers_text}`, repeat `{repeat}`, "
+            f"records `{record_count}`."
+        )
+        lines.append("")
+
+        counts = status_counts(records, manifest)
+        lines.append(
+            "Status counts: "
+            f"ok `{counts['ok']}`, skip `{counts['skip']}`, "
+            f"fail `{counts['fail']}`, unknown `{counts['unknown']}`."
+        )
+        lines.append("")
+
+        reasons = reason_counts(records)
+        if reasons:
+            lines.append("| Status | Reason | Count |")
+            lines.append("|--------|--------|-------|")
+            for (status, reason), count in sorted(reasons.items()):
+                lines.append(
+                    f"| {table_escape(status)} | {table_escape(reason)} | {count} |"
+                )
+            lines.append("")
+
+        if records:
+            lines.append("| Workload | Workers | Status | Median ms | Tuples | Iterations | Reason |")
+            lines.append("|----------|---------|--------|-----------|--------|------------|--------|")
+            for record in records:
+                summary = record.get("summary") if isinstance(record.get("summary"), dict) else {}
+                lines.append(
+                    "| "
+                    + " | ".join(
+                        [
+                            table_escape(record.get("workload")),
+                            table_escape(record.get("workers")),
+                            table_escape(record.get("status")),
+                            table_escape(fmt_number(summary.get("median_ms"))),
+                            table_escape(fmt_number(summary.get("tuples"))),
+                            table_escape(fmt_number(summary.get("iterations"))),
+                            table_escape(record.get("reason")),
+                        ]
+                    )
+                    + " |"
+                )
+            lines.append("")
+
+    if warnings:
+        lines.append("<details><summary>Portfolio artifact warnings</summary>")
+        lines.append("")
+        for warning in warnings:
+            lines.append(f"- {warning}")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a Markdown summary for current flowlog portfolio artifacts."
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=Path("perf-artifacts/portfolio"),
+        help="Directory containing manifest.json and portfolio artifacts.",
+    )
+    parser.add_argument(
+        "--artifact-name",
+        default=None,
+        help="Uploaded artifact name to mention in the summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    artifact_dir = args.artifact_dir
+    warnings: list[str] = []
+
+    manifest, manifest_error = load_json(artifact_dir / "manifest.json")
+    if manifest_error:
+        warnings.append(manifest_error)
+
+    records, record_errors = records_from_artifacts(artifact_dir)
+    warnings.extend(record_errors)
+
+    print(emit_summary(artifact_dir, args.artifact_name, manifest, records, warnings), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a bench_flowlog portfolio runner for smoke/light/readme-full tiers, including CSPA TSV parsing
- publish Linux and Windows perf-nightly portfolio artifacts, current-run summaries, and best-effort 30-day/current-available SKIP-rate summaries
- document the v1.0 perf-nightly continue-on-error monitoring posture and make scheduled nightlies run the readme-full portfolio

Closes #828

## Validation
- git diff --check
- python -m py_compile scripts/perf/*.py inside .venv
- run-flowlog portfolio smoke run: 2 OK records
- cspa-only portfolio run: 1 OK record
- synthetic current-run summary and missing-artifact summary checks
- synthetic history summary: ok=2 skip=1 fail=1, skip rate 25.0%, valid JSON
- missing history root returns 0 with warnings and JSON
- Ruby YAML parse of .github/workflows/perf-nightly.yml
- git show --check --stat HEAD

## Notes
- actionlint and markdownlint are not installed locally, so workflow/Markdown validation used Ruby YAML parsing and focused rg checks.
- Full readme portfolio on hosted runners may be slow or resource-heavy; the workflow remains monitoring-only with continue-on-error: true.