### PR TITLE
ci: gate 1.0 PRs with RC changelog freeze checks

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,9 +7,10 @@ name: CI PR
 #   └─ lint
 #      ├─ build-primary (ubuntu-latest gcc, SBOM/size/path-a gates)
 #      │  ├─ build-arm (ubuntu-24.04-arm gcc, ABI #681) ──┐
-#      │  ├─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix (parallel)
-#      │  ├─ tsan (independent, no gate) ────────────────┼─ sanitizer-matrix (parallel)
-#      │  └─ tsan-native (independent, no gate) ─────────┘
+#      │  └─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix (parallel)
+#      │                                                   └─ sanitizer-matrix (parallel)
+#      ├─ tsan (independent, no gate)
+#      └─ tsan-native (independent, no gate)
 #
 # CodeQL runs in its own workflow (GitHub default-setup); not invoked from here.
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,10 +22,28 @@ permissions:
 
 jobs:
   # ==========================================================================
+  # Issue #747 B18: RC changelog freeze gate (stable always-emitting context)
+  # Enforces only for PRs whose base branch is `1.0`; non-1.0 PRs SKIP/pass.
+  # ==========================================================================
+  rc-changelog-freeze:
+    name: RC changelog freeze gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Enforce RC changelog freeze policy
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: scripts/ci/check-changelog-rc.sh
+
+  # ==========================================================================
   # Phase 1: Lint (import lint-pr.yml as prerequisite)
   # editorconfig -> uncrustify -> clang-tidy 22 (sequential, hard gates)
   # ==========================================================================
   lint:
+    needs: [rc-changelog-freeze]
     uses: ./.github/workflows/lint-pr.yml
     with:
       base-ref: ${{ github.base_ref }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -3,12 +3,13 @@ name: CI PR
 # PR-specific CI workflow with gated serial/parallel execution.
 #
 # Execution flow:
-#   lint
-#   ├─ build-primary (ubuntu-latest gcc, SBOM/size/path-a gates)
-#   │  ├─ build-arm (ubuntu-24.04-arm gcc, ABI #681) ──┐
-#   │  ├─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix (parallel)
-#   │  ├─ tsan (independent, no gate) ────────────────┼─ sanitizer-matrix (parallel)
-#   │  └─ tsan-native (independent, no gate) ─────────┘
+#   rc-changelog-freeze
+#   └─ lint
+#      ├─ build-primary (ubuntu-latest gcc, SBOM/size/path-a gates)
+#      │  ├─ build-arm (ubuntu-24.04-arm gcc, ABI #681) ──┐
+#      │  ├─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix (parallel)
+#      │  ├─ tsan (independent, no gate) ────────────────┼─ sanitizer-matrix (parallel)
+#      │  └─ tsan-native (independent, no gate) ─────────┘
 #
 # CodeQL runs in its own workflow (GitHub default-setup); not invoked from here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **RC freeze PR gate for `1.0` branch targets** (#747): added
+  `scripts/ci/check-changelog-rc.sh` and wired it as an always-emitting
+  `RC changelog freeze gate` context in `.github/workflows/ci-pr.yml`.
+  The gate SKIPs/passes on non-`1.0` PRs, and enforces on `1.0` PRs:
+  `meson.build` project version must match `1.0.0` or `1.0.0-*`
+  (e.g. `1.0.0-rc1`), `CHANGELOG.md` `[Unreleased]` must remain frozen
+  versus base, and changelog edits must be confined to `## [1.0.0]`.
+
 ### Deprecated
 
 ### Removed

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -247,7 +247,9 @@ median targets should be added only after stable-run provenance exists.
 - The `[Unreleased]` section in `CHANGELOG.md` is **frozen** on
   `1.0` between rc1 and GA.  Hotfixes update the `[1.0.0]`
   versioned section, not `[Unreleased]`.  Mechanically enforced
-  by the per-branch CI rule under #747 B18.
+  by `scripts/ci/check-changelog-rc.sh` (always-emitting check context
+  name: `RC changelog freeze gate`) under #747 B18.  The check enforces
+  only when a PR base branch is `1.0`; non-`1.0` PRs SKIP/pass.
 
 ### Branch-protection (1.0, #746 B17)
 
@@ -281,6 +283,7 @@ the cutover commit sets `project_version` to `1.0.0-rc1`.
     replaced by a later policy-consolidation change): `lint / EditorConfig check`,
     `lint / uncrustify check`, `lint / clang-tidy 22 check`,
     `Build / ubuntu-latest / gcc`, `Build / ubuntu-24.04-arm / gcc`,
