### PR TITLE
Fix clang-cl CRC32 fallback build

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2299,12 +2299,11 @@ crc32_src = files(
 )
 
 # Architecture-specific flags to enable hardware CRC32 instructions.
-# Applied to all CRC-32 test executables so crc32.c compiles with the
-# correct feature macros on each platform.
-# Note: GCC/Clang only; MSVC doesn't support these flags and has built-in
-# support for CRC32 instructions without explicit flags.
+# Add GNU-style target feature flags only for compilers using GCC/Clang
+# argument syntax. MSVC-syntax builds, including clang-cl, rely on
+# crc32.c's compiler-specific paths and portable fallback.
 crc32_arch_c_args = []
-if cc.get_id() != 'msvc'
+if cc.get_argument_syntax() != 'msvc'
   if host_machine.cpu_family() == 'x86_64'
     crc32_arch_c_args = ['-msse4.2']
   elif host_machine.cpu_family() == 'aarch64'
@@ -2312,8 +2311,19 @@ if cc.get_id() != 'msvc'
   endif
 endif
 
+test_crc32_windows_fallback_exe = executable(
+  'test_crc32_windows_fallback',
+  files('test_crc32_windows_fallback.c'),
+  crc32_src,
+  c_args: crc32_arch_c_args,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+
+test('crc32_windows_fallback', test_crc32_windows_fallback_exe)
+
 # CRC-32 tests (Issue #145)
-# Note: MSVC has internal compiler errors on these test files; skip on Windows
+# These broader legacy CRC tests are still skipped under MSVC, but the
+# smoke test above keeps known-vector coverage on MSVC/clang-cl paths.
 if cc.get_id() != 'msvc'
   test_crc32_ethernet_exe = executable(
     'test_crc32_ethernet',

--- a/tests/test_crc32_windows_fallback.c
+++ b/tests/test_crc32_windows_fallback.c
@@ -1,0 +1,33 @@
+/*
+ * test_crc32_windows_fallback.c - CRC-32 smoke test for MSVC/clang-cl
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../wirelog/crc32.h"
+
+int
+main(void)
+{
+    static const uint8_t input[] = { '1', '2', '3', '4', '5',
+                                     '6', '7', '8', '9' };
+    uint32_t eth = ethernet_crc32(input, sizeof(input));
+    uint32_t crc32c = castagnoli_crc32(input, sizeof(input));
+
+    if (eth != 0xCBF43926u) {
+        printf(
+            "ethernet_crc32(\"123456789\"): expected 0xCBF43926, got 0x%08X\n",
+            eth);
+        return 1;
+    }
+
+    if (crc32c != 0xE3069283u) {
+        printf(
+            "castagnoli_crc32(\"123456789\"): expected 0xE3069283, got 0x%08X\n",
+            crc32c);
+        return 1;
+    }
+
+    return 0;
+}

--- a/wirelog/crc32.c
+++ b/wirelog/crc32.c
@@ -28,33 +28,26 @@
 
 /* Hardware intrinsics headers (GCC/Clang only) */
 #if (defined(__x86_64__) || defined(_M_X64)) && !defined(_MSC_VER)
-#define WL_ARCH_X86_64 1
+#define WL_HAVE_X86_CRC32_INTRINSICS 1
 #include <nmmintrin.h> /* _mm_crc32_u8 */
-#elif (defined(__aarch64__) || defined(_M_ARM64)) && !defined(_MSC_VER)
-#define WL_ARCH_ARM64 1
+#elif (defined(__aarch64__) || defined(_M_ARM64)) && !defined(_MSC_VER) && \
+    defined(__ARM_FEATURE_CRC32)
+#define WL_HAVE_ARM_CRC32_INTRINSICS 1
 #include <arm_acle.h> /* __crc32cb */
-#endif
-
-/* Architecture detection for MSVC (no hardware acceleration) */
-#if defined(_M_X64) && defined(_MSC_VER)
-#define WL_ARCH_X86_64 1
-#elif defined(_M_ARM64) && defined(_MSC_VER)
-#define WL_ARCH_ARM64 1
 #endif
 
 /* Runtime detection: returns 1 if hardware CRC32 is available */
 static int
 crc32_hw_available(void)
 {
-#if defined(WL_ARCH_X86_64) && !defined(_MSC_VER)
+#if defined(WL_HAVE_X86_CRC32_INTRINSICS)
     /* CPUID leaf 1, ECX bit 20 = SSE4.2 (includes CRC32 instruction) */
-    /* Note: MSVC does not support GCC-style inline asm, disable HW accel on Windows */
     unsigned int eax, ebx, ecx, edx;
     __asm__ volatile ("cpuid"
     : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx)
     : "a" (1), "c" (0));
     return ((ecx >> 20) & 1U) != 0U;
-#elif defined(WL_ARCH_ARM64) && !defined(_MSC_VER)
+#elif defined(WL_HAVE_ARM_CRC32_INTRINSICS)
 #if defined(__APPLE__)
     /* Apple Silicon always has CRC32 extension */
     return 1;
@@ -67,12 +60,8 @@ crc32_hw_available(void)
     unsigned long hwcap = getauxval(AT_HWCAP);
     return (hwcap & HWCAP_CRC32) != 0;
 #else
-    /* Conservative: use compile-time feature macro */
-#ifdef __ARM_FEATURE_CRC32
+    /* Conservative: the intrinsic path is only compiled when the feature exists. */
     return 1;
-#else
-    return 0;
-#endif
 #endif
 #else
     return 0;
@@ -98,7 +87,7 @@ hw_crc32_check(void)
 uint32_t
 intel_crc32_hw_u8(uint32_t crc, uint8_t byte)
 {
-#if defined(WL_ARCH_X86_64)
+#if defined(WL_HAVE_X86_CRC32_INTRINSICS)
     return (uint32_t)_mm_crc32_u8((unsigned int)crc, byte);
 #else
     (void)crc;
@@ -114,7 +103,7 @@ intel_crc32_hw_u8(uint32_t crc, uint8_t byte)
 uint32_t
 arm_crc32_hw_u8(uint32_t crc, uint8_t byte)
 {
-#if defined(WL_ARCH_ARM64) && defined(__ARM_FEATURE_CRC32)
+#if defined(WL_HAVE_ARM_CRC32_INTRINSICS)
     return __crc32cb(crc, byte);
 #else
     (void)crc;
@@ -200,13 +189,14 @@ castagnoli_crc32(const uint8_t *data, size_t len)
     uint32_t crc = 0xFFFFFFFFu;
     size_t i;
 
-#if defined(WL_ARCH_X86_64) || defined(WL_ARCH_ARM64)
+#if defined(WL_HAVE_X86_CRC32_INTRINSICS) || \
+    defined(WL_HAVE_ARM_CRC32_INTRINSICS)
     if (hw_crc32_check()) {
         /* Hardware path: use CRC32 instruction (Castagnoli polynomial) */
-#if defined(WL_ARCH_X86_64)
+#if defined(WL_HAVE_X86_CRC32_INTRINSICS)
         for (i = 0; i < len; i++)
             crc = intel_crc32_hw_u8(crc, data[i]);
-#elif defined(WL_ARCH_ARM64) && defined(__ARM_FEATURE_CRC32)
+#elif defined(WL_HAVE_ARM_CRC32_INTRINSICS)
         for (i = 0; i < len; i++)
             crc = arm_crc32_hw_u8(crc, data[i]);
 #endif

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -115,20 +115,16 @@ wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
 #poly) via SSE4.2 intrinsics on x86_64 and the ARMv8-A CRC extension on
 #aarch64.  The columnar evaluator's WL_PLAN_EXPR_ARITH_CRC32_* cases call
 #into these functions (Issue #884), so any test binary that pulls in the
-#columnar backend also pulls in crc32.c.  The architecture intrinsics
-#require their own compile flags; we apply them project-wide rather than
-#per-target because (a) the same flags were already required by the three
-#standalone crc32 tests, (b) all currently-supported deployment targets
-#predate-by-a-decade the relevant CPU features (SSE4.2 = Nehalem 2008,
-#ARMv8-A+CRC = ARMv8.1 2014), and (c) the alternative — threading
-#per-source compile flags through 130+ test binaries — is significantly
-#more fragile.
+#columnar backend also pulls in crc32.c.  GNU-style architecture flags are
+#applied project-wide only for compilers using GCC/Clang argument syntax;
+#MSVC-syntax compilers such as MSVC and clang-cl rely on crc32.c's
+#compiler-specific paths and portable fallback.
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_crc32_src = files('crc32.c')
 
 wirelog_crc32_arch_c_args = []
-if cc.get_id() != 'msvc'
+if cc.get_argument_syntax() != 'msvc'
   if host_machine.cpu_family() == 'x86_64'
     wirelog_crc32_arch_c_args = ['-msse4.2']
   elif host_machine.cpu_family() == 'aarch64'


### PR DESCRIPTION
## Summary

Fixes #902.

- gate CRC32 hardware intrinsic paths on explicit intrinsic capability macros instead of architecture macros
- avoid GNU-style CRC feature flags for MSVC-syntax compilers such as clang-cl
- add an always-built CRC fallback smoke test that covers MSVC/clang-cl paths

## Verification

- `meson setup build-issue902-clangcl-fixed --default-library=static` with `CC=clang-cl` and `C:\Program Files\LLVM\bin` on `PATH`
- confirmed generated `build.ninja` contains no `-msse4.2` / `-march=armv8-a+crc`
- `meson test -C build-issue902-clangcl-fixed crc32_windows_fallback --print-errorlogs`
- `ninja -C build-issue902-clangcl-fixed libwirelog.a`

Note: clang-cl still emits existing project warnings such as ignored `-std=c11`, but the issue #902 `_mm_crc32_u8` undeclared failure is gone.