### PR TITLE
ci: add CLA signoff gate

### DIFF
--- a/.github/workflows/cla-required.yml
+++ b/.github/workflows/cla-required.yml
@@ -1,0 +1,85 @@
+name: CLA Required
+
+on:
+  pull_request:
+    branches: [main, "1.0"]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  statuses: read
+
+jobs:
+  cla-signoff-gate:
+    name: CLA signoff gate
+    runs-on: ubuntu-latest
+    env:
+      CLA_CONTEXT: license/cla
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Verify hosted CLA status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          attempts=12
+          interval=10
+          status_url="https://api.github.com/repos/${REPOSITORY}/commits/${HEAD_SHA}/status"
+
+          echo "Checking ${CLA_CONTEXT} on PR head SHA ${HEAD_SHA}."
+
+          for attempt in $(seq 1 "$attempts"); do
+            response="$(
+              curl --fail --silent --show-error --location \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "$status_url"
+            )"
+
+            cla_state="$(
+              jq -r --arg context "$CLA_CONTEXT" \
+                '[.statuses[] | select(.context == $context)][0].state // "missing"' \
+                <<<"$response"
+            )"
+            cla_url="$(
+              jq -r --arg context "$CLA_CONTEXT" \
+                '[.statuses[] | select(.context == $context)][0].target_url // ""' \
+                <<<"$response"
+            )"
+
+            case "$cla_state" in
+              success)
+                echo "${CLA_CONTEXT} is success."
+                if [ -n "$cla_url" ]; then
+                  echo "Source: ${cla_url}"
+                fi
+                exit 0
+                ;;
+              pending)
+                echo "${CLA_CONTEXT} is pending (attempt ${attempt}/${attempts})."
+                ;;
+              failure|error)
+                echo "::error::${CLA_CONTEXT} is ${cla_state} on ${HEAD_SHA}; CLA signoff is required before merge."
+                if [ -n "$cla_url" ]; then
+                  echo "::error::Source: ${cla_url}"
+                fi
+                exit 1
+                ;;
+              missing)
+                echo "${CLA_CONTEXT} is missing on ${HEAD_SHA} (attempt ${attempt}/${attempts})."
+                ;;
+              *)
+                echo "::error::${CLA_CONTEXT} returned unexpected state '${cla_state}' on ${HEAD_SHA}."
+                exit 1
+                ;;
+            esac
+
+            if [ "$attempt" -lt "$attempts" ]; then
+              sleep "$interval"
+            fi
+          done
+
+          echo "::error::Timed out waiting for ${CLA_CONTEXT} to report success on ${HEAD_SHA}; latest state was ${cla_state}."
+          exit 1

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -269,7 +269,10 @@ Execute only after `1.0` is created during the RC1 cutover and
 the cutover commit sets `project_version` to `1.0.0-rc1`.
 
 - At least one CODEOWNER review.
-- CLA signoff required (blocking CLA status context).
+- CLA signoff required via branch protection on the stable
+  `CLA signoff gate` check.  This repository-owned gate verifies the
+  hosted cla-assistant external status context `license/cla`; do not
+  make `license/cla` itself the required protected check.
 - Linear history (no force-push, no merge commits).
 - Signed commits (GPG verified).
 - Tag protection on `v1.x.*`.
@@ -283,7 +286,7 @@ the cutover commit sets `project_version` to `1.0.0-rc1`.
     replaced by a later policy-consolidation change): `lint / EditorConfig check`,
     `lint / uncrustify check`, `lint / clang-tidy 22 check`,
     `Build / ubuntu-latest / gcc`, `Build / ubuntu-24.04-arm / gcc`,
-    `RC changelog freeze gate`,
+    `RC changelog freeze gate`, `CLA signoff gate`,
     `mbedtls-enabled / ubuntu-latest / gcc`,
     `Build / ubuntu-latest / clang`, `Build / macos-latest / clang`,
     `Build / windows-latest / msvc`,
@@ -299,14 +302,16 @@ synthetic PR targeting `1.0` and verify:
 
 1. The required check contexts above are present and enforced.
 2. Merge is blocked until at least one CODEOWNER review is granted.
-3. Merge is blocked until CLA signoff is complete.
+3. Merge is blocked until `CLA signoff gate` passes by observing
+   hosted `license/cla: success` on the PR head SHA.
 4. Merge is blocked while any required check is failing or pending.
 5. Linear-history and signed-commit constraints are enforced.
 
 Phase B prerequisites for final #746 acceptance are not fully present in
-this repository state yet: `CODEOWNERS` is present, but the CLA workflow
-plus its always-emitting required status context remain missing. Land the
-remaining prerequisite before attempting final cutover verification.
+this repository state yet: `CODEOWNERS` and the always-emitting
+`CLA signoff gate` workflow are present, but final synthetic PR
+validation remains a Phase B cutover task after `1.0` branch protection
+is configured.
 
 Close the synthetic PR after capturing verification evidence for #746.
 Final #746 acceptance is deferred until this Phase B verification passes


### PR DESCRIPTION
## Summary

Adds a repository-owned CLA guard for #746 Phase A/Phase B readiness.

- add `.github/workflows/cla-required.yml`
- emit a stable `CLA signoff gate` check on PRs targeting `main` and future `1.0`
- treat hosted cla-assistant's external `license/cla` status as the source signal
- fail clearly when `license/cla` is missing, pending, failed, or errored
- update release-process docs so branch protection should require `CLA signoff gate`, not raw `license/cla`

This intentionally does not create `1.0`, does not change `meson.build`, and does not change branch protection.

## Validation

- `git diff --check HEAD~1 HEAD`
- Ruby YAML parse for `.github/workflows/cla-required.yml`
- `actionlint .github/workflows/cla-required.yml`
- API evidence:
  - #905 head `777d4111570dacbb818fa5fd4d9b8e0d2420c3e8`: `license/cla: success`
  - #906 head `67e8ffbd654f444aa798e3ac8cd1a07dafbd9ffe`: `license/cla: missing`
- Reviewer subagent found no blocking findings for commit `35d85a4`
- Architect and Critic subagents agreed this can proceed to PR; if this PR fails due to missing `license/cla`, that is intended integration evidence to fix hosted CLA emission before final #746 acceptance

## Remaining #746 work

Final #746 acceptance still waits for last-moment Phase B:

- create/protect real `1.0`
- verify `CLA signoff gate`, CODEOWNER review, required checks, signed/linear history, and force-push rejection through a synthetic PR targeting `1.0`

Refs #746.
