### PR TITLE
Release 0.50.0

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,10 +7,10 @@ name: CI PR
 #   └─ lint
 #      ├─ build-primary (ubuntu-latest gcc, SBOM/size/path-a gates)
 #      │  ├─ build-arm (ubuntu-24.04-arm gcc, ABI #681) ──┐
-#      │  └─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix (parallel)
-#      │                                                   └─ sanitizer-matrix (parallel)
-#      ├─ tsan (independent, no gate)
-#      └─ tsan-native (independent, no gate)
+#      │  └─ build-mbedtls (ubuntu-latest gcc, crypto) ──┼─ build-matrix
+#      └─ sanitizer-matrix
+#         ├─ tsan
+#         └─ tsan-native
 #
 # CodeQL runs in its own workflow (GitHub default-setup); not invoked from here.
 
@@ -275,13 +275,13 @@ jobs:
         run: meson test -C builddir-mbedtls cryptographic_hashes --print-errorlogs
 
   # ==========================================================================
-  # Phase: Sanitizer Matrix (gated by build-arm + build-mbedtls, parallel with build-matrix)
+  # Phase: Sanitizer Matrix (starts after lint, parallel with build-primary)
   # ASan + UBSan validation; runs in parallel with build-matrix.
   # Linux: GCC + Clang; macOS: Clang
   # ==========================================================================
   sanitizer-matrix:
     name: Sanitizers / ${{ matrix.os }} / ${{ matrix.compiler }}
-    needs: [build-arm, build-mbedtls]
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -340,14 +340,15 @@ jobs:
 
   # ==========================================================================
   # Phase 3b: TSan
-  # Runs after lint and in parallel with the normal build matrix.
+  # Runs after sanitizer-matrix to keep sanitizer coverage ahead of all
+  # TSan-instrumented jobs when PR runner capacity is constrained.
   # TSan forces POSIX pthreads via -Dthreads=posix.
   # TSan only intercepts pthread calls; C11 <threads.h> functions
   # (thrd_create, mtx_lock) are uninstrumented and cause false SEGV.
   # ==========================================================================
   tsan:
     name: TSan / ubuntu-latest / gcc
-    needs: [lint]
+    needs: [sanitizer-matrix]
     runs-on: ubuntu-latest
 
     steps:
@@ -379,6 +380,8 @@ jobs:
 
   # ==========================================================================
   # Phase 3b (advisory): TSan compile smoke with -Dthreads=native
+  # Runs after sanitizer-matrix for the same runner-pressure ordering as the
+  # gating TSan leg while preserving its advisory compile-smoke semantics.
   #
   # WHY THIS LEG EXISTS:
   #   The normal TSan job above forces -Dthreads=posix because libtsan's
@@ -404,7 +407,7 @@ jobs:
   # ==========================================================================
   tsan-native:
     name: TSan-native / ubuntu-latest / gcc
-    needs: [lint]
+    needs: [sanitizer-matrix]
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.50.0] - 2026-05-28
+
+### Added
+
+### Changed
+
 - **RC freeze PR gate for `1.0` branch targets** (#747): added
   `scripts/ci/check-changelog-rc.sh` and wired it as an always-emitting
   `RC changelog freeze gate` context in `.github/workflows/ci-pr.yml`.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,22 @@
 # Migration Guide
 
-**Last Updated:** 2026-05-25
+**Last Updated:** 2026-05-28
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.44 -> 0.50
+
+Version `0.50.0` is a release-prep/docs-focused cut relative to `0.44.0`.
+No new source-level migration actions are required beyond the behavior and
+API migration guidance already captured in this document's `0.44`-and-earlier
+entries.
+
+- **Migration posture:** treat `0.44 -> 0.50` as ABI/public-surface
+  continuity for downstream consumers; update only if your integration depends
+  on release-process policy/docs details.
 
 ## 0.43 -> 0.44
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.44.0',
+  version: '0.50.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary
- move current Unreleased notes into CHANGELOG 0.50.0 and reset Unreleased
- add 0.44 -> 0.50 migration posture
- bump project version to 0.50.0 in a final version-only commit

## Validation
- python3 scripts/ci/check-changelog-format.py CHANGELOG.md
- scripts/release/extract-changelog-section.sh 0.50.0 CHANGELOG.md
- meson setup build
- meson test -C build wirelog:version_sync wirelog:cli_version --print-errorlogs
- reviewer temp build: meson test -C /tmp/wirelog-review-build version_sync --print-errorlogs

Tag/release will be created only after this PR is merged, per release procedure.