### PR TITLE
ci: refactor build job into primary and matrix for parallel execution

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,11 +2,12 @@ name: CI PR
 
 # PR-specific CI workflow with 3-phase validation.
 #
-# Phase 1 (Lint):        lint-pr.yml — editorconfig -> uncrustify -> clang-tidy
-# Phase 2 (Build):       Linux (GCC + Clang) + macOS (Clang) + Windows (MSVC), fail-fast
-# Phase 3 (Sanitizers):  ASan/UBSan + TSan, runs after lint
+# Phase 1 (Lint):         lint-pr.yml — editorconfig -> uncrustify -> clang-tidy
+# Phase 2a (Build Primary): Linux GCC (ubuntu-latest) with SBOM/binary size/path-a gates
+# Phase 2b (Build Matrix):  Linux Clang + macOS Clang + Windows MSVC + ARM64 GCC (parallel)
+# Phase 3 (Sanitizers):     ASan/UBSan + TSan + TSan-native + mbedTLS (parallel)
 #
-# Execution order on PR: lint -> build + sanitizers
+# Execution order on PR: lint -> build-primary + build-matrix + mbedtls-enabled + sanitizer + tsan + tsan-native
 # CodeQL runs in its own workflow (GitHub default-setup); not invoked from here.
 
 on:
@@ -26,13 +27,85 @@ jobs:
     uses: ./.github/workflows/lint-pr.yml
 
   # ==========================================================================
-  # Phase 2: Build & Test matrix
-  # Depends on all lint jobs passing.
-  # Linux: GCC + Clang; macOS: Clang; Windows: MSVC
-  # fail-fast: true — first failure cancels remaining matrix jobs
-  # Excludes: subprojects/**, build/**
+  # Phase 2a: Build Primary (ubuntu-latest + gcc)
+  # Fast-path job that gates critical checks: SBOM, binary size, Path A example.
+  # This completes first and unblocks downstream validation.
   # ==========================================================================
-  build:
+  build-primary:
+    name: Build / ubuntu-latest / gcc
+    needs: [lint]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      CC: gcc
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools
+
+      - name: Configure
+        run: meson setup builddir -Dtests=true -DmbedTLS=disabled
+
+      - name: Build
+        run: meson compile -C builddir
+
+      - name: Test
+        run: meson test -C builddir --print-errorlogs
+
+      # =======================================================================
+      # Issue #744: SBOM snapshot CI gate
+      # =======================================================================
+      - name: Install syft
+        run: |
+          SYFT_VERSION="1.7.0"
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin syft
+
+      - name: SBOM snapshot gate
+        run: |
+          meson test -C builddir --suite sbom --print-errorlogs || {
+            echo "=== SBOM gate failed. Generating debug info..."
+            echo "=== Baseline snapshot:"
+            head -20 sbom/snapshot.txt
+            echo "..."
+            echo "=== Current scan (first 20):"
+            syft dir:. -o syft-json 2>/dev/null | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' | sort | head -20
+            exit 1
+          }
+
+      # =======================================================================
+      # Binary size regression gate (Issue #460)
+      # =======================================================================
+      - name: Check binary size
+        run: scripts/ci/check-text-size.sh builddir/libwirelog.so
+
+      # =======================================================================
+      # Path A example compile-check (Issue #462)
+      # =======================================================================
+      - name: Path A example compile-check
+        run: |
+          meson install -C builddir --destdir="$PWD/staging"
+          staging_prefix="$PWD/staging/usr/local"
+          multiarch="$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || true)"
+          PKG_CONFIG_SYSROOT_DIR="$PWD/staging" \
+          PKG_CONFIG_PATH="$staging_prefix/lib/${multiarch:+$multiarch/}pkgconfig:$staging_prefix/lib/pkgconfig" \
+            meson setup builddir-path-a examples/path_a_pcap_skeleton
+          meson compile -C builddir-path-a
+          LD_LIBRARY_PATH="$staging_prefix/lib/${multiarch:+$multiarch:}$staging_prefix/lib" \
+            ./builddir-path-a/pcap_skeleton
+
+  # ==========================================================================
+  # Phase 2b: Build Matrix (remaining platforms)
+  # Linux Clang + macOS Clang + Windows MSVC + ARM64 GCC
+  # Runs in parallel with build-primary.
+  # ==========================================================================
+  build-matrix:
     name: Build / ${{ matrix.os }} / ${{ matrix.compiler }}
     needs: [lint]
     runs-on: ${{ matrix.os }}
