### PR TITLE
Release: v0.44.0

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -64,7 +64,7 @@ jobs:
       # =======================================================================
       - name: Install syft
         run: |
-          SYFT_VERSION="1.7.0"
+          SYFT_VERSION="1.44.0"
           curl -sSfL \
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /usr/local/bin syft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **CRC-32 checksum expressions** (#884): added the `crc32_ethernet(x)`
+  and `crc32_castagnoli(x)` columnar expression built-ins. Each accepts a
+  single arithmetic argument and returns the CRC-32 of its 8-byte `int64`
+  representation as a non-negative `int64` (CRC-32/ISO-HDLC and CRC-32C
+  respectively). Unlike the mbedTLS-backed digest/HMAC built-ins, the
+  CRC-32 functions are always available regardless of the `mbedTLS` build
+  option. See `docs/SYNTAX.md` and `examples/05-crc32-checksum/`.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.44.0] - 2026-05-25
+
+### Added
+
 - **CRC-32 checksum expressions** (#884): added the `crc32_ethernet(x)`
   and `crc32_castagnoli(x)` columnar expression built-ins. Each accepts a
   single arithmetic argument and returns the CRC-32 of its 8-byte `int64`

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,24 @@
 # Migration Guide
 
-**Last Updated:** 2026-05-24
+**Last Updated:** 2026-05-25
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.43 -> 0.44
+
+Version `0.44.0` is an additive, ABI-compatible release. No source-level
+migration steps are required for applications already on the 0.43 public
+API surface; the public ABI symbol set and struct layouts are unchanged.
+
+- **New CRC-32 checksum expressions are available** (#884).
+  `crc32_ethernet(x)` and `crc32_castagnoli(x)` are new columnar
+  expression built-ins (see `docs/SYNTAX.md`). They are purely additive
+  for existing programs, but note that `crc32_ethernet` and
+  `crc32_castagnoli` are now reserved keywords in the query syntax and
+  can no longer be used as bare identifiers.
 
 ## 0.41 -> 0.43
 

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -204,6 +204,19 @@ predicates without crypto support, columnar expression evaluation fails
 closed. Filters reject the row, while MAP/head and REDUCE expression
 contexts return an evaluation error.
 
+### Checksum Functions
+
+`crc32_ethernet(x)`, `crc32_castagnoli(x)`
+
+Both compute a CRC-32 over the 8-byte `int64` representation of their
+argument and return the result as a non-negative `int64` in the range
+`[0, 2^32)`. `crc32_ethernet` uses the Ethernet/ISO-HDLC polynomial
+(0x04C11DB7, ISO 3309 / IEEE 802.3); `crc32_castagnoli` uses the
+Castagnoli polynomial (CRC-32C, iSCSI/SCTP). Unlike the crypto hash
+built-ins above, the CRC-32 functions are always available and do not
+depend on the `mbedTLS` build option. See `examples/05-crc32-checksum/`
+for a frame-integrity validation example.
+
 ### UUID Functions
 
 `uuid4()`, `uuid5(namespace, name)`

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.43.99',
+  version: '0.44.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -56,7 +56,7 @@ actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 codecov/codecov-action@v6:NOASSERTION
-docker/login-action@v4.1.0:NOASSERTION
+docker/login-action@v4.2.0:NOASSERTION
 docker/setup-buildx-action@v4.0.0:NOASSERTION
 docker/setup-qemu-action@v4.0.0:NOASSERTION
 docker/setup-qemu-action@v4.0.0:NOASSERTION

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -1,5 +1,3 @@
-./.github/workflows/lint-main.yml@:NOASSERTION
-./.github/workflows/lint-pr.yml@:NOASSERTION
 actions/cache@v4:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
@@ -7,8 +5,8 @@ actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
-actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683:NOASSERTION
-actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683:NOASSERTION
+actions/checkout@v4.2.2:NOASSERTION
+actions/checkout@v4.2.2:NOASSERTION
 actions/checkout@v5:NOASSERTION
 actions/checkout@v5:NOASSERTION
 actions/checkout@v5:NOASSERTION
@@ -44,12 +42,12 @@ actions/setup-python@v6:NOASSERTION
 actions/setup-python@v6:NOASSERTION
 actions/setup-python@v6:NOASSERTION
 actions/setup-python@v6:NOASSERTION
-actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882:NOASSERTION
 actions/upload-artifact@main:NOASSERTION
 actions/upload-artifact@main:NOASSERTION
 actions/upload-artifact@main:NOASSERTION
 actions/upload-artifact@main:NOASSERTION
 actions/upload-artifact@main:NOASSERTION
+actions/upload-artifact@v4.4.3:NOASSERTION
 actions/upload-artifact@v4:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
@@ -58,16 +56,19 @@ actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 codecov/codecov-action@v6:NOASSERTION
-docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee:NOASSERTION
-docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd:NOASSERTION
-docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a:NOASSERTION
-docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a:NOASSERTION
-github/codeql-action/upload-sarif@c6c77c8c2d62cfd5b2e8d548817fd3d1582ac744:NOASSERTION
+docker/login-action@v4.1.0:NOASSERTION
+docker/setup-buildx-action@v4.0.0:NOASSERTION
+docker/setup-qemu-action@v4.0.0:NOASSERTION
+docker/setup-qemu-action@v4.0.0:NOASSERTION
+github/codeql-action/upload-sarif@v2.14.5:NOASSERTION
+./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
+./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ilammy/msvc-dev-cmd@v1:NOASSERTION
 msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff:NOASSERTION
 mymindstorm/setup-emsdk@v14:NOASSERTION
+nanoarrow@0.8.0.9000:Apache
 nttld/setup-ndk@v1:NOASSERTION
-ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736:NOASSERTION
+ossf/scorecard-action@v2.3.1:NOASSERTION
 r-lib/actions/check-r-package@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION
@@ -76,4 +77,4 @@ r-lib/actions/setup-r-dependencies@v2:NOASSERTION
 r-lib/actions/setup-r@v2:NOASSERTION
 r-lib/actions/setup-r@v2:NOASSERTION
 r-lib/actions/setup-tinytex@v2:NOASSERTION
-# nanoarrow-resolved-sha: 65ab7e9f29244589ccbe7f95900c1295633baf42
+# nanoarrow-resolved-sha: 8dcb55e735354ece7e1776d2d9577806cda3ee00


### PR DESCRIPTION
## Summary

Release PR for **v0.44.0**. The final commit on this branch is the standalone/taggable release metadata commit:

- `d4c2b8e` — `release: 0.44.0`

After this PR is merged to `main`, the `v0.44.0` tag should be placed on the resulting `main` commit corresponding to `d4c2b8e`.

## Done in this PR

- [x] **SBOM baseline refreshed and CI Syft pin aligned** (`fb74cff`, `e688ef5`)
  - Regenerated the committed `sbom/snapshot.txt` baseline after the nanoarrow pin bump.
  - Updated the PR SBOM gate's Syft pin from `1.7.0` to `1.44.0` so CI and the current local/release SBOM baseline agree on GitHub Action version resolution.
  - Focused validation: `bash scripts/ci/check-sbom-snapshot.sh` passes locally: `OK; 80 packages in snapshot match baseline`.

- [x] **crc32 checksum expressions documented (#884)** (`9f99082`)
  - `CHANGELOG.md`: added the missing release entry.
  - `docs/SYNTAX.md`: added checksum function docs for `crc32_ethernet(x)` and `crc32_castagnoli(x)`.
  - `docs/MIGRATION.md`: added the `0.43 -> 0.44` migration note, including the two new reserved keywords.

- [x] **v0.44.0 version cut** (`d4c2b8e`)
  - `meson.build`: bumped `project_version` from `0.43.99` to `0.44.0`.
  - `CHANGELOG.md`: moved the `[Unreleased]` CRC-32 entry to `## [0.44.0] - 2026-05-25` and reset `[Unreleased]` to the empty placeholder shape.
  - `scripts/release/extract-changelog-section.sh 0.44.0` emits the GitHub Release body source.

## Local validation

Run from this branch:

- `meson test -C build-0.44-release version_sync changelog_format release_template --print-errorlogs` — passed (`3/3 OK`).
- `meson compile -C build-0.44-release` — passed.
- `meson test -C build-0.44-release --suite abi --print-errorlogs` — passed (`31/31 OK`).
- `bash scripts/ci/check-sbom-snapshot.sh` — passed (`80 packages in snapshot match baseline`).
- `scripts/release/extract-changelog-section.sh 0.44.0` — emits the expected `0.44.0` changelog section.

## Remaining release steps after PR CI is green

- [ ] Wait for the refreshed PR checks to pass on commit `d4c2b8e`.
- [ ] Mark this PR ready for review/merge when maintainers are satisfied with the release evidence.
- [ ] Merge via rebase to `main` per `docs/RELEASE_PROCESS.md`.
- [ ] Tag `v0.44.0` on `main` at the merged release commit.
- [ ] Create the GitHub Release using `scripts/release/extract-changelog-section.sh 0.44.0` as the notes source.
- [ ] Produce/attach release artifacts manually unless/until `release-tag.yml` (#749) exists: signed tarball, checksums, SBOMs, ABI manifest, and provenance.

## Known release-evidence gaps

These are publication gates, not additional source changes in this PR:

- Release perf evidence still needs a stable runner with `WIRELOG_PERF_REQUIRE=1`.
- `stress-release` is manual per `docs/STRESS_BASELINE.md`.
- Fuzz release evidence is manual workflow-dispatch per `docs/FUZZING.md`.
- `release-tag.yml` does not exist yet, so tag-time artifact production is manual.