+    `RC changelog freeze gate`,
     `mbedtls-enabled / ubuntu-latest / gcc`,
     `Build / ubuntu-latest / clang`, `Build / macos-latest / clang`,
     `Build / windows-latest / msvc`,

--- a/scripts/ci/check-changelog-rc.sh
+++ b/scripts/ci/check-changelog-rc.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# check-changelog-rc.sh - Issue #747 RC changelog freeze gate.
+#
+# Enforces the RC freeze policy only for PRs targeting branch `1.0`.
+# For non-1.0 PRs, SKIPs cleanly with exit 0 so `main` remains unaffected.
+#
+# Active checks (base-ref == 1.0):
+#   1) meson.build project version must be 1.0.0 or 1.0.0-* (e.g. 1.0.0-rc1)
+#   2) CHANGELOG.md edits are restricted to the [1.0.0] section only, and
+#      [Unreleased] must match the base branch byte-for-byte.
+#
+# Usage:
+#   scripts/ci/check-changelog-rc.sh [--base-ref REF]
+#                                    [--base-changelog PATH]
+#                                    [--head-changelog PATH]
+#                                    [--meson-file PATH]
+#
+# Exit codes:
+#   0 - OK or SKIP.
+#   1 - policy violation or hard failure.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+base_ref="${GITHUB_BASE_REF:-main}"
+base_changelog_override=""
+head_changelog="$repo_root/CHANGELOG.md"
+meson_file="$repo_root/meson.build"
+
+usage() {
+    cat <<EOF
+usage: check-changelog-rc.sh [--base-ref REF] [--base-changelog PATH] [--head-changelog PATH] [--meson-file PATH]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --base-ref)
+            base_ref="${2:-}"
+            shift 2
+            ;;
+        --base-changelog)
+            base_changelog_override="${2:-}"
+            shift 2
+            ;;
+        --head-changelog)
+            head_changelog="${2:-}"
+            shift 2
+            ;;
+        --meson-file)
+            meson_file="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "check-changelog-rc: FAIL: unknown argument '$1'" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$base_ref" != "1.0" ]; then
+    echo "check-changelog-rc: SKIP: base ref is '$base_ref' (policy only enforces on '1.0')"
+    exit 0
+fi
+
+if [ ! -f "$meson_file" ]; then
+    echo "check-changelog-rc: FAIL: meson file not found: $meson_file" >&2
+    exit 1
+fi
+
+if [ ! -f "$head_changelog" ]; then
+    echo "check-changelog-rc: FAIL: head changelog not found: $head_changelog" >&2
+    exit 1
+fi
+
+project_version="$(sed -nE "s/^[[:space:]]*version:[[:space:]]*'([^']+)'.*/\1/p" "$meson_file" | head -n1)"
+if [ -z "$project_version" ]; then
+    echo "check-changelog-rc: FAIL: could not parse project version from $meson_file" >&2
+    exit 1
+fi
+
+case "$project_version" in
+    1.0.0|1.0.0-*)
+        ;;
+    *)
+        echo "check-changelog-rc: FAIL: project version '$project_version' is invalid for base '1.0'" >&2
+        echo "  expected: 1.0.0 or 1.0.0-* (e.g. 1.0.0-rc1)" >&2
+        exit 1
+        ;;
+esac
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+base_changelog="$workdir/base-CHANGELOG.md"
+
+if [ -n "$base_changelog_override" ]; then
+    if [ ! -f "$base_changelog_override" ]; then
+        echo "check-changelog-rc: FAIL: base changelog not found: $base_changelog_override" >&2
+        exit 1
+    fi
+    cp "$base_changelog_override" "$base_changelog"
+else
+    if ! git -C "$repo_root" fetch --no-tags origin \
+        "+refs/heads/$base_ref:refs/remotes/origin/$base_ref" >/dev/null 2>&1; then
+        echo "check-changelog-rc: FAIL: could not fetch origin/$base_ref" >&2
+        exit 1
+    fi
+    if ! git -C "$repo_root" show "origin/$base_ref:CHANGELOG.md" > "$base_changelog"; then
+        echo "check-changelog-rc: FAIL: could not read CHANGELOG.md from origin/$base_ref" >&2
+        exit 1
+    fi
+fi
+
+extract_section() {
+    # $1 = section key (inside brackets), $2 = input file, $3 = output file
+    local section="$1"
+    local infile="$2"
+    local outfile="$3"
+
+    awk -v section="$section" '
+BEGIN {
+    target = "## [" section "]"
+    in_section = 0
+    found = 0
+}
+{
+    is_target = ($0 == target || index($0, target " ") == 1)
+    is_h2 = ($0 ~ /^## \[/)
+
+    if (is_target) {
+        in_section = 1
+        found = 1
+    } else if (in_section && is_h2) {
+        exit
+    }
+
+    if (in_section) {
+        print
+    }
+}
+END {
+    if (!found) {
+        exit 3
+    }
+}
+' "$infile" > "$outfile"
+}
+
+strip_section() {
+    # $1 = section key (inside brackets), $2 = input file, $3 = output file
+    local section="$1"
+    local infile="$2"
+    local outfile="$3"
+
+    awk -v section="$section" '
+BEGIN {
+    target = "## [" section "]"
+    in_section = 0
+}
+{
+    is_target = ($0 == target || index($0, target " ") == 1)
+    is_h2 = ($0 ~ /^## \[/)
+
+    if (is_target) {
+        in_section = 1
+        next
+    }
+    if (in_section && is_h2) {
+        in_section = 0
+    }
+    if (!in_section) {
+        print
+    }
+}
+' "$infile" > "$outfile"
+}
+
+base_unreleased="$workdir/base-unreleased.md"
+head_unreleased="$workdir/head-unreleased.md"
+extract_section "Unreleased" "$base_changelog" "$base_unreleased" || {
+    echo "check-changelog-rc: FAIL: base CHANGELOG missing '## [Unreleased]'" >&2
+    exit 1
+}
+extract_section "Unreleased" "$head_changelog" "$head_unreleased" || {
+    echo "check-changelog-rc: FAIL: head CHANGELOG missing '## [Unreleased]'" >&2
+    exit 1
+}
+
+if ! cmp -s "$base_unreleased" "$head_unreleased"; then
+    echo "check-changelog-rc: FAIL: CHANGELOG [Unreleased] is frozen on base '1.0'" >&2
+    diff -u "$base_unreleased" "$head_unreleased" >&2 || true
+    exit 1
+fi
+
+base_without_100="$workdir/base-without-1.0.0.md"
+head_without_100="$workdir/head-without-1.0.0.md"
+strip_section "1.0.0" "$base_changelog" "$base_without_100"
+strip_section "1.0.0" "$head_changelog" "$head_without_100"
+
+if ! cmp -s "$base_without_100" "$head_without_100"; then
+    echo "check-changelog-rc: FAIL: CHANGELOG edits must be confined to '## [1.0.0]' on base '1.0'" >&2
+    diff -u "$base_without_100" "$head_without_100" >&2 || true
+    exit 1
+fi
+
+echo "check-changelog-rc: OK: base '1.0' policy satisfied (version=$project_version; [Unreleased] frozen; edits scoped to [1.0.0])"
+exit 0

--- a/scripts/ci/test-check-changelog-rc.sh
+++ b/scripts/ci/test-check-changelog-rc.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test-check-changelog-rc.sh - self-test harness for check-changelog-rc.sh.
+#
+# Coverage:
+#   1) no relevant changes => pass
+#   2) [Unreleased] mutation => fail
+#   3) [1.0.0] mutation => pass
+#   4) version 1.0.0-rc1 => pass
+#   5) version 1.1.0 => fail
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+gate="$script_dir/check-changelog-rc.sh"
+
+if [ ! -x "$gate" ]; then
+    echo "test-check-changelog-rc: FAIL: missing executable gate script: $gate" >&2
+    exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+base_changelog="$workdir/base-CHANGELOG.md"
+head_same="$workdir/head-same.md"
+head_unreleased_mut="$workdir/head-unreleased-mut.md"
+head_100_mut="$workdir/head-1.0.0-mut.md"
+
+cat > "$base_changelog" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+- Placeholder.
+
+## [1.0.0] - 2026-05-27
+
+### Added
+
+- Baseline entry.
+EOF
+
+cp "$base_changelog" "$head_same"
+
+cat > "$head_unreleased_mut" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- This mutates frozen unreleased.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+- Placeholder.
+
+## [1.0.0] - 2026-05-27
+
+### Added
+
+- Baseline entry.
+EOF
+
+cat > "$head_100_mut" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+- Placeholder.
+
+## [1.0.0] - 2026-05-27
+
+### Added
+
+- Baseline entry.
+- RC fix landed.
+EOF
+
+make_meson() {
+    local out="$1"
+    local version="$2"
+    cat > "$out" <<EOF
+project(
+  'wirelog',
+  'c',
+  version: '$version',
+)
+EOF
+}
+
+run_expect() {
+    local expect="$1"
+    local label="$2"
+    local head_file="$3"
+    local version="$4"
+    local meson_file="$workdir/meson-$label.build"
+
+    make_meson "$meson_file" "$version"
+
+    set +e
+    "$gate" \
+      --base-ref 1.0 \
+      --base-changelog "$base_changelog" \
+      --head-changelog "$head_file" \
+      --meson-file "$meson_file" \
+      >"$workdir/$label.stdout" 2>"$workdir/$label.stderr"
+    rc=$?
+    set -e
+
+    if [ "$expect" = "pass" ] && [ "$rc" -eq 0 ]; then
+        echo "PASS: $label"
+        return 0
+    fi
+    if [ "$expect" = "fail" ] && [ "$rc" -ne 0 ]; then
+        echo "PASS: $label (expected failure)"
+        return 0
+    fi
+
+    echo "FAIL: $label (expect=$expect rc=$rc)" >&2
+    if [ -s "$workdir/$label.stdout" ]; then
+        echo "--- stdout ---" >&2
+        cat "$workdir/$label.stdout" >&2
+    fi
+    if [ -s "$workdir/$label.stderr" ]; then
+        echo "--- stderr ---" >&2
+        cat "$workdir/$label.stderr" >&2
+    fi
+    exit 1
+}
+
+run_expect pass "no-relevant-changes" "$head_same" "1.0.0"
+run_expect fail "unreleased-mutation-fails" "$head_unreleased_mut" "1.0.0"
+run_expect pass "1.0.0-mutation-passes" "$head_100_mut" "1.0.0"
+run_expect pass "version-1.0.0-rc1-passes" "$head_same" "1.0.0-rc1"
+run_expect fail "version-1.1.0-fails" "$head_same" "1.1.0"
+
+echo "test-check-changelog-rc: OK"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -608,6 +608,15 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #747 B18: RC changelog selftest for changelog-freeze checker.
+# Shell gate uses the same shared `sh` handle to keep skip behavior
+# consistent on platforms without bash.
+if sh.found()
+  test('changelog_rc_selftest', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-check-changelog-rc.sh'],
+       suite: 'abi')
+endif
+
 # Issue #734: docs/THREADING.md atomics audit row count must match
 # the count of atomic_* call sites in wirelog/ production sources.
 # Static text scan; no build-tree input required.


### PR DESCRIPTION
## Summary
- add `RC changelog freeze gate` for PRs targeting `1.0` while skipping/passing on non-`1.0` bases
- enforce frozen `CHANGELOG.md` `[Unreleased]`, confine release-branch changelog edits to `[1.0.0]`, and require the Meson release triple `1.0.0` with RC suffixes allowed
- add and register `changelog_rc_selftest` in the ABI suite

## Validation
- `scripts/ci/test-check-changelog-rc.sh`
- `meson test -C builddir --suite abi changelog_rc_selftest --print-errorlogs`
- `actionlint .github/workflows/ci-pr.yml`
- `uv venv --allow-existing && . .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md`
- `git diff --check origin/main..HEAD`

Refs #747
Refs #685
Refs #746

Note: real PR-targeting-`1.0` verification remains deferred until the last-moment `1.0` branch cutover, because the branch intentionally does not exist yet.