### PR TITLE
release: add CODEOWNERS prerequisite for 1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @justinjoy

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -304,9 +304,9 @@ synthetic PR targeting `1.0` and verify:
 5. Linear-history and signed-commit constraints are enforced.
 
 Phase B prerequisites for final #746 acceptance are not fully present in
-this repository state yet: `CODEOWNERS` is missing, and the CLA workflow
-plus its always-emitting required status context are also missing. Land
-those prerequisites before attempting final cutover verification.
+this repository state yet: `CODEOWNERS` is present, but the CLA workflow
+plus its always-emitting required status context remain missing. Land the
+remaining prerequisite before attempting final cutover verification.
 
 Close the synthetic PR after capturing verification evidence for #746.
 Final #746 acceptance is deferred until this Phase B verification passes


### PR DESCRIPTION
## Summary

Adds the CODEOWNERS prerequisite for #746 before the last-moment `1.0` branch cut.

- add `.github/CODEOWNERS` with repo-wide ownership by `@justinjoy`
- update `docs/RELEASE_PROCESS.md` so #746 Phase B no longer lists CODEOWNERS as missing
- keep the remaining Phase B blockers explicit: CLA required context, real `1.0` branch creation/protection, and synthetic PR verification

This intentionally does not create `1.0`, does not change `meson.build`, and does not perform the rc1 version/changelog cutover.

## Validation

- `git diff --check HEAD~1 HEAD`
- `test -f .github/CODEOWNERS`
- `gh api repos/semantic-reasoning/wirelog/collaborators/justinjoy/permission --jq .permission` -> `admin`
- Reviewer subagent found no blocking findings for commit `67e8ffb`
- Architect and Critic subagents agreed the review outcome is acceptable

## Remaining #746 work

Final #746 acceptance still waits for the last-moment rc1 cutover:

- create/protect the real `1.0` branch
- configure/verify branch rules and required checks
- verify CODEOWNER/CLA/check enforcement with a synthetic PR targeting `1.0`

Refs #746.
