### PR TITLE
[codex] prepare release-branch CI policy

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -27,6 +27,8 @@ jobs:
   # ==========================================================================
   lint:
     uses: ./.github/workflows/lint-pr.yml
+    with:
+      base-ref: ${{ github.base_ref }}
 
   # ==========================================================================
   # Phase 2a: Build Primary (ubuntu-latest + gcc)
@@ -226,7 +228,7 @@ jobs:
   # Optional crypto coverage; must pass before build-matrix proceeds.
   # ==========================================================================
   build-mbedtls:
-    name: Build / ubuntu-latest / gcc (mbedTLS-enabled)
+    name: mbedtls-enabled / ubuntu-latest / gcc
     needs: [build-primary]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ name: CI PR
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-1.x]
 
 permissions:
   actions: read

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ name: CI PR
 
 on:
   pull_request:
-    branches: [main, release-1.x]
+    branches: [main, "1.0"]
 
 permissions:
   actions: read

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,6 +7,12 @@ name: Lint PR
 
 on:
   workflow_call:
+    inputs:
+      base-ref:
+        description: PR base branch to diff against for changed-file checks
+        required: false
+        default: main
+        type: string
 
 permissions:
   contents: read
@@ -76,8 +82,11 @@ jobs:
       - name: Run uncrustify (hard gate)
         run: |
           set -o pipefail
+          BASE_REF="${{ inputs.base-ref }}"
+          git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
           # Get list of changed .c and .h files in this PR
-          CHANGED_FILES=$(git diff origin/main...HEAD --name-only --diff-filter=ACM | grep -E '\.(c|h)$' | grep -E '^(wirelog|tests)/' || true)
+          CHANGED_FILES=$(git diff "origin/${BASE_REF}...HEAD" --name-only --diff-filter=ACM | grep -E '\.(c|h)$' | grep -E '^(wirelog|tests)/' || true)
 
           if [ -z "$CHANGED_FILES" ]; then
             echo "No C/H files changed in this PR."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,13 @@ All notable changes to wirelog are documented in this file.
 - Clarified #746 release-branch readiness/cutover sequencing:
   preparatory repo-side CI targeting now lands before branch creation,
   while final `release-1.x` branch-protection acceptance is deferred to
-  the last-moment RC1 cutover when `project_version` is `1.0.0-rc1`,
-  including synthetic PR verification expectations.
+  the last-moment RC1 cutover when `project_version` is `1.0.0-rc1`.
+  Updated Phase B concrete required-check naming to
+  `mbedtls-enabled / ubuntu-latest / gcc`, removed the path-filtered
+  perf-suite context from required branch-protection checks, and
+  documented that final acceptance requires a dedicated always-emitting
+  release perf context (`WIRELOG_PERF_REQUIRE=1`) plus CODEOWNERS and
+  CLA workflow/context prerequisites verified by a synthetic PR.
 
 ## [0.44.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ All notable changes to wirelog are documented in this file.
 
 - Documented the required-check policy for mbedTLS-enabled validation,
   including the stable `mbedtls-enabled / ubuntu-latest / gcc` check
