### PR TITLE
build: bump version to 0.51.99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.51.0',
+  version: '0.51.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary
- Bump the post-0.51.0 development version from 0.51.0 to 0.51.99 in meson.build.

## Validation
- meson setup build-bump-0.51.99
- meson compile -C build-bump-0.51.99
- meson test -C build-bump-0.51.99 version_sync cli_version changelog_format
- meson test -C build-bump-0.51.99 --suite abi