### PR TITLE
docs: clear rc1 docs-freeze blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+- **Docs-freeze readiness follow-up** (#900): updated
+  `docs/MIGRATION.md` external migration guidance to use public APIs
+  (`wirelog_session_make_compound()` / `wirelog_easy_make_compound()`
+  and `wirelog_session_step()` / `wirelog_easy_step()`), strengthened
+  GA deferral cross-links for #752 and #753 in release-facing docs, and
+  aligned the remaining current-source branch-name reference to `1.0`.
+
 - Clarified #746 release-branch readiness/cutover sequencing:
   preparatory repo-side CI targeting now lands before branch creation,
   while final `1.0` branch-protection acceptance is deferred to
@@ -481,7 +488,7 @@ All notable changes to wirelog are documented in this file.
   and carries at least one `#N` PR or issue reference.  Versioned
   section headers must use `## [X.Y.Z] - YYYY-MM-DD`.  CONTRIBUTING.md
   gains a "Changelog Conventions" section documenting the format,
-  cutover procedure, and the freeze rule for `release-1.x`
+  cutover procedure, and the freeze rule for `1.0`
   (cross-link with #747 B18).
 - **ABI symbol allowlist gate (#733 K2)**: `meson test --suite abi:abi_symbols`
   diffs `nm -D --defined-only build/libwirelog.so | awk '$2=="T"'`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,10 @@
 wirelog is still pre-1.0. Security fixes are currently made on `main`; release
 branch backports begin with supported 1.x release lines.
 
+Full GA PSIRT/CVE-intake activation and the explicit 1.x support-window
+declaration are deferred and tracked by #753. Until that lands, the pre-1.0
+policy in this file remains unchanged.
+
 | Version line | Security support |
 | --- | --- |
 | `main` / current pre-1.0 development | Supported for security fixes on `main` |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -485,10 +485,11 @@ To add a compound column to an existing relation:
 2. Update any rules that reference that column to use compound pattern
    matching syntax (`f(x, y)` in rule bodies).
 3. Update any C API call sites that insert rows into the relation to supply
-   the compound arguments. For the side-relation tier, obtain a handle via
-   `wl_compound_arena_alloc` and store it in the column. For the inline
-   tier, pass the argument values directly as additional `int64` columns in
-   the row array.
+   the compound arguments. For advanced sessions, use
+   `wirelog_session_make_compound()` to construct side-tier compounds before
+   insertion. For easy sessions, use `wirelog_easy_make_compound()`. For the
+   inline tier, pass the argument values directly as additional `int64`
+   columns in the row array.
 
 No changes are needed to relations or rules that do not use compound columns.
 
@@ -527,7 +528,8 @@ from all graphs — no filtering is implicit.
 - [ ] Add `__graph_id: int64` to those relations' `.decl` statements.
 - [ ] Update fact insertion call sites to supply the graph ID.
 - [ ] If you need per-graph metadata, declare `__graph_metadata` and insert
-      graph attribute rows before calling `wl_session_step`.
+      graph attribute rows before calling `wirelog_session_step()` (advanced
+      sessions) or `wirelog_easy_step()` (easy sessions).
 - [ ] Review existing rules: rules that previously saw all rows continue to
       see all rows (graph ID is not an implicit filter). Add explicit graph
       ID constraints only where isolation is required.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -379,5 +379,7 @@ changes that policy.
 - #749 (B19) — at-tag CI re-verification workflow.
 - #750 — GPG + cosign-keyless signing pipeline.
 - #751 — tarball + SHA256 + BLAKE3 + provenance attestation.
+- #752 — GA release-facing deferrals/readiness follow-up in release process docs.
+- #753 — GA PSIRT/CVE-intake activation and 1.x support-window declaration deferral.
 - #744 — SBOM automation (SPDX + CycloneDX).
 - `stable-release-plan.md` §12.8 — GA exit conditions.


### PR DESCRIPTION
## Summary
- update `docs/MIGRATION.md` external migration guidance to use public compound/step APIs
- add GA deferral cross-links for #752/#753 in release-facing docs and `SECURITY.md`
- align the remaining current-source changelog branch reference to `1.0`

## Validation
- `uv venv --allow-existing && . .venv/bin/activate && python scripts/ci/check-changelog-format.py CHANGELOG.md`
- `rg -n 'release-1\\.x|wl_compound_arena_alloc|wl_session_step|#752|#753' CHANGELOG.md docs/MIGRATION.md docs/RELEASE_PROCESS.md SECURITY.md`\n- `git diff --check HEAD~1..HEAD`\n- reviewer also ran `meson test -C build --no-rebuild changelog_format release_template public_api_macro`\n\nRefs #900\nRefs #699\nRefs #714\nRefs #752\nRefs #753