### PR TITLE
release: prepare 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,45 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+## [0.52.0] - 2026-06-28
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- **Unsafe variables in negated body atoms** (#920): the IR lowering now
+  rejects rules where a named variable appears only inside a negated body
+  atom (e.g. `c(X) :- a(X), !b(X, Y).`).  Such variables have an unbounded
+  range and were previously treated like wildcards, silently accepting the
+  rule and producing range-dependent results.  Every named variable in a
+  negated atom must now also be bound by a positive body atom, otherwise the
+  rule is rejected with `WIRELOG_ERR_INVALID_IR`; the error names the
+  supported workaround (project the negated relation to a key relation
+  first).  Wildcards (`!b(X, _)`) and constant columns remain accepted.
+- **String literal escape decoding** (#925): the lexer now recognizes `\"`
+  and `\\` escapes inside string literals.  An escaped quote no longer
+  terminates the string early, and the decoded token value unescapes `\"`
+  and `\\` instead of preserving the backslash verbatim.
+
+### Performance
+
+### Security
+
+### Documentation
+
+- **Negation and side compounds** (#921): documented that negating a
+  side-tier compound body pattern (e.g. `!event(ID, metadata(...))`) is
+  rejected because negated side-join lowering is not yet implemented, and
+  the supported positive-extraction workaround that preserves the same
+  expressive power.  The IR-conversion error now names the workaround and
+  points at `docs/COMPOUND_TERMS.md`.
+
 ## [0.51.0] - 2026-06-13
 
 ### Added

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,31 @@
 # Migration Guide
 
-**Last Updated:** 2026-06-13
+**Last Updated:** 2026-06-28
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.51 -> 0.52
+
+Version `0.52.0` is a correctness-focused release after `0.51.0`. Two
+parser/IR fixes can change behavior for programs that relied on previously
+accepted-but-unsafe input. No public API or ABI changes are required.
+
+- **Unsafe negated-atom variables now rejected** (#920): a rule where a named
+  variable appears only inside a negated body atom (e.g.
+  `c(X) :- a(X), !b(X, Y).`) is now rejected at IR lowering with
+  `WIRELOG_ERR_INVALID_IR`.  Such variables had an unbounded range and
+  produced range-dependent results when silently accepted.  Bind the variable
+  in a positive body atom, or project the negated relation to a key relation
+  first (the error message names the workaround).  Wildcards (`!b(X, _)`) and
+  constant columns are unaffected.
+- **String literal escape decoding** (#925): `\"` and `\\` inside a string
+  literal are now treated as escapes.  Strings that previously relied on a
+  literal backslash being preserved verbatim will decode differently; double
+  the backslash (`\\`) to keep a literal backslash, and use `\"` to embed a
+  quote without terminating the string.
 
 ## 0.50 -> 0.51
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.51.99',
+  version: '0.52.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

Release-preparation PR for **wirelog 0.52.0**, following `docs/RELEASE_PROCESS.md` §2.

- Bumps `project_version` in `meson.build` 0.51.99 -> 0.52.0.
- Moves the `[Unreleased]` changes under `## [0.52.0] - 2026-06-28` in `CHANGELOG.md` and resets `[Unreleased]` to the placeholder shape.
- Adds the `0.51 -> 0.52` entry to `docs/MIGRATION.md` and refreshes `Last Updated`.

## Changes included since v0.51.0

### Fixed
- **Unsafe variables in negated body atoms** (#920): IR lowering now rejects rules where a named variable appears only inside a negated body atom (e.g. `c(X) :- a(X), !b(X, Y).`). Wildcards and constant columns remain accepted.
- **String literal escape decoding** (#925): the lexer now recognizes `\"` and `\\` escapes inside string literals.

### Documentation
- **Negation and side compounds** (#921): documents the positive-extraction workaround for negating side-tier compound body patterns; the IR-conversion error now names it.

_Excluded as internal-only: sccache CI caching, post-0.51 dev version bump._

## Verification
- `scripts/ci/check-changelog-format.py` -> `OK`
- `scripts/release/extract-changelog-section.sh 0.52.0` produces the expected section
- No code changes in this PR; the feature commits (#920/#925/#921) already merged and passed CI on main.

## Next steps (post-merge, per RELEASE_PROCESS.md)
- Tag on `main`: `git tag -s v0.52.0 -m "wirelog 0.52.0"` && push
- `gh release create v0.52.0 --notes-file <(./scripts/release/extract-changelog-section.sh 0.52.0)`