### PR TITLE
release: prepare 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+## [0.51.0] - 2026-06-13
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- **Non-recursive strata after recursive evaluation** (#914): reset the
+  columnar evaluator's iteration context before non-recursive strata run,
+  preventing stale recursive iteration state from incorrectly suppressing
+  static EDB reads and dropping derived rows such as
+  `requires_review(...)`.
+- **Windows CI compiler selection** (#917): force the MSVC compiler in the
+  Windows PR and main workflows so the intended toolchain is selected
+  consistently.
+
+### Performance
+
+### Security
+
+### Documentation
+
 ## [0.50.0] - 2026-05-28
 
 ### Added

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,27 @@
 # Migration Guide
 
-**Last Updated:** 2026-05-28
+**Last Updated:** 2026-06-13
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.50 -> 0.51
+
+Version `0.51.0` is a stability-focused release after `0.50.0`.
+No source-level migration actions are required for applications already
+using the 0.50 public API surface.
+
+- **Columnar recursive-to-non-recursive evaluation correctness** (#914):
+  programs with a recursive stratum followed by a non-recursive stratum may
+  now derive rows that were previously dropped because stale recursive
+  iteration state suppressed static EDB reads.  No API changes are required;
+  downstream tests that encoded the incorrect missing-row behavior should be
+  updated to expect the corrected output.
+- **Windows CI compiler selection** (#917): project CI now forces MSVC on Windows
+  so release validation uses the intended compiler consistently.  This does
+  not change source compatibility for consumers.
 
 ## 0.44 -> 0.50
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.50.99',
+  version: '0.51.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary
- bump project version to 0.51.0
- add 0.51.0 changelog notes for #914 and #917
- document 0.50 -> 0.51 migration posture

## Local validation
- `meson test -C build-0.51-default`: 250 OK, 10 SKIP, 0 FAIL
- `meson test -C build-0.51-release --suite abi`: 32 OK, 0 FAIL
- `python scripts/ci/check-version-sync.py build-0.51-release/wirelog`: OK
- `scripts/release/extract-changelog-section.sh 0.51.0`: OK

Full release matrix remains required before tag publication per `docs/RELEASE_PROCESS.md`.