### PR TITLE
ci: make ABI symbol sorting locale-stable

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -93,16 +93,18 @@ allowlists on the matching hosts:
 ```bash
 nm -gU builddir/libwirelog.1.dylib \
   | awk '{name = $NF; sub(/^_/, "", name); if (name ~ /^wirelog_/) print name}' \
-  | sort -u > abi/libwirelog-1.0.macos.symbols
+  | LC_ALL=C sort -u > abi/libwirelog-1.0.macos.symbols
 ```
 
 ```powershell
-dumpbin /EXPORTS builddir\wirelog-1.dll |
+$symbols = dumpbin /EXPORTS builddir\wirelog-1.dll |
   Select-String '^\s*\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+([A-Za-z_][A-Za-z0-9_]*)\b' |
   ForEach-Object { $_.Matches[0].Groups[1].Value } |
-  Where-Object { $_ -like 'wirelog_*' } |
-  Sort-Object -Unique |
-  Set-Content abi\libwirelog-1.0.windows.symbols
+  Where-Object { $_ -like 'wirelog_*' }
+$set = [System.Collections.Generic.SortedSet[string]]::new(
+  [System.StringComparer]::Ordinal)
+$symbols | ForEach-Object { [void]$set.Add($_) }
+$set | Set-Content abi\libwirelog-1.0.windows.symbols
 ```
 
 ### Template (Markdown)

--- a/scripts/ci/check-abi-symbols-locale.sh
+++ b/scripts/ci/check-abi-symbols-locale.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# check-abi-symbols-locale.sh - Regression for issue #886.
+#
+# Verifies that the Linux ABI symbol gate stays deterministic under a
+# locale whose collation reorders underscores after alphabetic continuation
+# (for example en_US.utf8).
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+locale_name=""
+for candidate in en_US.utf8 en_US.UTF-8; do
+    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
+        locale_name="$candidate"
+        break
+    fi
+done
+
+if [ -z "$locale_name" ]; then
+    echo "check-abi-symbols-locale: SKIP: en_US UTF-8 locale not installed"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-abi-locale.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+build_root="$tmpdir/build"
+fakebin="$tmpdir/bin"
+mkdir -p "$build_root" "$fakebin"
+: > "$build_root/libwirelog.so"
+
+cat > "$fakebin/nm" <<'EOF'
+#!/usr/bin/env bash
+repo_root="${WIRELOG_REPO_ROOT:?}"
+while IFS= read -r sym; do
+    [ -z "$sym" ] && continue
+    printf '0000000000000000 T %s\n' "$sym"
+done < "$repo_root/abi/libwirelog-1.0.symbols"
+EOF
+chmod +x "$fakebin/nm"
+
+WIRELOG_REPO_ROOT="$repo_root" \
+PATH="$fakebin:$PATH" \
+LC_ALL="$locale_name" \
+    "$repo_root/scripts/ci/check-abi-symbols.sh" "$build_root"
+
+echo "check-abi-symbols-locale: OK under LC_ALL=$locale_name"

--- a/scripts/ci/check-abi-symbols-macos.sh
+++ b/scripts/ci/check-abi-symbols-macos.sh
@@ -51,9 +51,9 @@ fi
 actual="$(
     nm -gU "$lib" 2>/dev/null \
         | awk '{name = $NF; sub(/^_/, "", name); if (name ~ /^wirelog_/) print name}' \
-        | sort -u
+        | LC_ALL=C sort -u
 )"
-expected="$(sort -u "$allowlist")"
+expected="$(LC_ALL=C sort -u "$allowlist")"
 
 if [ "$actual" = "$expected" ]; then
     n="$(printf '%s\n' "$actual" | sed '/^$/d' | wc -l | tr -d ' ')"
@@ -66,5 +66,5 @@ echo "" >&2
 diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
 echo "" >&2
 echo "Regenerate after a deliberate public ABI change:" >&2
