### PR TITLE
ci(security): add explicit permissions block to fuzz-evidence.yml

### DIFF
--- a/.github/workflows/fuzz-evidence.yml
+++ b/.github/workflows/fuzz-evidence.yml
@@ -30,6 +30,9 @@ on:
         default: "360"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-evidence:
     name: libFuzzer evidence


### PR DESCRIPTION
Closes #889. Resolves code scanning alert [#622](https://github.com/semantic-reasoning/wirelog/security/code-scanning/622) (`actions/missing-workflow-permissions`, CWE-275, medium).

## Change

Add a root-level `permissions: { contents: read }` block to `.github/workflows/fuzz-evidence.yml`.

## Why

- It was the **only** workflow of nine without an explicit `permissions` block, so its `GITHUB_TOKEN` fell back to repository/organization default permissions instead of least privilege.
- The job only checks out, builds, runs a libFuzzer soak, minimizes the corpus, and uploads an artifact. None of these need write scope; artifact upload uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`. `contents: read` is sufficient.
- Matches the existing convention used by the other eight workflows.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses; `permissions == {contents: read}`
- [ ] `fuzz-evidence` still runs via `workflow_dispatch` (checkout + build + soak + artifact upload)
- [ ] Code scanning alert #622 auto-resolves on next CodeQL `actions` analysis of `main`