### PR TITLE
build: bump version to 0.52.99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.52.0',
+  version: '0.52.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

Opens the post-0.52.0 development cycle by bumping `project_version` in `meson.build` 0.52.0 -> 0.52.99.

This mirrors the established cadence (`build: bump version to 0.51.99` after the 0.51.0 release): the `.99` dev version marks main as the in-progress cycle toward the next release.

## Changes
- `meson.build`: `version: '0.52.0'` -> `'0.52.99'`

No code, behavior, ABI, or changelog changes. `[Unreleased]` in `CHANGELOG.md` stays the placeholder shape and accumulates entries for the next release.