-echo "  nm -gU $lib | awk '{name = \$NF; sub(/^_/, \"\", name); if (name ~ /^wirelog_/) print name}' | sort -u > abi/libwirelog-1.0.macos.symbols" >&2
+echo "  nm -gU $lib | awk '{name = \$NF; sub(/^_/, \"\", name); if (name ~ /^wirelog_/) print name}' | LC_ALL=C sort -u > abi/libwirelog-1.0.macos.symbols" >&2
 exit 0

--- a/scripts/ci/check-abi-symbols-windows.ps1
+++ b/scripts/ci/check-abi-symbols-windows.ps1
@@ -5,6 +5,23 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Sort-OrdinalUnique {
+    param([string[]]$Items)
+
+    $Set = [System.Collections.Generic.SortedSet[string]]::new(
+        [System.StringComparer]::Ordinal)
+
+    foreach ($Item in $Items) {
+        if ($null -ne $Item -and $Item -ne "") {
+            [void]$Set.Add($Item)
+        }
+    }
+
+    foreach ($Item in $Set) {
+        Write-Output $Item
+    }
+}
+
 function Write-AdvisoryWarning {
     param([string]$Message)
     Write-Error "check-abi-symbols-windows: WARNING: $Message" -ErrorAction Continue
@@ -58,16 +75,16 @@ if (-not $Dumpbin) {
     exit 0
 }
 
-$Actual = @(& $Dumpbin.Source /EXPORTS $Dll |
+$ActualRaw = @(& $Dumpbin.Source /EXPORTS $Dll |
     ForEach-Object {
         if ($_ -match '^\s*\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+([A-Za-z_][A-Za-z0-9_]*)\b') {
             $Matches[1]
         }
     } |
-    Where-Object { $_ -like 'wirelog_*' } |
-    Sort-Object -Unique)
+    Where-Object { $_ -like 'wirelog_*' })
 
-$Expected = @(Get-Content $Allowlist | Where-Object { $_ -ne "" } | Sort-Object -Unique)
+$Actual = @(Sort-OrdinalUnique $ActualRaw)
+$Expected = @(Sort-OrdinalUnique @(Get-Content $Allowlist | Where-Object { $_ -ne "" }))
 
 $ActualText = ($Actual -join "`n")
 $ExpectedText = ($Expected -join "`n")
@@ -80,5 +97,5 @@ if ($ActualText -eq $ExpectedText) {
 Write-AdvisoryWarning "exported symbols differ from abi/libwirelog-1.0.windows.symbols"
 Compare-Object -ReferenceObject $Expected -DifferenceObject $Actual | Out-String | Write-Error -ErrorAction Continue
 Write-Error "Regenerate after a deliberate public ABI change:" -ErrorAction Continue
-Write-Error "  dumpbin /EXPORTS $Dll | <extract wirelog_* names> | sort > abi/libwirelog-1.0.windows.symbols" -ErrorAction Continue
+Write-Error "  dumpbin /EXPORTS $Dll | <extract wirelog_* names> | Sort-OrdinalUnique > abi/libwirelog-1.0.windows.symbols" -ErrorAction Continue
 exit 0

--- a/scripts/ci/check-abi-symbols-windows.ps1
+++ b/scripts/ci/check-abi-symbols-windows.ps1
@@ -97,5 +97,5 @@ if ($ActualText -eq $ExpectedText) {
 Write-AdvisoryWarning "exported symbols differ from abi/libwirelog-1.0.windows.symbols"
 Compare-Object -ReferenceObject $Expected -DifferenceObject $Actual | Out-String | Write-Error -ErrorAction Continue
 Write-Error "Regenerate after a deliberate public ABI change:" -ErrorAction Continue
-Write-Error "  dumpbin /EXPORTS $Dll | <extract wirelog_* names> | Sort-OrdinalUnique > abi/libwirelog-1.0.windows.symbols" -ErrorAction Continue
+Write-Error "  Use the ordinal-sorted Windows recipe in docs/RELEASE_PROCESS.md." -ErrorAction Continue
 exit 0

--- a/scripts/ci/check-abi-symbols.sh
+++ b/scripts/ci/check-abi-symbols.sh
@@ -47,6 +47,13 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 allowlist="$repo_root/abi/libwirelog-1.0.symbols"
 
+case "$(uname -s)" in
+  MSYS*|MINGW*|CYGWIN*)
+    echo "check-abi-symbols: SKIP: Windows POSIX layer ($(uname -s)) detected" >&2
+    exit 0
+    ;;
+esac
+
 # Skip on platforms where libwirelog.so doesn't exist (Windows,
 # static-only builds).  The macOS dylib has different naming; this
 # gate is Linux/ELF-focused at v1.0 -- matching #690 B3's stated

--- a/scripts/ci/check-abi-symbols.sh
+++ b/scripts/ci/check-abi-symbols.sh
@@ -32,7 +32,7 @@
 #
 #   meson compile -C build
 #   nm -D --defined-only build/libwirelog.so \
-#       | awk '$2=="T"{print $3}' | sort -u \
+#       | awk '$2=="T"{print $3}' | LC_ALL=C sort -u \
 #       > abi/libwirelog-1.0.symbols
 
 set -euo pipefail
@@ -73,7 +73,7 @@ if [ ! -f "$allowlist" ]; then
 fi
 
 actual=$(nm -D --defined-only "$lib" 2>/dev/null \
-    | awk '$2=="T"{print $3}' | sort -u)
+    | awk '$2=="T"{print $3}' | LC_ALL=C sort -u)
 
 expected=$(cat "$allowlist")
 
@@ -91,7 +91,7 @@ echo "To accept the new symbol set (after a deliberate ABI-impacting" >&2
 echo "PR), regenerate the allowlist:" >&2
 echo "" >&2
 echo "  nm -D --defined-only $lib \\" >&2
-echo "      | awk '\$2==\"T\"{print \$3}' | sort -u \\" >&2
+echo "      | awk '\$2==\"T\"{print \$3}' | LC_ALL=C sort -u \\" >&2
 echo "      > abi/libwirelog-1.0.symbols" >&2
 echo "" >&2
 echo "and commit the diff alongside the API change." >&2

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -657,6 +657,10 @@ if sh.found()
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols.sh',
               meson.project_build_root()],
        suite: 'abi')
