### PR TITLE
ci(pr): cache compilation via sccache across all build jobs

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -22,6 +22,12 @@ permissions:
   actions: read
   contents: read
 
+# Compiler caching: route gcc/clang/MSVC through sccache with the GitHub
+# Actions cache backend. Set workflow-wide so every build job's compile steps
+# pick it up; non-build jobs simply ignore it.
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
 jobs:
   # ==========================================================================
   # Issue #747 B18: RC changelog freeze gate (stable always-emitting context)
@@ -62,10 +68,13 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      CC: gcc
+      CC: sccache gcc
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install dependencies
         run: |
@@ -135,10 +144,13 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      CC: gcc
+      CC: sccache gcc
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install dependencies
         run: |
@@ -185,6 +197,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -212,7 +227,7 @@ jobs:
         if: runner.os != 'Windows'
         run: meson setup builddir -Dtests=true -DmbedTLS=disabled
         env:
-          CC: ${{ matrix.cc }}
+          CC: sccache ${{ matrix.cc }}
 
       - name: Configure (Windows / MSVC)
         if: runner.os == 'Windows'
@@ -231,8 +246,8 @@ jobs:
           if (-not $clExe) { throw 'cl.exe was not found under the MSVC toolset' }
           $env:PATH = "$(Split-Path -Parent $clExe);$env:PATH"
           Get-Command cl.exe
-          $env:CC = 'cl'
-          $env:CXX = 'cl'
+          $env:CC = 'sccache cl'
+          $env:CXX = 'sccache cl'
           meson setup builddir -Dtests=true -DmbedTLS=disabled
 
       - name: Build (Linux / macOS)
@@ -297,6 +312,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -305,7 +323,7 @@ jobs:
       - name: Configure with mbedTLS enabled
         run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
         env:
-          CC: gcc
+          CC: sccache gcc
 
       - name: Build with mbedTLS enabled
         run: meson compile -C builddir-mbedtls
@@ -347,6 +365,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -369,7 +390,7 @@ jobs:
           -Dtests=true
           --buildtype=debug
         env:
-          CC: ${{ matrix.cc }}
+          CC: sccache ${{ matrix.cc }}
 
       - name: Build with sanitizers
         run: meson compile -C builddir-san
@@ -396,6 +417,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -410,7 +434,7 @@ jobs:
             -Dtests=true \
             --buildtype=debug
         env:
-          CC: gcc
+          CC: sccache gcc
 
       - name: Build with TSan
         run: meson compile -C builddir-tsan
@@ -455,6 +479,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -469,7 +496,7 @@ jobs:
             -Dtests=true \
             --buildtype=debug
         env:
-          CC: gcc
+          CC: sccache gcc
 
       - name: Build with TSan (native threads)
         run: meson compile -C builddir-tsan-native

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -64,6 +64,7 @@ github/codeql-action/upload-sarif@v2.14.5:NOASSERTION
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ilammy/msvc-dev-cmd@v1:NOASSERTION
+mozilla-actions/sccache-action@v0.0.10:NOASSERTION
 msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff:NOASSERTION
 mymindstorm/setup-emsdk@v14:NOASSERTION
 nanoarrow@0.8.0.9000:Apache


### PR DESCRIPTION
## Summary

PR builds rebuild libwirelog from scratch in every job with no compiler cache, which dominates wall-clock time. This routes **every build job** through [sccache](https://github.com/mozilla/sccache) backed by the GitHub Actions cache, **without touching the job graph, `needs:` chains, or the matrix**.

sccache supports gcc, clang, **and MSVC `cl.exe`**, so the Windows leg is cached too — no compiler is left out.

## Changes (`.github/workflows/ci-pr.yml`)

- Enable the sccache GHA backend workflow-wide via `env: SCCACHE_GHA_ENABLED: "true"`. Non-build jobs simply ignore it.
- Add a `Setup sccache` step (`mozilla-actions/sccache-action@v0.0.10`) to all seven build jobs: `build-primary`, `build-arm`, `build-mbedtls`, `build-matrix` (Linux/macOS clang + Windows MSVC), `sanitizer-matrix`, `tsan`, `tsan-native`.
- Wrap the compiler in each configure step: `CC='sccache <cc>'` on Linux/macOS, and `CC/CXX='sccache cl'` for MSVC. Meson records the launcher at configure time, so ninja invokes sccache on every translation unit.

## Why this works

Meson does not auto-detect sccache (only ccache), so the compiler is wrapped explicitly. Verified locally that `meson setup` accepts a wrapped `CC` and that the launcher is invoked on every compile (the wrapper prefix appears in `compile_commands.json` and runs once per TU).

The MSVC **Build**/**Test** pwsh blocks still set `\$env:CC = 'cl'`; that is intentional and inert — ninja uses the compiler rule baked into `build.ninja` at configure time (`sccache cl`), and sccache is on `PATH` for the whole job via the action.

## Scope / non-goals

This PR is caching only. It deliberately does **not** flatten the serial `needs:` chain, add path filters, or merge the TSan legs — those are separate discussions.

## Validation

- `actionlint` passes (exit 0); YAML parses.
- Local meson sanity check confirms the `CC='sccache <cc>'` wrapper mechanism.
- The MSVC + sccache + meson path cannot be exercised locally (no Windows runner); the first CI run on this PR is the real validation for that leg. First run is a cold cache (populate); subsequent pushes should show hits and reduced build time. `sccache --show-stats` can be added later if we want hit-rate visibility.

## Risk

Low-to-medium. Worst case sccache misses and falls back to invoking the compiler directly (a cache miss is still a correct build). The only genuinely unverified surface is MSVC cl.exe wrapping, gated by this PR's own CI run.