-  name and its PR, main-monitoring, `release-1.x`, and release-tag
+  name and its PR, main-monitoring, `1.0`, and release-tag
   roles without changing the default `mbedTLS=disabled` artifact
   posture (#849).
 - Added `docs/PLATFORM_SUPPORT.md` to classify Android/iOS release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+- Clarified #746 release-branch readiness/cutover sequencing:
+  preparatory repo-side CI targeting now lands before branch creation,
+  while final `release-1.x` branch-protection acceptance is deferred to
+  the last-moment RC1 cutover when `project_version` is `1.0.0-rc1`,
+  including synthetic PR verification expectations.
+
 ## [0.44.0] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to wirelog are documented in this file.
 
 - Clarified #746 release-branch readiness/cutover sequencing:
   preparatory repo-side CI targeting now lands before branch creation,
-  while final `release-1.x` branch-protection acceptance is deferred to
+  while final `1.0` branch-protection acceptance is deferred to
   the last-moment RC1 cutover when `project_version` is `1.0.0-rc1`.
   Updated Phase B concrete required-check naming to
   `mbedtls-enabled / ubuntu-latest / gcc`, removed the path-filtered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,10 +246,10 @@ When cutting a release tag (`vX.Y.Z`):
    that lack a #N reference, not on empty categories.
 3. Open the release PR; CI will refuse to merge if the gate fails.
 
-### Freeze rule (post-release-1.x cut)
+### Freeze rule (post-1.0 cut)
 
-After `release-1.x` is cut for v1.0 RC1 (#685), the `[Unreleased]`
-section on `release-1.x` is **frozen** — every hotfix landing on
-`release-1.x` between rc1 cut and GA tag updates the versioned
+After `1.0` is cut for v1.0 RC1 (#685), the `[Unreleased]`
+section on `1.0` is **frozen** — every hotfix landing on
+`1.0` between rc1 cut and GA tag updates the versioned
 section, not `[Unreleased]`.  This is mechanically enforced by
 the per-branch CI rule landed under #747 (B18).

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -242,20 +242,20 @@ median targets should be added only after stable-run provenance exists.
 
 ## 3. Branch-protection and freeze rules
 
-### After release-1.x cut (post-#685 v1.0 RC1)
+### After 1.0 cut (post-#685 v1.0 RC1)
 
 - The `[Unreleased]` section in `CHANGELOG.md` is **frozen** on
-  `release-1.x` between rc1 and GA.  Hotfixes update the `[1.0.0]`
+  `1.0` between rc1 and GA.  Hotfixes update the `[1.0.0]`
   versioned section, not `[Unreleased]`.  Mechanically enforced
   by the per-branch CI rule under #747 B18.
 
-### Branch-protection (release-1.x, #746 B17)
+### Branch-protection (1.0, #746 B17)
 
 #### Phase A — preparatory (repo-side readiness only)
 
 - Keep `.github/workflows/ci-pr.yml` subscribed to PR targets
-  `[main, release-1.x]` so the same CI contexts are emitted as soon as
-  `release-1.x` exists.
+  `[main, 1.0]` so the same CI contexts are emitted as soon as
+  `1.0` exists.
 - Do **not** configure GitHub branch protection yet; the branch does
   not exist before the last-moment RC1 cutover.
 - This phase is intentionally incomplete by itself: final #746
@@ -263,7 +263,7 @@ median targets should be added only after stable-run provenance exists.
 
 #### Phase B — final RC1 cutover (last moment)
 
-Execute only after `release-1.x` is created during the RC1 cutover and
+Execute only after `1.0` is created during the RC1 cutover and
 the cutover commit sets `project_version` to `1.0.0-rc1`.
 
 - At least one CODEOWNER review.
@@ -292,7 +292,7 @@ the cutover commit sets `project_version` to `1.0.0-rc1`.
 #### Synthetic PR verification plan (Phase B)
 
 After branch creation and protection rules are configured, open a
-synthetic PR targeting `release-1.x` and verify:
+synthetic PR targeting `1.0` and verify:
 
 1. The required check contexts above are present and enforced.
 2. Merge is blocked until at least one CODEOWNER review is granted.
@@ -307,7 +307,7 @@ those prerequisites before attempting final cutover verification.
 
 Close the synthetic PR after capturing verification evidence for #746.
 Final #746 acceptance is deferred until this Phase B verification passes
-on the real `release-1.x` branch at the `1.0.0-rc1` cutover.
+on the real `1.0` branch at the `1.0.0-rc1` cutover.
 
 ### Perf nightly monitoring posture
 
@@ -345,7 +345,7 @@ changes that policy.
 - Pushes to `main`: `ci-main.yml` may mirror the same coverage as
   monitoring only, consistent with its existing `continue-on-error`
   posture.
-- `release-1.x`: #746 branch-protection work should require the same
+- `1.0`: #746 branch-protection work should require the same
   stable check name once the branch is cut.
 - Release tags: #749 tag-time verification should include this enabled
   crypto validation at minimum by running `cryptographic_hashes` under

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -267,24 +267,27 @@ Execute only after `release-1.x` is created during the RC1 cutover and
 the cutover commit sets `project_version` to `1.0.0-rc1`.
 
 - At least one CODEOWNER review.
+- CLA signoff required (blocking CLA status context).
 - Linear history (no force-push, no merge commits).
 - Signed commits (GPG verified).
 - Tag protection on `v1.x.*`.
 - Required status checks:
   - Stable policy plan: `default`, `abi`, `asan`, `tsan`, `perf`,
     plus `mbedtls-enabled / ubuntu-latest / gcc`.
+  - `perf` must be represented by a dedicated always-emitting release
+    perf context that runs with `WIRELOG_PERF_REQUIRE=1`; do not rely on
+    path-filtered contexts for branch protection.
   - Currently known concrete PR contexts to require at cutover (unless
     replaced by a later policy-consolidation change): `EditorConfig check`,
     `uncrustify check`, `clang-tidy 22 check`,
     `Build / ubuntu-latest / gcc`, `Build / ubuntu-24.04-arm / gcc`,
-    `Build / ubuntu-latest / gcc (mbedTLS-enabled)`,
+    `mbedtls-enabled / ubuntu-latest / gcc`,
     `Build / ubuntu-latest / clang`, `Build / macos-latest / clang`,
     `Build / windows-latest / msvc`,
     `Sanitizers / ubuntu-latest / gcc`,
     `Sanitizers / ubuntu-latest / clang`,
     `Sanitizers / macos-latest / clang`,
-    `TSan / ubuntu-latest / gcc`,
-    `Perf Suite (col_rel_compact_runs / heap surfaces)`.
+    `TSan / ubuntu-latest / gcc`.
 
 #### Synthetic PR verification plan (Phase B)
 
@@ -293,8 +296,14 @@ synthetic PR targeting `release-1.x` and verify:
 
 1. The required check contexts above are present and enforced.
 2. Merge is blocked until at least one CODEOWNER review is granted.
-3. Merge is blocked while any required check is failing or pending.
-4. Linear-history and signed-commit constraints are enforced.
+3. Merge is blocked until CLA signoff is complete.
+4. Merge is blocked while any required check is failing or pending.
+5. Linear-history and signed-commit constraints are enforced.
+
+Phase B prerequisites for final #746 acceptance are not fully present in
+this repository state yet: `CODEOWNERS` is missing, and the CLA workflow
+plus its always-emitting required status context are also missing. Land
+those prerequisites before attempting final cutover verification.
 
 Close the synthetic PR after capturing verification evidence for #746.
 Final #746 acceptance is deferred until this Phase B verification passes

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -249,16 +249,56 @@ median targets should be added only after stable-run provenance exists.
   versioned section, not `[Unreleased]`.  Mechanically enforced
   by the per-branch CI rule under #747 B18.
 
-### Branch-protection (release-1.x)
+### Branch-protection (release-1.x, #746 B17)
 
-Per #746 B17, `release-1.x` requires:
+#### Phase A — preparatory (repo-side readiness only)
+
+- Keep `.github/workflows/ci-pr.yml` subscribed to PR targets
+  `[main, release-1.x]` so the same CI contexts are emitted as soon as
+  `release-1.x` exists.
+- Do **not** configure GitHub branch protection yet; the branch does
+  not exist before the last-moment RC1 cutover.
+- This phase is intentionally incomplete by itself: final #746
+  acceptance remains gated on Phase B.
+
+#### Phase B — final RC1 cutover (last moment)
+
+Execute only after `release-1.x` is created during the RC1 cutover and
+the cutover commit sets `project_version` to `1.0.0-rc1`.
 
 - At least one CODEOWNER review.
-- Required status checks (default + abi + asan + tsan + perf,
-  plus `mbedtls-enabled / ubuntu-latest / gcc` once #843 lands).
 - Linear history (no force-push, no merge commits).
 - Signed commits (GPG verified).
 - Tag protection on `v1.x.*`.
+- Required status checks:
+  - Stable policy plan: `default`, `abi`, `asan`, `tsan`, `perf`,
+    plus `mbedtls-enabled / ubuntu-latest / gcc`.
+  - Currently known concrete PR contexts to require at cutover (unless
+    replaced by a later policy-consolidation change): `EditorConfig check`,
+    `uncrustify check`, `clang-tidy 22 check`,
+    `Build / ubuntu-latest / gcc`, `Build / ubuntu-24.04-arm / gcc`,
+    `Build / ubuntu-latest / gcc (mbedTLS-enabled)`,
+    `Build / ubuntu-latest / clang`, `Build / macos-latest / clang`,
+    `Build / windows-latest / msvc`,
+    `Sanitizers / ubuntu-latest / gcc`,
+    `Sanitizers / ubuntu-latest / clang`,
+    `Sanitizers / macos-latest / clang`,
+    `TSan / ubuntu-latest / gcc`,
+    `Perf Suite (col_rel_compact_runs / heap surfaces)`.
+
+#### Synthetic PR verification plan (Phase B)
+
+After branch creation and protection rules are configured, open a
+synthetic PR targeting `release-1.x` and verify:
+
+1. The required check contexts above are present and enforced.
+2. Merge is blocked until at least one CODEOWNER review is granted.
+3. Merge is blocked while any required check is failing or pending.
+4. Linear-history and signed-commit constraints are enforced.
+
+Close the synthetic PR after capturing verification evidence for #746.
+Final #746 acceptance is deferred until this Phase B verification passes
+on the real `release-1.x` branch at the `1.0.0-rc1` cutover.
 
 ### Perf nightly monitoring posture
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -278,8 +278,8 @@ the cutover commit sets `project_version` to `1.0.0-rc1`.
     perf context that runs with `WIRELOG_PERF_REQUIRE=1`; do not rely on
     path-filtered contexts for branch protection.
   - Currently known concrete PR contexts to require at cutover (unless
-    replaced by a later policy-consolidation change): `EditorConfig check`,
-    `uncrustify check`, `clang-tidy 22 check`,
+    replaced by a later policy-consolidation change): `lint / EditorConfig check`,
+    `lint / uncrustify check`, `lint / clang-tidy 22 check`,
     `Build / ubuntu-latest / gcc`, `Build / ubuntu-24.04-arm / gcc`,
     `mbedtls-enabled / ubuntu-latest / gcc`,
     `Build / ubuntu-latest / clang`, `Build / macos-latest / clang`,


### PR DESCRIPTION
## Summary

- Enable the existing PR CI workflow for future `1.0` release-branch pull requests without creating the branch or doing rc1 cutover.
- Make the reusable lint workflow diff against the actual PR base branch instead of hard-coding `origin/main`.
- Align release-branch policy docs around the `1.0` branch name, required check contexts, synthetic PR verification, and final-cutover prerequisites.

## Scope boundaries

This is preparatory work only. It does not create `1.0`, configure branch protection, bump `meson.build`, create a `[1.0.0]` changelog section, or distribute rc1 beta artifacts.

## Validation

- `git diff origin/main..HEAD --check`
- `uv venv --allow-existing`
- `source .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md`
- `actionlint .github/workflows/ci-pr.yml .github/workflows/lint-pr.yml`
- `rg -n 'release-1\.x' CONTRIBUTING.md CHANGELOG.md docs/RELEASE_PROCESS.md .github/workflows/ci-pr.yml` (only remaining hit is historical `CHANGELOG.md:476`)

Refs #746.