+
+  test('abi_symbols_locale', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols-locale.sh'],
+       suite: 'abi')
 endif
 
 # Issue #788: warning-only platform ABI surface advisory checks.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -657,7 +657,9 @@ if sh.found()
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols.sh',
               meson.project_build_root()],
        suite: 'abi')
+endif
 
+if host_machine.system() == 'linux' and sh.found()
   test('abi_symbols_locale', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols-locale.sh'],
        suite: 'abi')


### PR DESCRIPTION
## Summary
- Fixes #886
- Pin Linux and macOS ABI symbol sorting to `LC_ALL=C sort -u` so UTF-8 locale collation cannot reorder `_` unexpectedly.
- Use ordinal unique sorting for the Windows ABI advisory check.
- Add a locale regression test that runs the Linux ABI check under `en_US.utf8`/`en_US.UTF-8` when available.
- Update release-process regeneration recipes.

## Validation
- `git diff --check`
- `bash -n scripts/ci/check-abi-symbols.sh scripts/ci/check-abi-symbols-macos.sh scripts/ci/check-abi-symbols-locale.sh`
- `scripts/ci/check-abi-symbols-locale.sh`
- `meson test -C build-886 abi_symbols_locale abi_symbols --print-errorlogs`
- Earlier full ABI suite after compile: `meson compile -C build-886 && meson test -C build-886 --suite abi --print-errorlogs` (31/31 OK)

## Review
- implementation-workflow Reviewer: no blocking findings for both commits.
- Architect and Critic verified the review outcomes and agreed both atomic commits can stand.

## Known gap
- Local PowerShell/dumpbin validation was unavailable; Windows advisory path should be exercised by Windows CI or a Windows maintainer host.