@@ -40,11 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux - GCC
-          - os: ubuntu-latest
-            compiler: gcc
-            cc: gcc
-
           # Linux - Clang
           - os: ubuntu-latest
             compiler: clang
@@ -133,57 +201,6 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson test -C builddir --print-errorlogs
-
-      # =======================================================================
-      # Issue #744: SBOM snapshot CI gate
-      # Only runs on Linux GCC + ubuntu-latest (to avoid ARM64 binary issues)
-      # =======================================================================
-      - name: Install syft
-        if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.os == 'ubuntu-latest'
-        run: |
-          SYFT_VERSION="1.7.0"
-          curl -sSfL \
-            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin syft
-
-      - name: SBOM snapshot gate
-        if: runner.os == 'Linux' && matrix.compiler == 'gcc' && matrix.os == 'ubuntu-latest'
-        run: |
-          meson test -C builddir --suite sbom --print-errorlogs || {
-            echo "=== SBOM gate failed. Generating debug info..."
-            echo "=== Baseline snapshot:"
-            head -20 sbom/snapshot.txt
-            echo "..."
-            echo "=== Current scan (first 20):"
-            syft dir:. -o syft-json 2>/dev/null | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' | sort | head -20
-            exit 1
-          }
-
-      # =======================================================================
-      # Binary size regression gate (Issue #460)
-      # Only runs on Linux GCC (reference platform for .text baseline)
-      # =======================================================================
-      - name: Check binary size
-        if: runner.os == 'Linux' && matrix.compiler == 'gcc'
-        run: scripts/ci/check-text-size.sh builddir/libwirelog.so
-
-      # =======================================================================
-      # Path A example compile-check (Issue #462)
-      # Install wirelog to a staging dir, then build the example as a
-      # separate project to catch header-install regressions (#449).
-      # =======================================================================
-      - name: Path A example compile-check
-        if: runner.os == 'Linux' && matrix.compiler == 'gcc'
-        run: |
-          meson install -C builddir --destdir="$PWD/staging"
-          staging_prefix="$PWD/staging/usr/local"
-          multiarch="$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || true)"
-          PKG_CONFIG_SYSROOT_DIR="$PWD/staging" \
-          PKG_CONFIG_PATH="$staging_prefix/lib/${multiarch:+$multiarch/}pkgconfig:$staging_prefix/lib/pkgconfig" \
-            meson setup builddir-path-a examples/path_a_pcap_skeleton
-          meson compile -C builddir-path-a
-          LD_LIBRARY_PATH="$staging_prefix/lib/${multiarch:+$multiarch:}$staging_prefix/lib" \
-            ./builddir-path-a/pcap_skeleton
 
   # ==========================================================================
   # Phase 2b: Optional crypto coverage


### PR DESCRIPTION
## Summary

Split the monolithic `build` job into two independent jobs to enable faster feedback on critical gates:

- **build-primary**: ubuntu-latest + gcc (fast path with SBOM, binary size, Path A gates)
- **build-matrix**: remaining platforms (Linux Clang, macOS, Windows, ARM64)

All Phase 3 jobs (mbedtls-enabled, sanitizer, tsan, tsan-native) run in parallel after lint, unblocked by any build job.

## Rationale

- `build-primary` completes first, enabling early feedback on critical gates (SBOM snapshot, binary size regression, header install validation) without waiting for slower matrix combinations
- Reduces overall CI latency by parallelizing the build matrix independently
- Maintains all existing validation checks

## Test Plan

- [x] Workflow syntax valid
- [ ] PR checks pass (SBOM gate, binary size check, Path A example)